### PR TITLE
Provide nnx.display alternative for flax<0.12.0

### DIFF
--- a/examples/dpo_demo.ipynb
+++ b/examples/dpo_demo.ipynb
@@ -102,8 +102,11 @@
         "from tunix.generate import sampler as sampler_lib\n",
         "from tunix.models.gemma3 import params as gemma3_params_lib\n",
         "from tunix.sft import metrics_logger\n",
+        "from tunix.sft import utils as sft_utils\n",
         "from tunix.sft.dpo.dpo_trainer import DPOTrainer, DPOTrainingConfig\n",
-        "from tunix.sft.peft_main import obtain_model_config"
+        "from tunix.sft.peft_main import obtain_model_config\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
       ]
     },
     {
@@ -212,7 +215,7 @@
         "\n",
         "The data preprocessing is taken care of by Tunix's `DPOTrainer`. All we need is\n",
         "to make sure we feed in our prompts in the correct format (for example, adding\n",
-        "correct special tokens, such as `<start_of_turn>`, `<end_of_turn>`), etc."
+        "correct special tokens, such as `\u003cstart_of_turn\u003e`, `\u003cend_of_turn\u003e`), etc."
       ]
     },
     {
@@ -223,9 +226,9 @@
       },
       "outputs": [],
       "source": [
-        "PROMPT_TEMPLATE = \"\"\"<start_of_turn>user\n",
-        "{prompt}<end_of_turn>\n",
-        "<start_of_turn>model\"\"\""
+        "PROMPT_TEMPLATE = \"\"\"\u003cstart_of_turn\u003euser\n",
+        "{prompt}\u003cend_of_turn\u003e\n",
+        "\u003cstart_of_turn\u003emodel\"\"\""
       ]
     },
     {
@@ -236,7 +239,7 @@
       },
       "outputs": [],
       "source": [
-        "def get_dataset() -> grain.MapDataset:\n",
+        "def get_dataset() -\u003e grain.MapDataset:\n",
         "  hf_dataset = load_dataset(\n",
         "      \"argilla/ultrafeedback-binarized-preferences-cleaned\"\n",
         "  )[\"train\"]\n",
@@ -441,7 +444,7 @@
       "source": [
         "# Policy model\n",
         "lora_model = get_lora_model(ref_model, mesh=mesh)\n",
-        "nnx.display(lora_model)"
+        "nnx_display(lora_model)"
       ]
     },
     {

--- a/examples/dpo_demo_gemma3.ipynb
+++ b/examples/dpo_demo_gemma3.ipynb
@@ -69,6 +69,7 @@
         "from tunix.models.gemma3 import params_safetensors as params_safetensors_lib\n",
         "\n",
         "from datasets import load_dataset\n",
+        "from tunix.sft import utils as sft_utils\n",
         "from tunix.sft.dpo.dpo_trainer import DPOTrainingConfig\n",
         "from tunix.sft.dpo.dpo_trainer import DPOTrainer\n",
         "from huggingface_hub import snapshot_download\n",
@@ -77,7 +78,9 @@
         "import numpy as np\n",
         "from tunix.sft.utils import show_hbm_usage\n",
         "from tunix.sft import metrics_logger\n",
-        "from orbax import checkpoint as ocp"
+        "from orbax import checkpoint as ocp\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
       ]
     },
     {
@@ -236,7 +239,7 @@
         "  gemma3 = params_safetensors_lib.create_model_from_safe_tensors(\n",
         "      MODEL_CP_PATH, model_config, mesh\n",
         "  )\n",
-        "  nnx.display(gemma3)"
+        "  nnx_display(gemma3)"
       ]
     },
     {
@@ -314,7 +317,7 @@
       "source": [
         "# Policy model\n",
         "lora_gemma = get_lora_model(gemma3, mesh=mesh)\n",
-        "nnx.display(lora_gemma)"
+        "nnx_display(lora_gemma)"
       ]
     },
     {

--- a/examples/grpo_demo.ipynb
+++ b/examples/grpo_demo.ipynb
@@ -99,7 +99,10 @@
         "from tunix.rl import rl_cluster as rl_cluster_lib\n",
         "from tunix.rl.grpo.grpo_learner import GRPOConfig, GRPOLearner\n",
         "from tunix.rl.rollout import base_rollout\n",
-        "from tunix.sft import metrics_logger"
+        "from tunix.sft import metrics_logger\n",
+        "from tunix.sft import utils as sft_utils\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
       ]
     },
     {
@@ -238,9 +241,9 @@
         "## Data preprocessing\n",
         "\n",
         "First, let's define some special tokens. We instruct the model to first reason\n",
-        "between the `<reasoning>` and `</reasoning>` tokens. After\n",
-        "reasoning, we expect it to provide the answer between the `<answer>` and\n",
-        "`</answer>` tokens."
+        "between the `\u003creasoning\u003e` and `\u003c/reasoning\u003e` tokens. After\n",
+        "reasoning, we expect it to provide the answer between the `\u003canswer\u003e` and\n",
+        "`\u003c/answer\u003e` tokens."
       ]
     },
     {
@@ -250,10 +253,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "reasoning_start = \"<reasoning>\"\n",
-        "reasoning_end = \"</reasoning>\"\n",
-        "solution_start = \"<answer>\"\n",
-        "solution_end = \"</answer>\"\n",
+        "reasoning_start = \"\u003creasoning\u003e\"\n",
+        "reasoning_end = \"\u003c/reasoning\u003e\"\n",
+        "solution_start = \"\u003canswer\u003e\"\n",
+        "solution_end = \"\u003c/answer\u003e\"\n",
         "\n",
         "\n",
         "SYSTEM_PROMPT = f\"\"\"You are given a problem. Think about the problem and \\\n",
@@ -261,11 +264,11 @@
         "{reasoning_end}. Then, provide the final answer (i.e., just one numerical \\\n",
         "value) between {solution_start} and {solution_end}.\"\"\"\n",
         "\n",
-        "TEMPLATE = \"\"\"<start_of_turn>user\n",
+        "TEMPLATE = \"\"\"\u003cstart_of_turn\u003euser\n",
         "{system_prompt}\n",
         "\n",
-        "{question}<end_of_turn>\n",
-        "<start_of_turn>model\"\"\""
+        "{question}\u003cend_of_turn\u003e\n",
+        "\u003cstart_of_turn\u003emodel\"\"\""
       ]
     },
     {
@@ -283,13 +286,13 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "def extract_hash_answer(text: str) -> str | None:\n",
+        "def extract_hash_answer(text: str) -\u003e str | None:\n",
         "  if \"####\" not in text:\n",
         "    return None\n",
         "  return text.split(\"####\")[1].strip()\n",
         "\n",
         "\n",
-        "def get_dataset(data_dir, split=\"train\") -> grain.MapDataset:\n",
+        "def get_dataset(data_dir, split=\"train\") -\u003e grain.MapDataset:\n",
         "  # Download data\n",
         "  if not os.path.exists(data_dir):\n",
         "    os.makedirs(data_dir)\n",
@@ -561,7 +564,7 @@
       "source": [
         "# Policy model\n",
         "lora_policy = get_lora_model(ref_model, mesh=mesh)\n",
-        "nnx.display(lora_policy)"
+        "nnx_display(lora_policy)"
       ]
     },
     {
@@ -591,7 +594,7 @@
         "- reward if the format of the output approximately matches the instruction given\n",
         "in `TEMPLATE`;\n",
         "- reward if the answer is correct/partially correct;\n",
-        "- Sometimes, the text between `<answer>`, `</answer>` might not be one\n",
+        "- Sometimes, the text between `\u003canswer\u003e`, `\u003c/answer\u003e` might not be one\n",
         "  number. So, we extract the number, and reward the model if the answer is correct.\n",
         "\n",
         "The reward functions are inspired from\n",
@@ -637,7 +640,10 @@
       "outputs": [],
       "source": [
         "def match_format_exactly(prompts, completions, **kwargs):\n",
-        "  return [0 if match_format.search(response) is None else 3.0 for response in completions]"
+        "  return [\n",
+        "      0 if match_format.search(response) is None else 3.0\n",
+        "      for response in completions\n",
+        "  ]"
       ]
     },
     {
@@ -697,7 +703,9 @@
         "  ]\n",
         "\n",
         "  scores = []\n",
-        "  assert len(extracted_responses) == len(answer), f\"{extracted_responses} and {answer} have mismatching length\"\n",
+        "  assert len(extracted_responses) == len(\n",
+        "      answer\n",
+        "  ), f\"{extracted_responses} and {answer} have mismatching length\"\n",
         "  for guess, true_answer in zip(extracted_responses, answer):\n",
         "    score = 0\n",
         "    if guess is None:\n",
@@ -714,9 +722,9 @@
         "      # Ie if the answer is within some range, reward it!\n",
         "      try:\n",
         "        ratio = float(guess) / float(true_answer)\n",
-        "        if ratio >= 0.9 and ratio <= 1.1:\n",
+        "        if ratio \u003e= 0.9 and ratio \u003c= 1.1:\n",
         "          score += 0.5\n",
-        "        elif ratio >= 0.8 and ratio <= 1.2:\n",
+        "        elif ratio \u003e= 0.8 and ratio \u003c= 1.2:\n",
         "          score += 0.25\n",
         "        else:\n",
         "          score -= 1.0  # Penalize wrong answers\n",
@@ -731,7 +739,7 @@
       "id": "nIpOVv78Tn1k",
       "metadata": {},
       "source": [
-        "Sometimes, the text between `<answer>` and `</answer>` might not be one\n",
+        "Sometimes, the text between `\u003canswer\u003e` and `\u003c/answer\u003e` might not be one\n",
         "number; it can be a sentence. So, we extract the number and compare the answer."
       ]
     },
