### PR TITLE
Use official qwix and flax release instead of repo head.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
   { name = "Tunix Developers", email = "tunix-dev@google.com" },
 ]
 description = "A lightweight JAX-native LLM post-training framework."
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 readme = "README.md"
 license = "Apache-2.0"
 classifiers = [
@@ -17,7 +17,7 @@ classifiers = [
 ]
 dependencies = [
   "datasets",
-  "flax@git+https://github.com/google/flax", # TODO: change to proper release
+  "flax",
   "grain",
   "huggingface_hub",
   "jax",
@@ -25,7 +25,7 @@ dependencies = [
   "jaxtyping",
   "kagglehub",
   "omegaconf",
-  "qwix@git+https://github.com/google/qwix", # TODO: change to proper release
+  "qwix",
   "sentencepiece",
   "tensorboardX",
   "tensorflow_datasets",


### PR DESCRIPTION
Qwix made it's first release: https://pypi.org/project/qwix/#history

We can switch the qwix dependency to its official release now. That's the requirement for release.

For Flax, we tentatively switch to the release for v0.0.1. It will break couple of things. We will fix this in v0.1.0 release. This PR is to just unblock the v0.0.1 release.