### PR TITLE
Fix ReadTheDocs build

### DIFF
--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -1,0 +1,46 @@
+name: Run Notebooks
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  run-notebooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install jupyter papermill kaggle google-colab
+
+      - name: Configure Kaggle
+        env:
+          KAGGLE_USERNAME: ${{ secrets.KAGGLE_USERNAME }}
+          KAGGLE_KEY: ${{ secrets.KAGGLE_KEY }}
+        run: |
+            mkdir -p ~/.kaggle
+            echo "{\"username\":\"$KAGGLE_USERNAME\",\"key\":\"$KAGGLE_KEY\"}" > ~/.kaggle/kaggle.json
+            chmod 600 ~/.kaggle/kaggle.json
+
+      - name: Run notebooks
+        run: |
+          for notebook in examples/qwen3_example.ipynb; do
+              if [ -f "$notebook" ]; then
+                  echo "Running $notebook"
+                  papermill "$notebook" "${notebook%.ipynb}_output.ipynb"
+              fi
+          done
+
+      - name: Upload notebook outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: notebook-outputs
+          path: examples/*_output.ipynb

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
 
 sphinx:
   builder: html


### PR DESCRIPTION
The RTD build for latest is currently failing since https://github.com/google/tunix/pull/344 due to the minimum required Python version. This PR bumps the RTD yaml file to also use Python 3.12.