@@ -808,7 +816,7 @@
         "ratio lies between 0.9 and 1.1.  \n",
         "* **Format Accuracy**: percentage of samples for which the model outputs the\n",
         "correct format, i.e., reasoning between the reasoning special tokens, and the\n",
-        "final answer between the \\`\\<start\\_answer\\>\\`, \\`\\<end\\_answer\\>\\` tokens.\n",
+        "final answer between the \\`\\\u003cstart\\_answer\\\u003e\\`, \\`\\\u003cend\\_answer\\\u003e\\` tokens.\n",
         "\n",
         "**Qualitative**\n",
         "\n",
@@ -930,7 +938,7 @@
         "            corr_ctr_per_question += 1\n",
         "\n",
         "          ratio = float(extracted_response.strip()) / float(answer.strip())\n",
-        "          if ratio >= 0.9 and ratio <= 1.1:\n",
+        "          if ratio \u003e= 0.9 and ratio \u003c= 1.1:\n",
         "            partially_corr_per_question += 1\n",
         "        except:\n",
         "          print(\"SKIPPED\")\n",
@@ -940,28 +948,28 @@
         "          corr_format_per_question += 1\n",
         "\n",
         "        if (\n",
-        "            corr_ctr_per_question > 0\n",
-        "            and partially_corr_per_question > 0\n",
-        "            and corr_format_per_question > 0\n",
+        "            corr_ctr_per_question \u003e 0\n",
+        "            and partially_corr_per_question \u003e 0\n",
+        "            and corr_format_per_question \u003e 0\n",
         "        ):\n",
         "          break\n",
         "\n",
