### PR TITLE
Clean up vllm tests.

### DIFF
--- a/scripts/llama3_example.py
+++ b/scripts/llama3_example.py
@@ -18,34 +18,25 @@ import os
 import tempfile
 
 from flax import nnx
-import huggingface_hub
 import jax
 import transformers
 from tunix.generate import sampler
 from tunix.models.llama3 import model
 from tunix.models.llama3 import params
+from tunix.tests import test_common as tc
 
-MODEL_VERSION = "meta-llama/Llama-3.1-8B-Instruct"
+
+MODEL_VERSION = "meta-llama/Llama-3.2-1B-Instruct"
 
 # Consider switch to tempfile after figuring out how it works
 temp_dir = tempfile.gettempdir()
 MODEL_CP_PATH = os.path.join(temp_dir, "models", MODEL_VERSION)
 
-
-print("Make sure you logged in to the huggingface cli.")
-
-all_files = huggingface_hub.list_repo_files(MODEL_VERSION)
-filtered_files = [f for f in all_files if not f.startswith("original/")]
-
-for filename in filtered_files:
-  huggingface_hub.hf_hub_download(
-      repo_id=MODEL_VERSION, filename=filename, local_dir=MODEL_CP_PATH
-  )
-print(f"Downloaded {filtered_files} to: {MODEL_CP_PATH}")
+all_files = tc.download_from_huggingface(repo_id=MODEL_VERSION, model_path=MODEL_CP_PATH)
 
 mesh = jax.make_mesh((1, len(jax.devices())), ("fsdp", "tp"))
 config = (
-    model.ModelConfig.llama3_1_8b()
+    model.ModelConfig.llama3_2_1b()
 )  # pick corresponding config based on model version
 llama3 = params.create_model_from_safe_tensors(MODEL_CP_PATH, config, mesh)
 nnx.display(llama3)
@@ -54,40 +45,17 @@ tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_CP_PATH)
 tokenizer.pad_token_id = 0
 
 
-def templatize(prompts):
-  """Apply chat template to the prompts using the tokenizer.
-
-  Args:
-    prompts: A list of prompts.
-
-  Returns:
-    A list of templated prompts.
-  """
-  outputs = []
-  for p in prompts:
-    outputs.append(
-        tokenizer.apply_chat_template(
-            [
-                {"role": "user", "content": p},
-            ],
-            tokenize=False,
-            add_generation_prompt=True,
-        )
-    )
-  return outputs
-
-
-inputs = templatize([
+inputs = tc.batch_templatize([
     "tell me about world war 2",
     "印度的首都在哪里",
     "tell me your name, respond in Chinese",
-])
+], tokenizer)
 
 sampler = sampler.Sampler(
     llama3,
     tokenizer,
     sampler.CacheConfig(
-        cache_size=256, num_layers=32, num_kv_heads=8, head_dim=128
+        cache_size=256, num_layers=config.num_layers, num_kv_heads=config.num_kv_heads, head_dim=config.head_dim
     ),
 )
 out = sampler(inputs, max_generation_steps=128, echo=True, top_p=None)


### PR DESCRIPTION
Use vLLM tests as example for other backend to integration with Tunix. This PR does the following:
1. Clean up the vllm sampler test
2. Move common logics to test_common.py and modified the tests that use the same util function.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
