### PR TITLE
Fix tunix/generate tests. [PR1/N to add all TPU tests to CI]

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -70,7 +70,11 @@ jobs:
 
     - name: Run tunix generation tests (PASSED only)
       run: |
-        python -m pytest tests/generate/utils_test.py -v --tb=short
+        # vllm_sampler_test depends on vllm TPU which is not OSS yet
+        # tokenizer_adapter_test requires access to gated repo
+        python -m pytest tests/generate/ -v --tb=short \
+          --ignore=tests/generate/vllm_sampler_test.py \
+          --ignore=tests/generate/tokenizer_adapter_test.py
 
     - name: Run tunix SFT tests (PASSED only)
       run: |
@@ -102,7 +106,7 @@ jobs:
 
     - name: Run tunix distillation tests
       run: |
-        python -m pytest tests/distillation/distillation_trainer_test.py -v --tb=short
+        python -m pytest tests/distillation/ -v --tb=short
 
     - name: Run tunix RL tests (PASSED only)
       run: |

--- a/tests/generate/beam_search_test.py
+++ b/tests/generate/beam_search_test.py
@@ -109,10 +109,10 @@ class BeamSearchTest(absltest.TestCase):
     new_scores1, tokens1 = jax.lax.top_k(
         jax.nn.log_softmax(jnp.array([1, 2, 1.1])), 2
     )
-    self.assertEqual(state.scores[0][0], new_scores0[0])
-    self.assertEqual(state.scores[0][1], new_scores0[1])
-    self.assertEqual(state.scores[1][0], new_scores1[0])
-    self.assertEqual(state.scores[1][1], new_scores1[1])
+    self.assertAlmostEqual(state.scores[0][0], new_scores0[0], places=6)
+    self.assertAlmostEqual(state.scores[0][1], new_scores0[1], places=6)
+    self.assertAlmostEqual(state.scores[1][0], new_scores1[0], places=6)
+    self.assertAlmostEqual(state.scores[1][1], new_scores1[1], places=6)
 
     updated_token_buffer = updated_params['token_buffer']
     expected = token_buffer
@@ -162,10 +162,10 @@ class BeamSearchTest(absltest.TestCase):
         ).ravel(),
         2,
     )
-    self.assertEqual(state.scores[0][0], new_scores0[0])
-    self.assertEqual(state.scores[0][1], new_scores0[1])
-    self.assertEqual(state.scores[1][0], new_scores1[0])
-    self.assertEqual(state.scores[1][1], new_scores1[1])
+    self.assertAlmostEqual(state.scores[0][0], new_scores0[0], places=6)
+    self.assertAlmostEqual(state.scores[0][1], new_scores0[1], places=6)
+    self.assertAlmostEqual(state.scores[1][0], new_scores1[0], places=6)
+    self.assertAlmostEqual(state.scores[1][1], new_scores1[1], places=6)
     # before the beam search, the token buffer[:][0] is [2, 1, 1, 2]
     # token_buffer[0] should be [1, 1, -1, ...]
     # token_buffer[1] should be [2, 1, -1, ...]

--- a/tunix/generate/tokenizer_adapter.py
+++ b/tunix/generate/tokenizer_adapter.py
@@ -34,12 +34,13 @@ class TokenizerAdapter:
     self._tokenizer = tokenizer
 
     missing_methods = self._missing_methods()
-    if not missing_methods:
-      self._tokenizer_type = TokenizerType.NONE
-    elif isinstance(self._tokenizer, spm.SentencePieceProcessor):
+
+    if isinstance(self._tokenizer, spm.SentencePieceProcessor):
       self._tokenizer_type = TokenizerType.SP
     elif self._is_hf_tokenizer():
       self._tokenizer_type = TokenizerType.HF
+    elif not missing_methods:
+      self._tokenizer_type = TokenizerType.NONE
     else:
       raise ValueError(
           'Your tokenizer should either be a `spm.SentencePieceProcessor` '


### PR DESCRIPTION
<!--- Describe your changes in detail. -->
This PR fixes the following:
1. Include all the distillation tests in CI. This is to fix a mistake in previous PR
2. Use assertAlmostEqual instead of assertEqual for floating number
3. Fix the tokenizer problem, in the original logic, 
    a. If user inherit from SentencePiece and creates his own Tokenizer, and didn't add the missing function (pad_id() for SP) in for this tokenizer, we will raise undefined Tokenizer error
    b. If user inherit from SentencePiece and creates his own Tokenizer, and add the missing function, we will consider it's a custom Tokenizer (not SP) and therefore will not call the SP designated decoding/encoding function (DecodeIds/EncodeAsIds), will call encode/decode instead. 
That's not the intended behavior. This fix make sure any inheritance from SP will be treated like SP.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