-        "      if corr_ctr_per_question > 0:\n",
+        "      if corr_ctr_per_question \u003e 0:\n",
         "        corr += 1\n",
         "        if corr_lst and make_lst:\n",
         "          response_lst.append((question, answer, multiple_call_response))\n",
         "      else:\n",
         "        if not corr_lst and make_lst:\n",
         "          response_lst.append((question, answer, multiple_call_response))\n",
-        "      if partially_corr_per_question > 0:\n",
+        "      if partially_corr_per_question \u003e 0:\n",
         "        partially_corr += 1\n",
-        "      if corr_format_per_question > 0:\n",
+        "      if corr_format_per_question \u003e 0:\n",
         "        corr_format += 1\n",
         "\n",
         "      total += 1\n",
         "      if total % 10 == 0:\n",
         "        print(\n",
-        "            f\"===> {corr=}, {total=}, {corr / total * 100=}, \"\n",
+        "            f\"===\u003e {corr=}, {total=}, {corr / total * 100=}, \"\n",
         "            f\"{partially_corr / total * 100=}, {corr_format / total * 100=}\"\n",
         "        )\n",
         "\n",
@@ -1146,11 +1154,11 @@
         "\n",
         "We then create a `GRPOLearner`, the specialized trainer that uses a list of **reward functions** to evaluate and optimize the model's output, completing the RL training setup.\n",
         "\n",
-        "Tunix trainers are integrated with [Weights & Biases](https://wandb.ai/) to help you visualize the training progress. You can choose how you want to use it:\n",
+        "Tunix trainers are integrated with [Weights \u0026 Biases](https://wandb.ai/) to help you visualize the training progress. You can choose how you want to use it:\n",
         "\n",
         "**Option 1 (Type 1)**: If you're running a quick experiment or just testing things out, choose this. It creates a temporary, private dashboard right in your browser without requiring you to log in or create an account.\n",
         "\n",
