### PR TITLE
Add the `get_model_input` method to Gemma3 for returning a dummy input

### DIFF
--- a/tunix/models/gemma3/model.py
+++ b/tunix/models/gemma3/model.py
@@ -753,6 +753,27 @@ class Gemma3(nnx.Module):
 
     return logits, new_cache  # pytype: disable=bad-return-type
 
+  def get_model_input(self):
+    """Returns a dummy model input for the transformer.
+
+    This dummy input has a batch size compatible with FSDP sharding on a
+    2-device axis.
+    """
+    dummy_batch_size = 2
+    dummy_seq_len = 1
+    return {
+        'last_tokens': jnp.ones(
+            (dummy_batch_size, dummy_seq_len), dtype=jnp.int32
+        ),
+        'positions': jnp.ones(
+            (dummy_batch_size, dummy_seq_len), dtype=jnp.int32
+        ),
+        'cache': None,
+        'attention_mask': jnp.ones(
+            (dummy_batch_size, 1, dummy_seq_len), dtype=jnp.bool
+        ),
+    }
+
   @property
   def embed_dim(self) -> int:
     return self.embedder.embed_dim


### PR DESCRIPTION
Similar to d4df30d and it is necessary for the Gemma3 model to be used in the GRPO demo.