### PR TITLE
Adds prod and dev mode for tunix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,23 +67,16 @@ You can install Tunix in several ways:
 1. From PyPI (recommended):
 
 ```sh
-pip install tunix
+pip install "tunix[prod]"
 ```
 
-2. With development extras If you want to contribute or run tests and examples
-   locally:
-
-```
-pip install "tunix[dev]"
-```
-
-3. Directly from GitHub (latest main branch)
+2. Directly from GitHub (latest main branch)
 
 ```sh
 pip install git+https://github.com/google/tunix
 ```
 
-4. From source (editable install) If you plan to modify the codebase and run it
+3. From source (editable install) If you plan to modify the codebase and run it
    in development mode:
 
 ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 ]
 dependencies = [
   "datasets",
-  "flax>=0.12.0",
   "gcsfs",
   "grain",
   "huggingface_hub",
@@ -49,9 +48,11 @@ docs = [
     "sphinx-collections>=0.0.1",
     "sphinx_contributors",
 ]
+prod = [
+    "flax>=0.12.0",
+]
 dev = [
-    "flax@git+https://github.com/google/flax",
-    "qwix@git+https://github.com/google/qwix",
+    "flax>=0.11.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
<!--- Describe your changes in detail. -->
User need to pip install google-tunix[prod]/[dev]. But actually dev mode is for our customer who needs a lower version of flax. This is also to satisfy that pypi release should not contain any editable wheel in the pyproject config.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