-        "**Option 2 (Type 2)**: If you have an existing W&B account and want to save your project's history to your personal dashboard, choose this. You'll be prompted to enter your API key or log in."
+        "**Option 2 (Type 2)**: If you have an existing W\u0026B account and want to save your project's history to your personal dashboard, choose this. You'll be prompted to enter your API key or log in."
       ]
     },
     {

--- a/examples/logit_distillation.ipynb
+++ b/examples/logit_distillation.ipynb
@@ -70,7 +70,10 @@
         "from tunix.examples.data import translation_dataset as data_lib\n",
         "from tunix.generate import sampler as sampler_lib\n",
         "from tunix.models.gemma import gemma as gemma_lib\n",
-        "from tunix.models.gemma import params as params_lib"
+        "from tunix.models.gemma import params as params_lib\n",
+        "from tunix.sft import utils as sft_utils\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
       ]
     },
     {
@@ -235,7 +238,7 @@
         "    os.path.join(TEACHER_CKPT_DIR, \"state\"), teacher_config, mesh\n",
         ")\n",
         "print(\"Teacher model created.\")\n",
-        "# nnx.display(teacher_model) # Optional: view model structure\n",
+        "# nnx_display(teacher_model) # Optional: view model structure\n",
         "\n",
         "# Create Student Model\n",
         "print(\"\\nCreating sharded student model (Gemma 2B)...\")\n",
@@ -244,7 +247,7 @@
         "    os.path.join(STUDENT_CKPT_DIR, \"state\"), student_config, mesh\n",
         ")\n",
         "print(\"Student model created.\")\n",
-        "# nnx.display(student_model) # Optional: view model structure\n",
+        "# nnx_display(student_model) # Optional: view model structure\n",
         "\n",
         "show_hbm_usage()"
       ]

--- a/examples/model_load/from_safetensor_load/gemma2_model_load.ipynb
+++ b/examples/model_load/from_safetensor_load/gemma2_model_load.ipynb
@@ -9,6 +9,7 @@
       "outputs": [],
       "source": [
         "!pip install -q git+https://github.com/google/tunix\n",
+        "\n",
         "!pip install -q git+https://github.com/google/qwix\n",
         "!pip uninstall -q -y flax\n",
         "!pip install --no-cache-dir git+https://github.com/google/flax.git\n",
@@ -17,21 +18,23 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "Crz-9Yt7IO0v"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "!huggingface-cli login"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "QJjzmkSCIRqv"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "import functools\n",
         "from flax import nnx\n",
@@ -39,16 +42,19 @@
         "import humanize\n",
         "import jax\n",
         "from tunix.models.gemma import gemma as model_lib\n",
-        "from tunix.models.gemma import params_safetensors as params_lib"
-      ],
-      "outputs": [],
-      "execution_count": null
+        "from tunix.models.gemma import params_safetensors as params_lib\n",
+        "from tunix.sft import utils as sft_utils\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "cr7lQ0PmU1Fd"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def show_hbm_usage():\n",
         "  \"\"\"Displays memory usage per device.\"\"\"\n",
@@ -76,24 +82,24 @@
         "    )\n",
         "\n",
         "  print(\"--- End HBM Usage ---\")"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "zcP25ZQ3TsZ7"
       },
-      "cell_type": "markdown",
       "source": [
         "# Download the weights and load into TPU"
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "yN5jp8b9VBXN"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "model_id = \"google/gemma-2-2b-it\"\n",
         "ignore_patterns = [\n",
@@ -104,27 +110,27 @@
         "    repo_id=model_id, ignore_patterns=ignore_patterns\n",
         ")\n",
         "print(f\"Model successfully downloaded to: {local_model_path}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "IJQKqNPaVPz6"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "print(\"\\n--- HBM Usage BEFORE Model Load ---\")\n",
         "show_hbm_usage()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "fZ3hUjf4VThk"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "MODEL_CP_PATH = local_model_path\n",
         "\n",
@@ -133,50 +139,50 @@
         "mesh = jax.make_mesh(*MESH)\n",
         "with mesh:\n",
         "  gemma = params_lib.create_model_from_safe_tensors(MODEL_CP_PATH, config, mesh)\n",
-        "  nnx.display(gemma)"
-      ],
-      "outputs": [],
-      "execution_count": null
+        "  nnx_display(gemma)"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "tc_a5GUEVeXf"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "print(\"\\n--- HBM Usage AFTER Model Load ---\")\n",
         "show_hbm_usage()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "jZCKBEjvTm_A"
       },
