### PR TITLE
partial fix vllm

### DIFF
--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -177,17 +177,24 @@ class VllmSamplerTest(absltest.TestCase):
         pad_output=True,  # Use padding for output
     )
 
-    vl_sampler = vllm_sampler.VllmSampler(
-        tokenizer=model_tokenizer,
-        mesh=self.mesh,
-        max_model_len=512,  # Set to 1024 for vLLM
+    vllm_config = vllm_sampler.VllmConfig(
         model_version=self.model_path,
+        max_model_len=512,
+        mesh=self.mesh,
+        hbm_utilization=0.2,
+        init_with_random_weights=True,
+        tpu_backend_type=None,
         mapping_config=vllm_sampler.MappingConfig(
             to_hf_mappings=tunix_model.to_hf_mappings(),
             to_hf_transpose_keys=tunix_model.to_hf_transpose_keys(),
             lora_to_hf_mappings=tunix_model.lora_to_hf_mappings(),
             lora_config=args["additional_config"]["lora_config"],
         ),
+    )
+
+    vl_sampler = vllm_sampler.VllmSampler(
+        tokenizer=model_tokenizer,
+        config=vllm_config,
     )
     state = nnx.state(tunix_model)
     vl_sampler.load_checkpoint(state)
@@ -209,7 +216,11 @@ class VllmSamplerTest(absltest.TestCase):
     print("-" * 50)
     print(f"Vanilla Generated text: {vanilla_output.text}")
     self.assertEqual(
-        vanilla_output.text, ["Nice to meet you. What's your name?", "Paris."]
+        vanilla_output.text,
+        [
+            "Nice to meet you. What's your name?",
+            "The capital of France is Paris.",
+        ],
     )
 
     print("-" * 50)

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -27,6 +27,7 @@ from tunix.generate import utils
 import tunix.generate.tokenizer_adapter as tok_adapter
 from tunix.rl import reshard
 from vllm import LLM
+from vllm.inputs import TokensPrompt
 from vllm.outputs import RequestOutput
 
 
@@ -240,8 +241,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
 
     prompt_ids = [self.tokenize(x) for x in input_strings]
     outputs = self.llm.generate(
-        prompts=None,
-        prompt_token_ids=prompt_ids,
+        prompts=[TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids],
         sampling_params=self.sampling_params,
         use_tqdm=True,
     )


### PR DESCRIPTION
Fix vllm sampler after API deprecation in vllm: https://github.com/vllm-project/vllm/commit/8896eb72ebe90be6f1b83f32b3d3d0c379db4f82

Unittest still didn't fully pass due to garbage output, but at least it can run now.