### PR TITLE
Relax the jax version requirement to get a working Kaggle image.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "gcsfs",
   "grain",
   "huggingface_hub",
-  "jax[tpu]==0.7.1", # Newer libtpu version has some perf regression on cloud TPU, pin to 0.7.1 for now. b/448646341
+  "jax[tpu]>=0.6.0,<=0.7.1", # Newer libtpu version has some perf regression on cloud TPU, pin to <=0.7.1 for now. b/448646341
   "jaxtyping",
   "kagglehub",
   "omegaconf",
@@ -48,7 +48,7 @@ docs = [
     "sphinx_contributors",
 ]
 prod = [
-    "flax>=0.12.0",
+    "flax>=0.11.2",
 ]
 dev = [
     "flax>=0.11.2",


### PR DESCRIPTION
<!--- Describe your changes in detail. -->
Kaggle image has additional dependency on torch xla which only works for libtpu 0.0.17 now, that maps to Jax 0.6.2. Relax the constraint to accommodate that.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
