### PR TITLE
Fix multiple vLLM Tunix integration issue.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
   "gcsfs",
   "grain",
   "huggingface_hub",
-  "jax[tpu]>=0.6.0,<=0.7.1", # Newer libtpu version has some perf regression on cloud TPU, pin to <=0.7.1 for now. b/448646341
   "jaxtyping",
   "kagglehub",
   "omegaconf",
@@ -49,10 +48,14 @@ docs = [
     "sphinx_contributors",
 ]
 prod = [
+    "jax[tpu]>=0.6.0,<=0.7.1", # Newer libtpu version has some perf regression on cloud TPU, pin to <=0.7.1 for now. b/448646341
     "flax>=0.11.2",
 ]
 dev = [
+    "jax[tpu]>=0.7.2",  # vLLM TPU backend only works with latest Jax
     "flax>=0.11.2",
+    "numba",
+    "vllm",
 ]
 
 [project.urls]

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -542,7 +542,8 @@ def _align_shape(
   repeat_ops = []
   for i, (src_dim, tgt_dim) in enumerate(zip(val.shape, tgt_shape)):
     if src_dim < tgt_dim:
-      if i == len(val.shape) - 1:
+      # For QKV, H is dim(-1); For O, H is dim(-2), same for Tunix and vLLM
+      if i == len(val.shape) - 1 or ('o_proj' in src_key and  i == len(val.shape) - 2):
         # Head dimension: pad with zeros
         pad_width.append((0, tgt_dim - src_dim))
       else:

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -138,7 +138,6 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     args["additional_config"] = {}
     args["model"] = config.model_version
     args["max_model_len"] = config.max_model_len
-    args["tensor_parallel_size"] = self._find_tp_size(config.mesh)
     args["gpu_memory_utilization"] = config.hbm_utilization
     if config.mapping_config.lora_config is not None:
       args["additional_config"][
@@ -146,7 +145,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       ] = config.mapping_config.lora_config
     device_indexes = config.mesh.device_ids.flatten().tolist()
     args["additional_config"]["sharding"] = {
-        "sharding_strategy": {"device_indexes": device_indexes}
+        "sharding_strategy": {"device_indexes": device_indexes, "tensor_parallelism": self._find_tp_size(config.mesh)}
     }
     return args
 


### PR DESCRIPTION
FYI, we are still waiting for tpu_inference (known as tpu_common) to OSS and therefore we don't have vLLM tests in CI to guard any changes yet. We need to manually run the vllm tests if we make changes to them.

This PR fixes the broken Tunix vLLM integration:
1. Fix the padding issue, for head dimension padding, the current logic assumes it's always the last dimension. However, that's not the case for o_proj, which is -2 dimension.

2. Bump up to Jax 0.7.2 in google-tunix[dev] mode because the latest tpu-common only works with latest Jax. Will merge to google-tunix[prod] when the performance regression is fixed in b/448646341
3. Add the missing dependencies for dev mode: numba, vllm
4. Using smaller model (llama3.2 1B) instead for the test
5. Using the model config instead of hard coded model parameters when constructing the sampler
6. Adds the missing to_hf_hook_fns
7. Use keyword matching instead of word by word matching in the test, a lot of things could contribute to randomness in LLM outputs
8. llama 3.2 doesn't have lm_head, instead it's reusing the embeder weights. Update the test to check another tensor instead of lm_head
9. Removed test_generation_length_exceed_max_model_len that checks exceeding the max length because vLLM always terminates at the max length limit.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
