### PR TITLE
properly merge batches with arbitrarily nested data structure

### DIFF
--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -25,6 +25,7 @@ from absl import logging
 from flax import nnx
 from flax.nnx import filterlib
 from flax.nnx import statelib
+from grain._src.core import tree_lib
 import humanize
 import jax
 import jax.numpy as jnp
@@ -240,7 +241,7 @@ def merge_micro_batches(batches: List[dict[str, Any]]) -> dict[str, Any]:
     if isinstance(all_values[0], list):
       merged[key] = list(chain.from_iterable(all_values))
     else:
-      merged[key] = np.concatenate([np.asarray(v) for v in all_values], axis=0)
+      merged[key] = tree_lib.map_structure(lambda *xs: np.concatenate(xs), *all_values)
 
   return merged
 

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -25,10 +25,10 @@ from absl import logging
 from flax import nnx
 from flax.nnx import filterlib
 from flax.nnx import statelib
-from grain._src.core import tree_lib
 import humanize
 import jax
 import jax.numpy as jnp
+from jax import tree_util
 import jaxtyping
 import numpy as np
 from tunix.oss import utils
@@ -241,7 +241,7 @@ def merge_micro_batches(batches: List[dict[str, Any]]) -> dict[str, Any]:
     if isinstance(all_values[0], list):
       merged[key] = list(chain.from_iterable(all_values))
     else:
-      merged[key] = tree_lib.map_structure(lambda *xs: np.concatenate(xs), *all_values)
+      merged[key] = tree_util.tree_map(lambda *xs: np.concatenate(xs), *all_values)
 
   return merged
 

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -27,8 +27,8 @@ from flax.nnx import filterlib
 from flax.nnx import statelib
 import humanize
 import jax
-import jax.numpy as jnp
 from jax import tree_util
+import jax.numpy as jnp
 import jaxtyping
 import numpy as np
 from tunix.oss import utils
@@ -241,7 +241,9 @@ def merge_micro_batches(batches: List[dict[str, Any]]) -> dict[str, Any]:
     if isinstance(all_values[0], list):
       merged[key] = list(chain.from_iterable(all_values))
     else:
-      merged[key] = tree_util.tree_map(lambda *xs: np.concatenate(xs), *all_values)
+      merged[key] = tree_util.tree_map(
+          lambda *xs: np.concatenate(xs), *all_values
+      )
 
   return merged
 


### PR DESCRIPTION
<!--- Describe your changes in detail. -->

When merging multiple micro batches into one, the current code assumes a specific form of data structure that allows concatenation. However when the batch elements are nested dicts (it is very common in many custom prepared datasets), the current code will not be able to handle that.

Since the package already depends on jax, we can directly use the jax's tree map and np concat, so as to handle the arbitrary data structure when merging batches.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

https://docs.jax.dev/en/latest/_autosummary/jax.tree_util.tree_map.html


**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