-      "cell_type": "markdown",
       "source": [
         "# Run inference"
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "31D_52F_TlTs"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "from transformers import AutoTokenizer\n",
         "\n",
         "tokenizer = AutoTokenizer.from_pretrained(MODEL_CP_PATH)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "kb--p9NxT7x1"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "from tunix.generate import sampler\n",
         "\n",
@@ -218,14 +224,15 @@
         "for t in out.text:\n",
         "  print(t)\n",
         "  print(\"*\" * 30)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     }
   ],
   "metadata": {
     "colab": {
       "private_outputs": true
+    },
+    "language_info": {
+      "name": "python"
     }
   },
   "nbformat": 4,

--- a/examples/model_load/from_safetensor_load/gemma3_model_load.ipynb
+++ b/examples/model_load/from_safetensor_load/gemma3_model_load.ipynb
@@ -9,6 +9,7 @@
       "outputs": [],
       "source": [
         "!pip install -q git+https://github.com/google/tunix\n",
+        "\n",
         "!pip install -q git+https://github.com/google/qwix\n",
         "!pip uninstall -q -y flax\n",
         "!pip install --no-cache-dir git+https://github.com/google/flax.git\n",
@@ -17,21 +18,23 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "OSEz5DzpVs0O"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "!huggingface-cli login"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "EOzZn4VwVsxR"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "import functools\n",
         "from flax import nnx\n",
@@ -39,16 +42,19 @@
         "import humanize\n",
         "import jax\n",
         "from tunix.models.gemma3 import model as model_lib\n",
-        "from tunix.models.gemma3 import params_safetensors as params_lib"
-      ],
-      "outputs": [],
-      "execution_count": null
+        "from tunix.models.gemma3 import params_safetensors as params_lib\n",
+        "from tunix.sft import utils as sft_utils\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "RNqkatgHVsuD"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "def show_hbm_usage():\n",
         "  \"\"\"Displays memory usage per device.\"\"\"\n",
@@ -76,24 +82,24 @@
         "    )\n",
         "\n",
         "  print(\"--- End HBM Usage ---\")"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "COcS1YLBeBSx"
       },
-      "cell_type": "markdown",
       "source": [
         "# Download the weights and load into TPU"
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "KWgpwuieVsqw"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "model_id = \"google/gemma-3-1b-it\"\n",
         "ignore_patterns = [\n",
@@ -104,27 +110,27 @@
         "    repo_id=model_id, ignore_patterns=ignore_patterns\n",
         ")\n",
         "print(f\"Model successfully downloaded to: {local_model_path}\")"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "uob4MJ0MVsl0"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "print(\"\\n--- HBM Usage BEFORE Model Load ---\")\n",
         "show_hbm_usage()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "E4BXD3O4VsfK"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "MODEL_CP_PATH = local_model_path\n",
         "\n",
@@ -137,50 +143,50 @@
         "  gemma3 = params_lib.create_model_from_safe_tensors(\n",
         "      MODEL_CP_PATH, config, mesh\n",
         "  )\n",
-        "  nnx.display(gemma3)"
-      ],
-      "outputs": [],
-      "execution_count": null
+        "  nnx_display(gemma3)"
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "FN_F1x5jWKFR"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "print(\"\\n--- HBM Usage AFTER Model Load ---\")\n",
         "show_hbm_usage()"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "markdown",
       "metadata": {
         "id": "uL_mqGK9UUtc"
       },
-      "cell_type": "markdown",
       "source": [
         "# Run inference"
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "hOJU7xkZV8Gd"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "from transformers import AutoTokenizer\n",
         "\n",
         "tokenizer = AutoTokenizer.from_pretrained(MODEL_CP_PATH)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "_D2vm9oIUXWU"
       },
-      "cell_type": "code",
+      "outputs": [],
       "source": [
         "from tunix.generate import sampler\n",
         "\n",
@@ -221,14 +227,15 @@
         "for t in out.text:\n",
         "  print(t)\n",
         "  print(\"*\" * 30)"
-      ],
-      "outputs": [],
-      "execution_count": null
+      ]
     }
   ],
   "metadata": {
     "colab": {
       "private_outputs": true
+    },
+    "language_info": {
+      "name": "python"
     }
   },
   "nbformat": 4,

