### PR TITLE
DOC Add API docs, take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /docs/_build/
 /docs/_collections/
 /docs/sg_execution_times.rst
+/docs/generated
+build/*

--- a/docs/api/api_distillation.rst
+++ b/docs/api/api_distillation.rst
@@ -1,0 +1,17 @@
+Distillation
+============
+
+.. currentmodule:: tunix
+
+.. autosummary::
+
+    DistillationTrainer
+    DistillationTrainingConfig
+
+----
+
+.. autoclass:: DistillationTrainer
+
+----
+
+.. autoclass:: DistillationTrainingConfig

--- a/docs/api/api_generation.rst
+++ b/docs/api/api_generation.rst
@@ -1,0 +1,18 @@
+Generation
+==========
+
+.. currentmodule:: tunix
+
+.. autosummary::
+
+    Sampler
+    CacheConfig
+
+----
+
+.. autoclass:: Sampler
+
+----
+
+.. autoclass:: CacheConfig
+

--- a/docs/api/api_rl.rst
+++ b/docs/api/api_rl.rst
@@ -1,0 +1,61 @@
+Reinforcement learning (RL)
+===========================
+
+.. currentmodule:: tunix
+
+.. autosummary::
+
+    GRPOConfig
+    GRPOLearner
+    RewardFn
+
+    PPOConfig
+    PPOLearner
+
+    ClusterConfig
+    RLCluster
+    RLTrainingConfig
+    Role
+    RolloutConfig
+
+-------
+
+.. autoclass:: GRPOConfig
+
+-------
+
+.. autoclass:: GRPOLearner
+
+-------
+
+.. autoclass:: RewardFn
+
+-------
+
+.. autoclass:: PPOConfig
+
+-------
+
+.. autoclass:: PPOLearner
+
+-------
+
+
+.. autoclass:: ClusterConfig
+
+-------
+
+.. autoclass:: RLCluster
+
+-------
+
+.. autoclass:: RLTrainingConfig
+
+-------
+
+.. autoclass:: Role
+
+-------
+
+.. autoclass:: RolloutConfig
+

--- a/docs/api/api_sft.rst
+++ b/docs/api/api_sft.rst
@@ -1,0 +1,42 @@
+Supervised fine-tuning (SFT)
+============================
+
+.. currentmodule:: tunix
+
+.. autosummary::
+
+    PeftTrainer
+    TrainingConfig
+
+    DPOTrainer
+    DPOTrainingConfig
+
+    MetricsLogger
+    MetricsLoggerOptions
+
+
+-------
+
+
+.. autoclass:: PeftTrainer
+
+-------
+
+.. autoclass:: TrainingConfig
+
+-------
+
+.. autoclass:: DPOTrainer
+
+-------
+
+.. autoclass:: DPOTrainingConfig
+
+-------
+
+.. autoclass:: MetricsLogger
+
+-------
+
+.. autoclass:: MetricsLoggerOptions
+

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -14,24 +14,24 @@ race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-*   Using welcoming and inclusive language
-*   Being respectful of differing viewpoints and experiences
-*   Gracefully accepting constructive criticism
-*   Focusing on what is best for the community
-*   Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-*   The use of sexualized language or imagery and unwelcome sexual attention or
-    advances
-*   Trolling, insulting/derogatory comments, and personal or political attacks
-*   Public or private harassment
-*   Publishing others' private information, such as a physical or electronic
-    address, without explicit permission
-*   Disrespecting the community's time by sending spam or other unsolicited
-    commercial messages
-*   Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+- Disrespecting the community's time by sending spam or other unsolicited
+  commercial messages
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 
@@ -71,8 +71,8 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
-Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+Reports should be directed to *\[PROJECT STEWARD NAME(s) AND EMAIL(s)\]*, the
+Project Steward(s) for *\[PROJECT NAME\]*. It is the Project Steward’s duty to
 receive and address reported violations of the code of conduct. They will then
 work with a committee consisting of representatives from the Open Source
 Programs Office and the Google Open Source Strategy team. If for any reason you
@@ -91,5 +91,4 @@ harassment or threats to anyone's safety, we may take action without notice.
 ## Attribution
 
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
-available at
-https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,11 @@ extensions = [
     "myst_nb",
     "sphinx_gallery.gen_gallery",
     "sphinxcontrib.collections",
+    # api docs
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
 ]
 
 templates_path = ["_templates"]
@@ -76,4 +81,25 @@ collections = {
     }
 }
 
+
 suppress_warnings = ["misc.highlighting_failure"]
+
+
+# -- Options for the API reference
+
+default_role = "py:obj"
+
+napoleon_include_init_with_doc = False
+
+autodoc_default_options = {
+    "members": True,
+    "imported-members": True,
+    "undoc-members": True,
+}
+
+
+intersphinx_mapping = {
+    "optax": ("https://optax.readthedocs.io/en/latest/", None),
+    "flax": ("https://flax.readthedocs.io/en/stable/", None),
+    "jax": ("https://docs.jax.dev/en/latest/", None),
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,4 +3,3 @@
 ```{include} ../CONTRIBUTING.md
 :start-line: 2
 ```
-

--- a/docs/ext/coverage_check.py
+++ b/docs/ext/coverage_check.py
@@ -1,0 +1,91 @@
+# Copyright 2021 DeepMind Technologies Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Asserts all public symbols are covered in the docs."""
+
+from collections.abc import Mapping
+import inspect
+import types
+from typing import Any, Sequence, Tuple
+
+import optax
+from sphinx import application
+from sphinx import builders
+from sphinx import errors
+
+
+def find_internal_python_modules(
+    root_module: types.ModuleType,
+) -> Sequence[Tuple[str, types.ModuleType]]:
+  """Returns `(name, module)` for all Optax submodules under `root_module`."""
+  modules = set([(root_module.__name__, root_module)])
+  visited = set()
+  to_visit = [root_module]
+
+  while to_visit:
+    mod = to_visit.pop()
+    visited.add(mod)
+
+    for name in dir(mod):
+      obj = getattr(mod, name)
+      if inspect.ismodule(obj) and obj not in visited:
+        if obj.__name__.startswith("optax"):
+          if "_src" not in obj.__name__:
+            to_visit.append(obj)
+            modules.add((obj.__name__, obj))
+
+  return sorted(modules)
+
+
+def optax_public_symbols():
+  """Collect all optax public symbols."""
+  names = set()
+  for module_name, module in find_internal_python_modules(optax):
+    for name in module.__all__:
+      names.add(module_name + "." + name)
+  return names
+
+
+class OptaxCoverageCheck(builders.Builder):
+  """Builder that checks all public symbols are included."""
+
+  name = "coverage_check"
+
+  def get_outdated_docs(self) -> str:
+    return "coverage_check"
+
+  def write(self, *ignored: Any) -> None:  # pylint: disable=overridden-final-method
+    pass
+
+  def finish(self) -> None:
+    documented_objects = frozenset(self.env.domaindata["py"]["objects"])  # pytype: disable=attribute-error
+    undocumented_objects = set(optax_public_symbols()) - documented_objects
+    if undocumented_objects:
+      undocumented_objects = tuple(sorted(undocumented_objects))
+      raise errors.SphinxError(
+          "All public symbols must be included in our documentation, did you "
+          "forget to add an entry to `api.rst`?\n"
+          f"Undocumented symbols: {undocumented_objects}"
+      )
+
+  def get_target_uri(self, docname, typ=None):
+    raise NotImplementedError
+
+  def write_doc(self, docname, doctree):
+    raise NotImplementedError
+
+
+def setup(app: application.Sphinx) -> Mapping[str, Any]:
+  app.add_builder(OptaxCoverageCheck)
+  return {"version": optax.__version__, "parallel_read_safe": True}

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,3 +11,16 @@ code-of-conduct.md
 contributing.md
 gallery.rst
 ```
+
+```{eval-rst}
+
+.. toctree::
+   :hidden:
+   :caption: 📖 Reference
+   :maxdepth: 2
+
+   api/api_sft
+   api/api_rl
+   api/api_distillation
+   api/api_generation
+```

--- a/tunix/rl/ppo/ppo_learner.py
+++ b/tunix/rl/ppo/ppo_learner.py
@@ -44,7 +44,7 @@ class TrainExample(common.TrainExample):
 class PPOConfig:
   """Configuration for PPO learner.
 
-  Attributes:
+  Parameters:
     num_ppo_epochs: The number of optimization epochs per batch of rollouts.
     mini_batch_size: The batch size on which the actual model updates happen.
       The rollout phase (`generate_and_compute_advantages`) happen on a larger

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -88,7 +88,7 @@ class Role(enum.Enum):
 class RLTrainingConfig(peft_trainer.TrainingConfig):
   """RLTraining config.
 
-  Attributes:
+  Parameters:
     actor_optimizer: Optimizer for the actor model.
     critic_optimizer: Optimizer for the critic model. If None, the critic model
       will be trained in the same optimizer as the actor model.
@@ -133,7 +133,7 @@ class RLTrainingConfig(peft_trainer.TrainingConfig):
 class ClusterConfig:
   """Cluster config.
 
-  Attributes:
+  Parameters:
     role_to_mesh: Mapping from model role to mesh. Key config for colocated vs
       disaggregated setup.
     rollout_engine: Rollout engine to use. E.g. "vanilla", "vllm".

--- a/tunix/sft/dpo/dpo_trainer.py
+++ b/tunix/sft/dpo/dpo_trainer.py
@@ -89,6 +89,8 @@ class TrainExample:
 
 @dataclasses.dataclass(slots=True, kw_only=True)
 class DPOTrainingConfig(peft_trainer.TrainingConfig):
+  """DPO Training Config."""
+
   beta: float = 0.1  # 𝛽 for KL penalty https://arxiv.org/pdf/2305.18290
   label_smoothing: float = 0.0
 

--- a/tunix/sft/metrics_logger.py
+++ b/tunix/sft/metrics_logger.py
@@ -24,6 +24,8 @@ _DEFAULT_STEP = 0
 
 @dataclasses.dataclass
 class MetricsLoggerOptions:
+  """Metrics Logger options."""
+
   log_dir: str
   flush_every_n_steps: int = 100
 

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -161,9 +161,9 @@ class PeftTrainer:
     model: The model to train.
     config: The training config.
     optimizer: The optimizer to use. To monitor the learning rate at each step,
-      use `optax.inject_hyperparams` to inject learning rate as a
-      hyperparameter. For example: optimizer =
-      optax.inject_hyperparams(optax.sgd)(learning_rate=learning_rate_schedule)
+      use `optax.schedules.inject_hyperparams` to inject learning rate as a
+      hyperparameter. For example: ``optimizer =
+      optax.schedules.inject_hyperparams(optax.sgd)(learning_rate=learning_rate_schedule)``
     loss_fn: The loss function to use.
     eval_loss_fn: The loss function to use for evaluation.
     gen_model_input_fn: The function to generate model input from training


### PR DESCRIPTION
As an alternative to https://github.com/google/tunix/pull/246, add API docs via Sphinx apidoc generation, so that information comes straight from docstrings of public objects.


