### PR TITLE
Downgrad the Jax/libtpu version to resolve performance issue on Cloud TPU

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-tunix"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
   { name = "Tunix Developers", email = "tunix-dev@google.com" },
 ]
@@ -22,8 +22,7 @@ dependencies = [
   "gcsfs",
   "grain",
   "huggingface_hub",
-  "jax",
-  "jax[tpu]",
+  "jax[tpu]<=0.7.1",
   "jaxtyping",
   "kagglehub",
   "omegaconf",


### PR DESCRIPTION
<!--- Describe your changes in detail. -->
We observe serious performance degradation on Cloud TPU, with 10-20 minutes to finish step 1 comparing 1 minute on Borg. After downgrading Jax to 0.7.1, libtpu from 0.0.23 to 0.0.20,  cloud TPU shows on par performance as Borg. For prior version of Jax=0.7.0 and 0.6.2, libtpu=0.0.20 and 0.0.17, we don't see this issue either.

This PR also bumps the Tunix version to 0.1.1.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
