### PR TITLE
Init vLLM model with random weights, bypassing from loading from HF.

### DIFF
--- a/scripts/grpo_demo_llama3.py
+++ b/scripts/grpo_demo_llama3.py
@@ -50,16 +50,9 @@ print(
     "your own discretion"
 )
 
-os.environ["TPU_BACKEND_TYPE"] = "jax"
-os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
-
 # Disable precompilation for faster iteration, need to toggle it back for
 # official run
 os.environ["SKIP_JAX_PRECOMPILE"] = "1"
-
-# vLLM recommends use the old model design
-# os.environ["NEW_MODEL_DESIGN"]= "True"
-
 
 # Parse command line options
 parser = argparse.ArgumentParser(description="Arguments for GRPO demo")

--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -27,15 +27,9 @@ from tunix.models.llama3 import model as llama_lib
 from tunix.models.llama3 import params as llama_params
 
 
-os.environ["TPU_BACKEND_TYPE"] = "jax"
-os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
-os.environ["SKIP_JAX_PRECOMPILE"] = "1"
-
 # vLLM Jax backend suggest to use old model desing for now.
 # os.environ["NEW_MODEL_DESIGN"]="True"
-
-# TODO(b/433750353): Enable random weights after vLLM supports it properly
-# os.environ["JAX_RANDOM_WEIGHTS"] = "True"
+os.environ["SKIP_JAX_PRECOMPILE"] = "1"
 
 
 class VllmSamplerTest(absltest.TestCase):

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -27,8 +27,15 @@ from vllm.entrypoints.llm import LLM
 from vllm.outputs import RequestOutput
 
 
+# vLLM recommends use the old model design
+# os.environ["NEW_MODEL_DESIGN"]= "True"
+# Enable Jax backend
 os.environ["TPU_BACKEND_TYPE"] = "jax"
+# Colocate vllm engine and worker in the main process
 os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+# Init vLLM model with random weights because model weights are synced from
+# trainer later on
+os.environ["JAX_RANDOM_WEIGHTS"] = "True"
 
 
 @dataclasses.dataclass
@@ -65,9 +72,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
         mesh (jax.sharding.Mesh): The JAX mesh for parallel execution.
         max_model_len (int): Maximum sequence (prompt + generation) length
           supported by vLLM.
-        model_version (Optional[str]): The model version identifier. This is
-          currently required for vLLM compatibility, but will be removed in the
-          future.
+        model_version (Optional[str]): The model version identifier.
         mapping_config: The config for weight name mappings from external model
           to vLLM model, including to_hf_mappings, lora_to_hf_mappings,
           to_hf_transpose_keys and lora_config.

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -85,8 +85,6 @@ class ClusterConfig:
   training_config: RLTrainingConfig
   rollout_config: base_rollout.RolloutConfig
 
-  # TODO(lancewang): Remove this when vLLM Jax backends supports sharded initial
-  # random weights properly
   rollout_model_version: str = ""
   rollout_lora_config: dict[str, Any] | None = None
 


### PR DESCRIPTION
We don't really need to load weights from HF because we will sync weights from trainer to sampler anyway. Bypass it will speed up bring up time and space.