### PR TITLE
[Bugfix] Make Tunix vLLM sampler work with vLLM HEAD

### DIFF
--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -254,7 +254,6 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     prompt_ids = [self.tokenize(x) for x in input_strings]
     outputs = self.llm.generate(
         prompts=[TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids],
-        prompt_token_ids=prompt_ids,
         sampling_params=self.sampling_params,
         use_tqdm=True,
     )


### PR DESCRIPTION
This pull request makes a small change to the `tunix/generate/vllm_sampler.py` file, simplifying the call to the language model's `generate` function by removing the redundant `prompt_token_ids` argument. Without this change running Tunix on the latest vLLM HEAD breaks. 