### PR TITLE
Add dev mode to install Tunix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ For minor changes, such as documentation updates or simple bug fixes, you can
 open a pull request directly.
 
 All bug fixes must include a link to a
-[Colab](https://colab.research.google.com/) notebook that clearly reproduces
-the error.
+[Colab](https://colab.research.google.com/) notebook that clearly reproduces the
+error.
 
 ### 2. Make code changes
 
@@ -45,6 +45,22 @@ after submitting your pull request. You can review the agreement
 A project maintainer will review your pull request. Be prepared for one or more
 rounds of comments and requested changes as we work with you to refine the
 contribution.
+
+### Setting up a development environment
+
+We recommend creating an isolated virtual environment before installing Tunix's
+development dependencies. From the repository root you can run:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+```
+
+The `dev` extra pulls in the bleeding-edge dependencies we rely on during local
+development. If you prefer to stick with released packages, skip the extra and
+run `pip install -e .` instead.
 
 ### Step 6. Merging
 
@@ -100,7 +116,13 @@ git commit -m "<message>" --no-verify
 
 ## Documentation
 
-The Tunix documentation website is built using [Sphinx](https://www.sphinx-doc.org) and [MyST](https://myst-parser.readthedocs.io/en/latest/). Documents can be written in [MyST Markdown syntax](https://myst-parser.readthedocs.io/en/latest/syntax/typography.html#syntax-core) or [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
+The Tunix documentation website is built using
+[Sphinx](https://www.sphinx-doc.org) and
+[MyST](https://myst-parser.readthedocs.io/en/latest/). Documents can be written
+in
+[MyST Markdown syntax](https://myst-parser.readthedocs.io/en/latest/syntax/typography.html#syntax-core)
+or
+[reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html).
 
 ### Building the documentation locally (optional)
 
@@ -136,9 +158,9 @@ documentation.
 ### Adding new documentation files
 
 If you are adding a new document, make sure it is included in the `toctree`
-directive corresponding to the section where the new document should live.
-For example, if adding a new page, make sure it is listed in the `toctree`
-directive in `docs/index.md`.
+directive corresponding to the section where the new document should live. For
+example, if adding a new page, make sure it is listed in the `toctree` directive
+in `docs/index.md`.
 
 <!-- ### Documentation deployment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 dependencies = [
   "datasets",
-  "flax@git+https://github.com/google/flax", # TODO: change to proper release
+  "flax>=0.11.2",
   "gcsfs",
   "grain",
   "huggingface_hub",
@@ -47,6 +47,10 @@ docs = [
     "sphinx-gallery>=0.19.0",
     "sphinx-collections>=0.0.1",
     "sphinx_contributors",
+]
+dev = [
+    "flax@git+https://github.com/google/flax",
+    "qwix@git+https://github.com/google/qwix",
 ]
 
 [project.urls]


### PR DESCRIPTION
Dev mode pulls from github instead of py package for certain libraries, e.g. Flax, Qwix. Nivida (through MaxText) reported issues when installing Tunix. They install flax by pip install -e /opt/flax which will be overwritten by our deps installation. This PR solves this problem.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
