### PR TITLE
Fix the pyink rules and pylint rules to apply to notebooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,10 @@ repos:
     rev: '24.10.1'
     hooks:
       - id: pyink
-        types: [python]
+        types_or: [python, jupyter]
+        files: '\.(py|ipynb)$'
+        additional_dependencies:
+          - "pyink[jupyter]"
 
   - repo: https://github.com/pylint-dev/pylint
     rev: v3.3.8
@@ -18,3 +21,11 @@ repos:
           # because pylint is very strict.
           - --exit-zero
         exclude: ^tests/
+
+  - repo: https://github.com/nbQA-dev/nbQA
+    rev: 1.9.1
+    hooks:
+      - id: nbqa-pylint
+        additional_dependencies: [pylint==3.3.8]
+        args: [--rcfile=.pylintrc-notebooks, --fail-under=10.0]
+        files: '\.ipynb$'

--- a/.pylintrc-notebooks
+++ b/.pylintrc-notebooks
@@ -1,0 +1,17 @@
+# pylintrc-notebooks
+# Derived from Google's pylintrc, adjusted for Jupyter notebooks.
+
+[MESSAGES CONTROL]
+
+disable = missing-module-docstring,
+          missing-function-docstring,
+          wrong-import-position,
+          ungrouped-imports,
+          redefined-outer-name,
+          wrong-import-order,
+          import-error,
+
+[FORMAT]
+
+indent-string='  '
+


### PR DESCRIPTION
In the current setup, pyink and pylint only applies to python files. This PR adds the notebook support for both auto formatting and linting. 