### PR TITLE
Add an image and build script to Tunix

### DIFF
--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This scripts takes a docker image that already contains the Tunix dependencies, copies the local source code in and
+# uploads that image into GCR. Once in GCR the docker image can be used for development.
+
+# Each time you update the base image via a "bash docker_build_dependency_image.sh", there will be a slow upload process
+# (minutes). However, if you are simply changing local code and not updating dependencies, uploading just takes a few seconds.
+
+# Script to buid a Tunix base image locally, example cmd is:
+# bash docker_build_dependency_image.sh
+# bash docker_build_dependency_image.sh --vllm
+set -e
+
+# Set default values
+VLLM_INSTALL="false"
+
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --vllm) VLLM_INSTALL="true"; ;; 
+        *) echo "Unknown parameter passed: $1"; exit 1 ;; 
+    esac
+    shift
+done
+
+DOCKERFILE=./tunix_dependencies.Dockerfile
+BUILD_ARGS=""
+
+if [[ "$VLLM_INSTALL" == "true" ]]; then
+    export LOCAL_IMAGE_NAME=tunix_vllm_image
+    BUILD_ARGS="--build-arg INSTALL_VLLM=true"
+    echo "Building image with vLLM support: $LOCAL_IMAGE_NAME"
+else
+    export LOCAL_IMAGE_NAME=tunix_base_image
+    echo "Building base image: $LOCAL_IMAGE_NAME"
+fi
+
+echo "Using Dockerfile: $DOCKERFILE"
+
+
+# Use Docker BuildKit so we can cache pip packages.
+export DOCKER_BUILDKIT=1
+
+echo "Starting to build your docker image. This will take a few minutes but the image can be reused as you iterate."
+
+build_ai_image() {
+    if [[ -z ${LOCAL_IMAGE_NAME+x} ]]; then
+        echo "Error: LOCAL_IMAGE_NAME is unset, please set it!"
+        exit 1
+    fi
+    COMMIT_HASH=$(git rev-parse --short HEAD)
+    echo "Building Tunix Image at commit hash ${COMMIT_HASH}..."
+
+    sudo docker build \
+        --network=host \
+        ${BUILD_ARGS} \
+        -t ${LOCAL_IMAGE_NAME} \
+        -f ${DOCKERFILE} .
+}
+
+build_ai_image
+
+echo ""
+echo "*************************
+"
+
+echo "Built your docker image and named it ${LOCAL_IMAGE_NAME}.
+It only has the dependencies installed. Assuming you're on a TPUVM, to run the
+docker image locally with full TPU access, use the following command:"
+echo ""
+echo 'sudo docker run -it --rm --net=host --ipc=host --ulimit memlock=-1:-1 -v "$(pwd)":/app --workdir /app --device=/dev/vfio/0 --device=/dev/vfio/1 --device=/dev/vfio/2 --device=/dev/vfio/3 --device=/dev/vfio/4 --device=/dev/vfio/5 --device=/dev/vfio/6 --device=/dev/vfio/7 --device=/dev/vfio/vfio ${LOCAL_IMAGE_NAME} bash'
+echo ""
+echo "You can run tunix and your development tests inside of the docker image. Changes to your workspace will automatically
+be reflected inside the docker container."
+echo "Once you want you upload your docker container to GCR, take a look at docker_upload_runner.sh"
+

--- a/install_vllm.sh
+++ b/install_vllm.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script installs the dependencies for running GRPO with MaxText+Tunix+vLLM on TPUs
+
+set -e
+set -x
+
+python -m ensurepip --default-pip
+
+pip uninstall -y jax jaxlib libtpu
+
+pip install aiohttp==3.12.15
+
+# Install Python packages that enable pip to authenticate with Google Artifact Registry automatically.
+pip install keyring keyrings.google-artifactregistry-auth
+
+# Install vLLM for Jax and TPUs from the artifact registry
+VLLM_TARGET_DEVICE="tpu" pip install --no-cache-dir --pre \
+    --index-url https://us-python.pkg.dev/cloud-tpu-images/maxtext-rl/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    --extra-index-url https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \
+    --extra-index-url https://download.pytorch.org/whl/nightly/cpu \
+    --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html \
+    --find-links https://storage.googleapis.com/libtpu-wheels/index.html \
+    --find-links https://storage.googleapis.com/libtpu-releases/index.html \
+    --find-links https://storage.googleapis.com/jax-releases/jax_nightly_releases.html \
+    --find-links https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html \
+    vllm==0.10.2rc2.dev59+gdcb28a332.tpu
+
+# Install tpu-commons from the artifact registry
+pip install --no-cache-dir --pre \
+    --index-url https://us-python.pkg.dev/cloud-tpu-images/maxtext-rl/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    --extra-index-url https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \
+    --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html \
+    tpu-commons==0.1.1
+
+pip install numba==0.61.2

--- a/tunix_dependencies.Dockerfile
+++ b/tunix_dependencies.Dockerfile
@@ -1,0 +1,37 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ARG INSTALL_VLLM=false
+
+# Install git and upgrade pip
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    pip install --no-cache-dir --upgrade pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install base python dependencies
+RUN pip install --no-cache-dir \
+    jax \
+    jaxtyping \
+    sentencepiece \
+    tensorboardX \
+    tqdm \
+    grain \
+    kagglehub \
+    tensorflow \
+    datasets \
+    git+https://github.com/google/qwix
+
+# Uninstall default flax and install from git
+RUN pip uninstall -y flax && \
+    pip install --no-cache-dir git+https://github.com/google/flax.git
+
+# Conditionally install vLLM using the provided script
+COPY install_vllm.sh .
+RUN if [ "$INSTALL_VLLM" = "true" ] ; then chmod +x install_vllm.sh && ./install_vllm.sh ; fi
+
+# Copy the project files
+COPY . .
+
+# Install the project itself
+RUN pip install .


### PR DESCRIPTION
To test with image:
```
sudo docker run -it --rm --net=host --ipc=host --ulimit memlock=-1:-1 -v "$(pwd)":/app --workdir /app --device=/dev/vfio/0       
   --device=/dev/vfio/1 --device=/dev/vfio/2 --device=/dev/vfio/3 --device=/dev/vfio/4 --device=/dev/vfio/5 --device=/dev/vfio/6        │
   --device=/dev/vfio/7 --device=/dev/vfio/vfio tunix_vllm_image bash
```
The scripts/grpo_demo_llama3_qwen2.py is not runnable now because the dataset is not downloaded by the script, instead, it expects to copy to a gcs bucket, I will fix that part