### PR TITLE
Add Gemma3-270M model configuration support #500

### DIFF
--- a/tests/cli/utils/model_test.py
+++ b/tests/cli/utils/model_test.py
@@ -35,6 +35,10 @@ from tunix.cli.utils import model
         model_name="gemma3-1b",
     ),
     dict(
+        testcase_name="gemma3-270m",
+        model_name="gemma3-270m",
+    ),
+    dict(
         testcase_name="llama3.2-1b",
         model_name="llama3.2-1b",
     ),

--- a/tunix/models/gemma3/model.py
+++ b/tunix/models/gemma3/model.py
@@ -109,6 +109,26 @@ class ModelConfig:
   param_dtype: jnp.dtype = jnp.bfloat16
 
   @classmethod
+  def gemma3_270m(
+      cls,
+      sharding_config: ShardingConfig = ShardingConfig.get_default_sharding(),
+  ) -> 'ModelConfig':
+    """Gemma3-270M text-only config."""
+    return cls(
+        num_layers=18,
+        num_embed=262144,
+        embed_dim=640,
+        hidden_dim=2048,
+        num_heads=4,
+        head_dim=256,
+        num_kv_heads=1,
+        sliding_window_size=512,
+        local_base_frequency=10_000,
+        global_base_frequency=1_000_000,
+        shd_config=sharding_config,
+    )
+
+  @classmethod
   def gemma3_1b(
       cls,
       sharding_config: ShardingConfig = ShardingConfig.get_default_sharding(),

--- a/tunix/models/gemma3/params.py
+++ b/tunix/models/gemma3/params.py
@@ -32,11 +32,13 @@ import sentencepiece as spm  # isort:skip  # pylint: disable=line-too-long
 
 
 # Pretrained
+GEMMA3_270M_PT = 'gs://gemma-data/checkpoints/gemma3-270m-pt'
 GEMMA3_1B_PT = 'gs://gemma-data/checkpoints/gemma3-1b-pt'
 GEMMA3_4B_PT = 'gs://gemma-data/checkpoints/gemma3-4b-pt'
 GEMMA3_12B_PT = 'gs://gemma-data/checkpoints/gemma3-12b-pt'
 GEMMA3_27B_PT = 'gs://gemma-data/checkpoints/gemma3-27b-pt'
 # Instruction Tuned
+GEMMA3_270M_IT = 'gs://gemma-data/checkpoints/gemma3-270m-it'
 GEMMA3_1B_IT = 'gs://gemma-data/checkpoints/gemma3-1b-it'
 GEMMA3_4B_IT = 'gs://gemma-data/checkpoints/gemma3-4b-it'
 GEMMA3_12B_IT = 'gs://gemma-data/checkpoints/gemma3-12b-it'


### PR DESCRIPTION
Add ModelConfig.gemma3_270m() classmethod with architecture specs:
  * 18 layers, 640 embed_dim, 2048 hidden_dim
  * 4 heads (256 head_dim), 1 KV head (GQA)
  * 512 sliding window, 262144 vocab size
- Add checkpoint path constants (GEMMA3_270M_PT, GEMMA3_270M_IT)

Resolves #500

<img width="701" height="372" alt="image" src="https://github.com/user-attachments/assets/88f23df7-c233-4a07-8bab-26fd2a10720b" />


> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