--- a/examples/qlora_demo.ipynb
+++ b/examples/qlora_demo.ipynb
@@ -152,6 +152,9 @@
         "from tunix.sft import utils\n",
         "from tunix.sft import metrics_logger\n",
         "from tunix.sft import peft_trainer\n",
+        "from tunix.sft import utils as sft_utils\n",
+        "\n",
+        "nnx_display = sft_utils.colab_nnx_display\n",
         "\n",
         "logger = logging.getLogger()\n",
         "logger.setLevel(logging.INFO)"
@@ -455,7 +458,7 @@
       },
       "outputs": [],
       "source": [
-        "nnx.display(base_model)"
+        "nnx_display(base_model)"
       ]
     },
     {
@@ -593,7 +596,7 @@
       "source": [
         "# LoRA model\n",
         "lora_model = get_lora_model(base_model, mesh=mesh)\n",
-        "nnx.display(lora_model)"
+        "nnx_display(lora_model)"
       ]
     },
     {
@@ -606,7 +609,7 @@
       "source": [
         "# QLoRA model\n",
         "qlora_model = get_lora_model(base_model, mesh=mesh, quantize=True)\n",
-        "nnx.display(qlora_model)"
+        "nnx_display(qlora_model)"
       ]
     },
     {

--- a/tests/models/llama3/params_test.py
+++ b/tests/models/llama3/params_test.py
@@ -33,12 +33,13 @@
 import unittest
 
 from absl.testing import absltest
-from flax import nnx
 from huggingface_hub import snapshot_download
 import jax
 from tunix.models.llama3 import model
 from tunix.models.llama3 import params
+from tunix.sft import utils as sft_utils
 
+nnx_display = sft_utils.colab_nnx_display
 
 # --- Model Download Section ---
 print("Downloading Llama-3.2-1B model from Hugging Face...")
@@ -98,16 +99,7 @@ class Llama3ParamsTest(absltest.TestCase):
       self.assertIsNotNone(llama3)
 
       # Test model display completes without exceptions
-      try:
-        nnx.display(llama3)
-        display_success = True
-      except Exception as e:
-        self.fail(f"nnx.display failed for {model_name} model: {e}")
-
-      self.assertTrue(
-          display_success, f"{model_name} model display should succeed"
-      )
-
+      self.assertTrue(nnx_display(llama3))
       print(f"Llama3-{model_name} model loaded and displayed successfully")
 
   def test_create_model_from_safe_tensors_1b(self):

--- a/tests/sft/test_utils.py
+++ b/tests/sft/test_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import jax
+from flax import nnx
+
+from tunix.sft import utils as sft_utils
+from absl.testing import absltest
+
+
+class MyModel(nnx.Module):
+
+  def __init__(self, din: int, dmid: int, dout: int, *, rngs: nnx.Rngs):
+    self.linear1 = nnx.Linear(din, dmid, rngs=rngs)
+    self.bn = nnx.BatchNorm(dmid, rngs=rngs)
+    self.dropout = nnx.Dropout(0.5, rngs=rngs)
+    self.linear2 = nnx.Linear(dmid, dout, rngs=rngs)
+    self.config_value = 123
+    self.config_list = [1, 2, 3]
+
+  def __call__(self, x: jax.Array, *, train: bool):
+    x = self.linear1(x)
+    x = self.bn(x, train=train)
+    x = self.dropout(x, train=train)
+    return self.linear2(x)
+
+
+def test_colab_nnx_display_lists_submodules():
+  model = MyModel(din=10, dmid=20, dout=5, rngs=nnx.Rngs(0))
+  summary = sft_utils.safe_display(model)
+
+  assert "linear1" in summary
+  assert "bn" in summary
+  assert "dropout" in summary
+  assert "linear2" in summary
+  assert summary.strip()
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
We were having issue with nnx.display in colab (only in colab) and I submit the fix to flax in cl/808733967, which is release in flax 0.12.0. However, Kaggle has issue building with Tunix (due to Jax, Pytorch, Libtpu, Tensorflow version conflicts). 

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->
This PR is to provide alternative to nnx.display interactive mode so that we can loosen the flax dependency to < 0.12.0

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
