### PR TITLE
Refactor the weight mapping config

### DIFF
--- a/tests/generate/mappings_config_test.py
+++ b/tests/generate/mappings_config_test.py
@@ -1,0 +1,86 @@
+"""Tests for tunix.generate.mappings.MappingConfig utilities."""
+
+from absl.testing import absltest
+
+from tunix.generate import mappings
+from tunix.models.llama3 import model as model_lib
+from flax import nnx
+
+class MappingConfigTest(absltest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    rng = nnx.Rngs(params=0)
+    cls.model = model_lib.Llama3(model_lib.ModelConfig.llama3_2_1b(), rngs=rng)
+
+  def test_from_object_with_none_errors_out(self):
+    with self.assertRaisesRegex(
+        AssertionError,
+        "Either mapping_obj or model must be provided"
+    ):
+      cfg = mappings.MappingConfig.build()
+
+  def test_from_object_with_mapping_config_instance(self):
+    original = mappings.MappingConfig(
+        to_hf_mappings={'foo': ('bar', ('tp',))},
+        lora_to_hf_mappings={'lora': ('baz', ('fsdp',))},
+        to_hf_hook_fns={'foo': lambda x: x},
+        to_hf_transpose_keys={'foo': (1, 0)},
+    )
+    cfg = mappings.MappingConfig.build(original)
+    self.assertIs(cfg, original)
+
+  def test_from_object_with_dict_and_callables(self):
+    mapping_obj = {
+        'to_hf_mappings': lambda: {'a': ('b', ('tp',))},
+        'lora_to_hf_mappings': lambda: {'c': ('d', ('fsdp',))},
+        'to_hf_hook_fns': lambda: {'a': lambda x: x},
+        'to_hf_transpose_keys': lambda: {'embedding': (1, 0)},
+    }
+    cfg = mappings.MappingConfig.build(mapping_obj)
+    self.assertEqual(cfg.to_hf_mappings, {'a': ('b', ('tp',))})
+    self.assertEqual(cfg.lora_to_hf_mappings, {'c': ('d', ('fsdp',))})
+    self.assertEqual(
+        cfg.to_hf_transpose_keys,
+        {'embedding': (1, 0)},
+    )
+    self.assertIn('a', cfg.to_hf_hook_fns)
+
+  def test_build_mapping_config_with_model_only(self):
+    cfg = mappings.MappingConfig.build(self.model)
+    self.assertTrue(
+        cfg.to_hf_mappings['embedder.input_embedding'],
+        (
+          'model.embed.embedding',
+          ('model', None),
+        )
+    )
+
+    self.assertTrue(
+        cfg.lora_to_hf_mappings['layers.*.mlp.gate_proj.kernel_lora_a'],
+        (
+          'model.layers.*.mlp.gate_proj.kernel_lora_a',
+          (None, None),
+        )
+    )
+
+    self.assertEqual(cfg.to_hf_transpose_keys, {'embedding': (1, 0)},)
+
+
+  def test_build_mapping_config_with_overrides(self):
+    override = {'embedder.input_embedding': (
+          'fake.path.embedding',
+          ('fake_dim', None),
+      )}
+    cfg = mappings.MappingConfig.build(
+        {"to_hf_mappings":override,
+        "to_hf_hook_fns":{'override': lambda x: x},
+        }
+    )
+    self.assertEqual(cfg.to_hf_mappings, override)
+    self.assertIn('override', cfg.to_hf_hook_fns)
+    self.assertTrue(callable(cfg.to_hf_hook_fns['override']))
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -23,6 +23,7 @@ import qwix
 import transformers
 from tunix.generate import sampler as vanilla_sampler
 from tunix.generate import vllm_sampler
+from tunix.generate import mappings
 from tunix.models.llama3 import model as llama_lib
 from tunix.models.llama3 import params as llama_params
 from tunix.tests import test_common as tc
@@ -51,9 +52,7 @@ class VllmSamplerTest(absltest.TestCase):
     # TODO(b/432096319): Enable after LoRA support in vLLM
     cls.enable_lora = False
 
-  def load_llama3_model(
-      self, model_version: str, enable_lora: bool = False
-  ):
+  def load_llama3_model(self, model_version: str, enable_lora: bool = False):
     model_config = {
         "meta-llama/Llama-3.2-1B-Instruct": llama_lib.ModelConfig.llama3_2_1b,
         "meta-llama/Llama-3.1-8B-Instruct": llama_lib.ModelConfig.llama3_1_8b,
@@ -67,7 +66,13 @@ class VllmSamplerTest(absltest.TestCase):
         self.model_path, model_config, self.mesh
     )
     if enable_lora:
-      llama3 = tc.get_lora_model(llama3, model_path=".*q_proj|.*k_proj|.*v_proj|.*o_proj|.*gate_proj|.*down_proj|.*up_proj", rank=64, alpha=64.0, mesh=self.mesh)
+      llama3 = tc.get_lora_model(
+          llama3,
+          model_path=".*q_proj|.*k_proj|.*v_proj|.*o_proj|.*gate_proj|.*down_proj|.*up_proj",
+          rank=64,
+          alpha=64.0,
+          mesh=self.mesh,
+      )
       print(f"Loaded LoRA model: {model_version} with LoRA enabled")
     # nnx.display(llama3)
     return llama3, model_config
@@ -85,9 +90,7 @@ class VllmSamplerTest(absltest.TestCase):
       args["additional_config"]["lora_config"] = {
           "rank": 64,
           "alpha": 64.0,
-          "module_path": (
-              ".*q_proj|.*k_proj|.*v_proj|.*o_proj|.*gate_proj|.*down_proj|.*up_proj"
-          ),
+          "module_path": ".*q_proj|.*k_proj|.*v_proj|.*o_proj|.*gate_proj|.*down_proj|.*up_proj",
           # "dropout": 0.0,
           # "bias": "none",
       }
@@ -112,7 +115,10 @@ class VllmSamplerTest(absltest.TestCase):
         transformer=tunix_model,
         tokenizer=model_tokenizer,
         cache_config=vanilla_sampler.CacheConfig(
-            cache_size=512, num_layers=model_config.num_layers, num_kv_heads=model_config.num_kv_heads, head_dim=model_config.head_dim
+            cache_size=512,
+            num_layers=model_config.num_layers,
+            num_kv_heads=model_config.num_kv_heads,
+            head_dim=model_config.head_dim,
         ),
     )
     vanilla_output = vn_sampler(
@@ -127,6 +133,8 @@ class VllmSamplerTest(absltest.TestCase):
         pad_output=True,  # Use padding for output
     )
 
+    mapping_config = mappings.MappingConfig.build(tunix_model)
+
     vllm_config = vllm_sampler.VllmConfig(
         model_version=self.model_path,
         max_model_len=512,
@@ -134,13 +142,8 @@ class VllmSamplerTest(absltest.TestCase):
         hbm_utilization=0.2,
         init_with_random_weights=True,
         tpu_backend_type="jax",
-        mapping_config=vllm_sampler.MappingConfig(
-            to_hf_mappings=tunix_model.to_hf_mappings(),
-            to_hf_transpose_keys=tunix_model.to_hf_transpose_keys(),
-            lora_to_hf_mappings=tunix_model.lora_to_hf_mappings(),
-            lora_config=args["additional_config"]["lora_config"],
-            to_hf_hook_fns=None,
-        ),
+        mapping_config=mapping_config,
+        lora_config=args["additional_config"]["lora_config"],
     )
 
     vl_sampler = vllm_sampler.VllmSampler(
@@ -173,8 +176,7 @@ class VllmSamplerTest(absltest.TestCase):
     print("-" * 50)
     print(f"Vanilla Generated text: {vanilla_output.text}")
 
-
-    tc.validate_llm_outputs(expected_output_pattern,vanilla_output.text)
+    tc.validate_llm_outputs(expected_output_pattern, vanilla_output.text)
 
     print("-" * 50)
     print(f"vLLM Generated text: {vllm_output.text}")
@@ -198,6 +200,7 @@ class VllmSamplerTest(absltest.TestCase):
               vllm_state["model"]["embed"]["embedding"].value,
           )
       )
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tunix/generate/mappings.py
+++ b/tunix/generate/mappings.py
@@ -1,0 +1,146 @@
+"""Shared helpers and dataclasses for model weight mappings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+from typing import Any, Dict, Optional, Tuple
+
+
+class BackendMappingMixin:
+  """Provides helper methods to retrieve backend-specific weight mappings."""
+
+  DEFAULT_BACKEND = 'vllm_jax'
+
+  @classmethod
+  def _backend_registry(cls) -> Dict[str, Any]:
+    module = cls.__module__
+    package_name = module.rsplit('.', 1)[0] if '.' in module else module
+    package = importlib.import_module(package_name)
+    return getattr(package, 'BACKEND_MAPPINGS', {})
+
+  @classmethod
+  def mapping_for(cls, backend: str | None = None) -> Dict[str, Any]:
+    backend = backend or cls.DEFAULT_BACKEND
+    registry = cls._backend_registry()
+    if backend not in registry:
+      raise RuntimeError(
+          f'{backend} mappings not available for {cls.__name__}.'
+      )
+    return registry[backend]
+
+  @classmethod
+  def to_hf_mappings(cls, backend: str | None = None):
+    mapping = cls.mapping_for(backend).get('to_hf_mappings')
+    if mapping is None:
+      raise RuntimeError(
+          f'{backend} to_hf_mappings missing for {cls.__name__}.'
+      )
+    return mapping
+
+  @classmethod
+  def lora_to_hf_mappings(cls, backend: str | None = None):
+    return cls.mapping_for(backend).get('lora_to_hf_mappings')
+
+  @classmethod
+  def to_hf_transpose_keys(cls, backend: str | None = None):
+    result = cls.mapping_for(backend).get('to_hf_transpose_keys')
+    return result or None
+
+  @classmethod
+  def to_hf_hook_fns(cls, backend: str | None = None):
+    return cls.mapping_for(backend).get('to_hf_hook_fns')
+
+
+@dataclass
+class MappingConfig:
+  """The key mapping config beteen actor and rollout models."""
+
+  to_hf_mappings: Optional[Dict[str, Any]] = None
+  lora_to_hf_mappings: Optional[Dict[str, Any]] = None
+  to_hf_hook_fns: Optional[Dict[str, Any]] = None
+  to_hf_transpose_keys: Optional[Dict[str, Tuple[int, ...]]] = None
+
+  @classmethod
+  def build(
+      cls,
+      mapping_obj: Any | None = None,
+      model: Any | None = None,
+      backend: str | None = None,
+  ) -> 'MappingConfig':
+    """Build the MappingConfg from existing MappingConfig, Dict or other qualified datastructure, or load from model."""
+    assert (
+        mapping_obj is not None or model is not None
+    ), 'Either mapping_obj or model must be provided (both cannot be None)'
+
+    if isinstance(mapping_obj, cls):
+      return mapping_obj
+
+    if mapping_obj is None:
+      return cls.from_model(model, backend)
+
+    keys = (
+        'to_hf_mappings',
+        'lora_to_hf_mappings',
+        'to_hf_hook_fns',
+        'to_hf_transpose_keys',
+    )
+
+    values: Dict[str, Any] = {}
+    if isinstance(mapping_obj, dict):
+      values.update(mapping_obj)
+    else:
+      for key in keys:
+        if hasattr(mapping_obj, key):
+          values[key] = getattr(mapping_obj, key)
+
+    resolved: Dict[str, Any] = {}
+    for key in keys:
+      value = values.get(key)
+      if callable(value):
+        try:
+          value = value()
+        except TypeError:
+          resolved[key] = value
+          continue
+      resolved[key] = value
+
+    return cls(
+        to_hf_mappings=resolved.get('to_hf_mappings'),
+        lora_to_hf_mappings=resolved.get('lora_to_hf_mappings'),
+        to_hf_hook_fns=resolved.get('to_hf_hook_fns'),
+        to_hf_transpose_keys=resolved.get('to_hf_transpose_keys'),
+    )
+
+  @classmethod
+  def from_model(
+      cls,
+      model: Any,
+      backend: str = 'vllm_jax',
+      **overrides: Any,
+  ) -> MappingConfig:
+    """Constructs a MappingConfig for the given model and backend."""
+
+    def maybe_call(attr: str):
+      value = getattr(model, attr, None)
+      if value is None:
+        return None
+      if callable(value):
+        try:
+          return value(backend)
+        except TypeError:
+          return value()
+      return value
+
+    config = MappingConfig(
+        to_hf_mappings=maybe_call('to_hf_mappings'),
+        lora_to_hf_mappings=maybe_call('lora_to_hf_mappings'),
+        to_hf_hook_fns=maybe_call('to_hf_hook_fns'),
+        to_hf_transpose_keys=maybe_call('to_hf_transpose_keys'),
+    )
+
+    for key, value in overrides.items():
+      if hasattr(config, key):
+        setattr(config, key, value)
+
+    return config

--- a/tunix/models/llama3/__init__.py
+++ b/tunix/models/llama3/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Llama3 API."""
+
+from tunix.models.llama3 import mapping_vllm_jax
+from tunix.models.llama3 import model
+from tunix.models.llama3 import params
+
+BACKEND_MAPPINGS = {
+    'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
+}
+
+
+__all__ = ['BACKEND_MAPPINGS', 'model', 'params']

--- a/tunix/models/llama3/mapping_vllm_jax.py
+++ b/tunix/models/llama3/mapping_vllm_jax.py
@@ -1,0 +1,249 @@
+"""Mappings for converting Llama3 weights to the vLLM JAX backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Tuple
+
+Sharding = Tuple[str | None, ...]
+MappingEntry = Tuple[str, Sharding]
+
+
+def _to_hf_mappings() -> Dict[str, MappingEntry]:
+  """The parameter key mapping between Tunix vanilla model and vLLM Jax backend"""
+  if os.environ.get('NEW_MODEL_DESIGN') == 'True':
+    return {
+        'lm_head.w': ('lm_head.input_embedding_table_DV', (None, 'model')),
+        'embedder.input_embedding': (
+            'embedder.input_embedding_table_VD',
+            ('model', None),
+        ),
+        'layers.*.input_layernorm.w': (
+            'layers.*.pre_attention_norm.scale',
+            (None,),
+        ),
+        'layers.*.mlp.down_proj.kernel': (
+            'layers.*.mlp.kernel_down_proj_FD',
+            ('model', None),
+        ),
+        'layers.*.mlp.gate_proj.kernel': (
+            'layers.*.mlp.kernel_gating_DF',
+            (None, 'model'),
+        ),
+        'layers.*.mlp.up_proj.kernel': (
+            'layers.*.mlp.kernel_up_proj_DF',
+            (None, 'model'),
+        ),
+        'layers.*.post_attention_layernorm.w': (
+            'layers.*.pre_mlp_norm.scale',
+            (None,),
+        ),
+        'layers.*.attn.k_proj.w': (
+            'layers.*.attn.kernel_k_proj_DKH',
+            (None, 'model', None),
+        ),
+        'layers.*.attn.o_proj.w': (
+            'layers.*.attn.kernel_o_proj_NHD',
+            ('model', None, None),
+        ),
+        'layers.*.attn.q_proj.w': (
+            'layers.*.attn.kernel_q_proj_DNH',
+            (None, 'model', None),
+        ),
+        'layers.*.attn.v_proj.w': (
+            'layers.*.attn.kernel_v_proj_DKH',
+            (None, 'model', None),
+        ),
+        'final_norm.w': ('final_norm.scale', (None,)),
+    }
+
+  return {
+      'lm_head.w': ('model.lm_head', (None, 'model')),
+      'embedder.input_embedding': (
+          'model.embed.embedding',
+          ('model', None),
+      ),
+      'layers.*.input_layernorm.w': (
+          'model.layers.*.input_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.mlp.down_proj.kernel': (
+          'model.layers.*.mlp.down_proj.kernel',
+          ('model', None),
+      ),
+      'layers.*.mlp.gate_proj.kernel': (
+          'model.layers.*.mlp.gate_proj.kernel',
+          (None, 'model'),
+      ),
+      'layers.*.mlp.up_proj.kernel': (
+          'model.layers.*.mlp.up_proj.kernel',
+          (None, 'model'),
+      ),
+      'layers.*.post_attention_layernorm.w': (
+          'model.layers.*.post_attention_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.attn.k_proj.w': (
+          'model.layers.*.self_attn.k_proj.kernel',
+          (None, 'model', None),
+      ),
+      'layers.*.attn.o_proj.w': (
+          'model.layers.*.self_attn.o_proj.kernel',
+          ('model', None, None),
+      ),
+      'layers.*.attn.q_proj.w': (
+          'model.layers.*.self_attn.q_proj.kernel',
+          (None, 'model', None),
+      ),
+      'layers.*.attn.v_proj.w': (
+          'model.layers.*.self_attn.v_proj.kernel',
+          (None, 'model', None),
+      ),
+      'final_norm.w': ('model.norm.scale', (None,)),
+  }
+
+
+def _lora_to_hf_mappings() -> Dict[str, MappingEntry] | None:
+  """The lora parameter key mapping between Tunix vanilla model and vLLM Jax backend"""
+  if os.environ.get('NEW_MODEL_DESIGN') == 'True':
+    return {
+        'layers.*.mlp.gate_proj.kernel_lora_a': (
+            'layers.*.mlp.kernel_gating_DF_lora_a',
+            (None, None),
+        ),
+        'layers.*.mlp.gate_proj.kernel_lora_b': (
+            'layers.*.mlp.kernel_gating_DF_lora_b',
+            (None, 'model'),
+        ),
+        'layers.*.mlp.up_proj.kernel_lora_a': (
+            'layers.*.mlp.kernel_up_proj_DF_lora_a',
+            (None, None),
+        ),
+        'layers.*.mlp.up_proj.kernel_lora_b': (
+            'layers.*.mlp.kernel_up_proj_DF_lora_b',
+            (None, 'model'),
+        ),
+        'layers.*.mlp.down_proj.kernel_lora_a': (
+            'layers.*.mlp.kernel_down_proj_FD_lora_a',
+            ('model', None),
+        ),
+        'layers.*.mlp.down_proj.kernel_lora_b': (
+            'layers.*.mlp.kernel_down_proj_FD_lora_b',
+            (None, None),
+        ),
+        'layers.*.attn.q_proj.w_lora_a': (
+            'layers.*.attn.kernel_q_proj_DNH_lora_a',
+            ('model', None),
+        ),
+        'layers.*.attn.q_proj.w_lora_b': (
+            'layers.*.attn.kernel_q_proj_DNH_lora_b',
+            (None, None),
+        ),
+        'layers.*.attn.k_proj.w_lora_a': (
+            'layers.*.attn.kernel_k_proj_DKH_lora_a',
+            ('model', None),
+        ),
+        'layers.*.attn.k_proj.w_lora_b': (
+            'layers.*.attn.kernel_k_proj_DKH_lora_b',
+            (None, None),
+        ),
+        'layers.*.attn.v_proj.w_lora_a': (
+            'layers.*.attn.kernel_v_proj_DKH_lora_a',
+            ('model', None),
+        ),
+        'layers.*.attn.v_proj.w_lora_b': (
+            'layers.*.attn.kernel_k_proj_DKH_lora_b',
+            (None, None),
+        ),
+        'layers.*.attn.o_proj.w_lora_a': (
+            'layers.*.attn.kernel_o_proj_NHD_lora_a',
+            ('model', None),
+        ),
+        'layers.*.attn.o_proj.w_lora_b': (
+            'layers.*.attn.kernel_o_proj_NHD_lora_b',
+            (None, None),
+        ),
+    }
+
+  return {
+      'layers.*.mlp.gate_proj.kernel_lora_a': (
+          'model.layers.*.mlp.gate_proj.kernel_lora_a',
+          (None, None),
+      ),
+      'layers.*.mlp.gate_proj.kernel_lora_b': (
+          'model.layers.*.mlp.gate_proj.kernel_lora_b',
+          (None, 'model'),
+      ),
+      'layers.*.mlp.up_proj.kernel_lora_a': (
+          'model.layers.*.mlp.up_proj.kernel_lora_a',
+          (None, None),
+      ),
+      'layers.*.mlp.up_proj.kernel_lora_b': (
+          'model.layers.*.mlp.up_proj.kernel_lora_b',
+          (None, 'model'),
+      ),
+      'layers.*.mlp.down_proj.kernel_lora_a': (
+          'model.layers.*.mlp.down_proj.kernel_lora_a',
+          ('model', None),
+      ),
+      'layers.*.mlp.down_proj.kernel_lora_b': (
+          'model.layers.*.mlp.down_proj.kernel_lora_b',
+          (None, None),
+      ),
+      'layers.*.attn.q_proj.w_lora_a': (
+          'model.layers.*.self_attn.q_proj.kernel_lora_a',
+          ('model', None),
+      ),
+      'layers.*.attn.q_proj.w_lora_b': (
+          'model.layers.*.self_attn.q_proj.kernel_lora_b',
+          (None, None),
+      ),
+      'layers.*.attn.k_proj.w_lora_a': (
+          'model.layers.*.self_attn.k_proj.kernel_lora_a',
+          ('model', None),
+      ),
+      'layers.*.attn.k_proj.w_lora_b': (
+          'model.layers.*.self_attn.k_proj.kernel_lora_b',
+          (None, None),
+      ),
+      'layers.*.attn.v_proj.w_lora_a': (
+          'model.layers.*.self_attn.v_proj.kernel_lora_a',
+          ('model', None),
+      ),
+      'layers.*.attn.v_proj.w_lora_b': (
+          'model.layers.*.self_attn.v_proj.kernel_lora_b',
+          (None, None),
+      ),
+      'layers.*.attn.o_proj.w_lora_a': (
+          'model.layers.*.self_attn.o_proj.kernel_lora_a',
+          ('model', None),
+      ),
+      'layers.*.attn.o_proj.w_lora_b': (
+          'model.layers.*.self_attn.o_proj.kernel_lora_b',
+          (None, None),
+      ),
+  }
+
+
+def _to_hf_transpose_keys() -> Dict[str, Tuple[int, int]] | None:
+  """The parameter key transposition mapping between Tunix vanilla model and vLLM Jax backend"""
+  return {
+      'embedding': (1, 0),
+  }
+
+
+def _to_hf_hook_fns() -> Dict[str, Any] | None:
+  """Additional parameter manipulation hook between Tunix vanilla model and vLLM Jax backend"""
+  return None
+
+
+VLLM_JAX_MAPPING: Dict[str, Any] = {
+    'to_hf_mappings': _to_hf_mappings(),
+    'lora_to_hf_mappings': _lora_to_hf_mappings(),
+    'to_hf_transpose_keys': _to_hf_transpose_keys(),
+    'to_hf_hook_fns': _to_hf_hook_fns(),
+}
+
+__all__ = [
+    'VLLM_JAX_MAPPING',
+]

--- a/tunix/models/llama3/model.py
+++ b/tunix/models/llama3/model.py
@@ -16,7 +16,6 @@
 
 import dataclasses
 import enum
-import os
 from typing import Tuple
 
 import flax
@@ -26,8 +25,8 @@ from jax import numpy as jnp
 from jax.interpreters import pxla
 import jax.sharding as shd
 import jaxtyping
+from tunix.generate.mappings import BackendMappingMixin
 from tunix.utils import container
-
 
 K_MASK = -2.3819763e38
 
@@ -298,6 +297,7 @@ class Attention(nnx.Module):
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array | None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
+    """Attention block."""
     seq_len = x.shape[1]
 
     query_proj = self.q_proj(x)
@@ -488,7 +488,7 @@ class DecoderLayer(nnx.Module):
     return cache, outputs
 
 
-class Llama3(nnx.Module):
+class Llama3(BackendMappingMixin, nnx.Module):
   """Llama3 model."""
 
   def __init__(
@@ -586,225 +586,3 @@ class Llama3(nnx.Module):
   @property
   def num_embed(self) -> int:
     return self.config.embed_dim
-
-  # For now, we are still passing sharding to vLLM, consider removing it after
-  # switching to the reshard API
-  @staticmethod
-  def to_hf_mappings():
-    if os.environ.get('NEW_MODEL_DESIGN') == 'True':
-      return {
-          'lm_head.w': ('lm_head.input_embedding_table_DV', (None, 'model')),
-          'embedder.input_embedding': (
-              'embedder.input_embedding_table_VD',
-              ('model', None),
-          ),
-          'layers.*.input_layernorm.w': (
-              'layers.*.pre_attention_norm.scale',
-              (None,),
-          ),
-          'layers.*.mlp.down_proj.kernel': (
-              'layers.*.mlp.kernel_down_proj_FD',
-              ('model', None),
-          ),
-          'layers.*.mlp.gate_proj.kernel': (
-              'layers.*.mlp.kernel_gating_DF',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.up_proj.kernel': (
-              'layers.*.mlp.kernel_up_proj_DF',
-              (None, 'model'),
-          ),
-          'layers.*.post_attention_layernorm.w': (
-              'layers.*.pre_mlp_norm.scale',
-              (None,),
-          ),
-          'layers.*.attn.k_proj.w': (
-              'layers.*.attn.kernel_k_proj_DKH',
-              (None, 'model', None),
-          ),
-          'layers.*.attn.o_proj.w': (
-              'layers.*.attn.kernel_o_proj_NHD',
-              ('model', None, None),
-          ),
-          'layers.*.attn.q_proj.w': (
-              'layers.*.attn.kernel_q_proj_DNH',
-              (None, 'model', None),
-          ),
-          'layers.*.attn.v_proj.w': (
-              'layers.*.attn.kernel_v_proj_DKH',
-              (None, 'model', None),
-          ),
-          'final_norm.w': ('final_norm.scale', (None,)),
-      }
-    else:
-      return {
-          'lm_head.w': ('model.lm_head', (None, 'model')),
-          'embedder.input_embedding': (
-              'model.embed.embedding',
-              ('model', None),
-          ),
-          'layers.*.input_layernorm.w': (
-              'model.layers.*.input_layernorm.scale',
-              (None,),
-          ),
-          'layers.*.mlp.down_proj.kernel': (
-              'model.layers.*.mlp.down_proj.kernel',
-              ('model', None),
-          ),
-          'layers.*.mlp.gate_proj.kernel': (
-              'model.layers.*.mlp.gate_proj.kernel',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.up_proj.kernel': (
-              'model.layers.*.mlp.up_proj.kernel',
-              (None, 'model'),
-          ),
-          'layers.*.post_attention_layernorm.w': (
-              'model.layers.*.post_attention_layernorm.scale',
-              (None,),
-          ),
-          'layers.*.attn.k_proj.w': (
-              'model.layers.*.self_attn.k_proj.kernel',
-              (None, 'model', None),
-          ),
-          'layers.*.attn.o_proj.w': (
-              'model.layers.*.self_attn.o_proj.kernel',
-              ('model', None, None),
-          ),
-          'layers.*.attn.q_proj.w': (
-              'model.layers.*.self_attn.q_proj.kernel',
-              (None, 'model', None),
-          ),
-          'layers.*.attn.v_proj.w': (
-              'model.layers.*.self_attn.v_proj.kernel',
-              (None, 'model', None),
-          ),
-          'final_norm.w': ('model.norm.scale', (None,)),
-      }
-
-  @staticmethod
-  def lora_to_hf_mappings():
-    if os.environ.get('NEW_MODEL_DESIGN') == 'True':
-      return {
-          'layers.*.mlp.gate_proj.kernel_lora_a': (
-              'layers.*.mlp.kernel_gating_DF_lora_a',
-              (None, None),
-          ),
-          'layers.*.mlp.gate_proj.kernel_lora_b': (
-              'layers.*.mlp.kernel_gating_DF_lora_b',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.up_proj.kernel_lora_a': (
-              'layers.*.mlp.kernel_up_proj_DF_lora_a',
-              (None, None),
-          ),
-          'layers.*.mlp.up_proj.kernel_lora_b': (
-              'layers.*.mlp.kernel_up_proj_DF_lora_b',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.down_proj.kernel_lora_a': (
-              'layers.*.mlp.kernel_down_proj_FD_lora_a',
-              ('model', None),
-          ),
-          'layers.*.mlp.down_proj.kernel_lora_b': (
-              'layers.*.mlp.kernel_down_proj_FD_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.q_proj.w_lora_a': (
-              'layers.*.attn.kernel_q_proj_DNH_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.q_proj.w_lora_b': (
-              'layers.*.attn.kernel_q_proj_DNH_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.k_proj.w_lora_a': (
-              'layers.*.attn.kernel_k_proj_DKH_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.k_proj.w_lora_b': (
-              'layers.*.attn.kernel_k_proj_DKH_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.v_proj.w_lora_a': (
-              'layers.*.attn.kernel_v_proj_DKH_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.v_proj.w_lora_b': (
-              'layers.*.attn.kernel_v_proj_DKH_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.o_proj.w_lora_a': (
-              'layers.*.attn.kernel_o_proj_NHD_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.o_proj.w_lora_b': (
-              'layers.*.attn.kernel_o_proj_NHD_lora_b',
-              (None, None),
-          ),
-      }
-    else:
-      return {
-          'layers.*.mlp.gate_proj.kernel_lora_a': (
-              'model.layers.*.mlp.gate_proj.kernel_lora_a',
-              (None, None),
-          ),
-          'layers.*.mlp.gate_proj.kernel_lora_b': (
-              'model.layers.*.mlp.gate_proj.kernel_lora_b',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.up_proj.kernel_lora_a': (
-              'model.layers.*.mlp.up_proj.kernel_lora_a',
-              (None, None),
-          ),
-          'layers.*.mlp.up_proj.kernel_lora_b': (
-              'model.layers.*.mlp.up_proj.kernel_lora_b',
-              (None, 'model'),
-          ),
-          'layers.*.mlp.down_proj.kernel_lora_a': (
-              'model.layers.*.mlp.down_proj.kernel_lora_a',
-              ('model', None),
-          ),
-          'layers.*.mlp.down_proj.kernel_lora_b': (
-              'model.layers.*.mlp.down_proj.kernel_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.q_proj.w_lora_a': (
-              'layers.*.self_attn.q_proj.kernel_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.q_proj.w_lora_b': (
-              'layers.*.self_attn.q_proj.kernel_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.k_proj.w_lora_a': (
-              'layers.*.self_attn.k_proj.kernel_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.k_proj.w_lora_b': (
-              'layers.*.self_attn.k_proj.kernel_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.v_proj.w_lora_a': (
-              'layers.*.self_attn.v_proj.kernel_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.v_proj.w_lora_b': (
-              'layers.*.self_attn.v_proj.kernel_lora_b',
-              (None, None),
-          ),
-          'layers.*.attn.o_proj.w_lora_a': (
-              'layers.*.self_attn.o_proj.kernel_lora_a',
-              ('model', None),
-          ),
-          'layers.*.attn.o_proj.w_lora_b': (
-              'layers.*.self_attn.o_proj.kernel_lora_b',
-              (None, None),
-          ),
-      }
-
-  @staticmethod
-  def to_hf_transpose_keys():
-    return {
-        'embedding': (1, 0),
-    }

--- a/tunix/models/qwen2/__init__.py
+++ b/tunix/models/qwen2/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen2 API."""
+
+from tunix.models.qwen2 import mapping_vllm_jax
+from tunix.models.qwen2 import model
+from tunix.models.qwen2 import params
+
+BACKEND_MAPPINGS = {
+    'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
+}
+
+
+__all__ = ['BACKEND_MAPPINGS', 'model', 'params']

--- a/tunix/models/qwen2/mapping_vllm_jax.py
+++ b/tunix/models/qwen2/mapping_vllm_jax.py
@@ -1,0 +1,173 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM JAX backend mappings for Qwen2 models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+Sharding = Tuple[str | None, ...]
+MappingEntry = Tuple[str, Sharding]
+
+
+TO_HF_MAPPINGS: Dict[str, MappingEntry] = {
+    'embedder.input_embedding': ('embed.embedding', ('model', None)),
+    'layers.*.input_layernorm.w': (
+        'model.layers.*.input_layernorm.scale',
+        (None,),
+    ),
+    'layers.*.mlp.down_proj.kernel': (
+        'model.layers.*.mlp.down_proj.kernel',
+        ('model', None),
+    ),
+    'layers.*.mlp.gate_proj.kernel': (
+        'model.layers.*.mlp.gate_proj.kernel',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.up_proj.kernel': (
+        'model.layers.*.mlp.up_proj.kernel',
+        (None, 'model'),
+    ),
+    'layers.*.post_attention_layernorm.w': (
+        'model.layers.*.post_attention_layernorm.scale',
+        (None,),
+    ),
+    'layers.*.attn.k_proj.w': (
+        'model.layers.*.self_attn.k_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.o_proj.w': (
+        'model.layers.*.self_attn.o_proj.kernel',
+        ('model', None, None),
+    ),
+    'layers.*.attn.q_proj.w': (
+        'model.layers.*.self_attn.q_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.v_proj.w': (
+        'model.layers.*.self_attn.v_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.q_bias': (
+        'model.layers.*.self_attn.q_proj.bias',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias': (
+        'model.layers.*.self_attn.k_proj.bias',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias': (
+        'model.layers.*.self_attn.v_proj.bias',
+        ('model', None),
+    ),
+    'final_norm.w': ('model.norm.scale', (None,)),
+    'lm_head.w': ('lm_head', (None, 'model')),
+}
+
+
+LORA_TO_HF_MAPPINGS: Dict[str, MappingEntry] = {
+    'layers.*.mlp.gate_proj.kernel_lora_a': (
+        'model.layers.*.mlp.gate_proj.kernel_lora_a',
+        (None, None),
+    ),
+    'layers.*.mlp.gate_proj.kernel_lora_b': (
+        'model.layers.*.mlp.gate_proj.kernel_lora_b',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.up_proj.kernel_lora_a': (
+        'model.layers.*.mlp.up_proj.kernel_lora_a',
+        (None, None),
+    ),
+    'layers.*.mlp.up_proj.kernel_lora_b': (
+        'model.layers.*.mlp.up_proj.kernel_lora_b',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.down_proj.kernel_lora_a': (
+        'model.layers.*.mlp.down_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.mlp.down_proj.kernel_lora_b': (
+        'model.layers.*.mlp.down_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.q_proj.w_lora_a': (
+        'layers.*.self_attn.q_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.q_proj.w_lora_b': (
+        'layers.*.self_attn.q_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.k_proj.w_lora_a': (
+        'layers.*.self_attn.k_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.k_proj.w_lora_b': (
+        'layers.*.self_attn.k_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.v_proj.w_lora_a': (
+        'layers.*.self_attn.v_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.v_proj.w_lora_b': (
+        'layers.*.self_attn.v_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.o_proj.w_lora_a': (
+        'layers.*.self_attn.o_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.o_proj.w_lora_b': (
+        'layers.*.self_attn.o_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.q_bias_lora_a': (
+        'model.layers.*.self_attn.q_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.q_bias_lora_b': (
+        'model.layers.*.self_attn.q_proj.bias_lora_b',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias_lora_a': (
+        'model.layers.*.self_attn.k_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias_lora_b': (
+        'model.layers.*.self_attn.k_proj.bias_lora_b',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias_lora_a': (
+        'model.layers.*.self_attn.v_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias_lora_b': (
+        'model.layers.*.self_attn.v_proj.bias_lora_b',
+        ('model', None),
+    ),
+}
+
+
+VLLM_JAX_MAPPING: Dict[str, Any] = {
+    'to_hf_mappings': TO_HF_MAPPINGS,
+    'lora_to_hf_mappings': LORA_TO_HF_MAPPINGS,
+    'to_hf_transpose_keys': {'embedding': (1, 0)},
+    'to_hf_hook_fns': None,
+}
+
+__all__ = [
+    'VLLM_JAX_MAPPING',
+]

--- a/tunix/models/qwen2/model.py
+++ b/tunix/models/qwen2/model.py
@@ -25,6 +25,7 @@ from jax import numpy as jnp
 from jax.interpreters import pxla
 import jax.sharding as shd
 import jaxtyping
+from tunix.generate.mappings import BackendMappingMixin
 from tunix.utils import container
 
 K_MASK = -2.3819763e38
@@ -336,6 +337,7 @@ class Attention(nnx.Module):
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array | None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
+    """Attention block."""
     seq_len = x.shape[1]
 
     query_proj = self.q_proj(x)
@@ -535,7 +537,7 @@ class DecoderLayer(nnx.Module):
     return cache, outputs
 
 
-class Qwen2(nnx.Module):
+class Qwen2(BackendMappingMixin, nnx.Module):
   """Qwen2.5 model."""
 
   def __init__(
@@ -637,151 +639,4 @@ class Qwen2(nnx.Module):
         'attention_mask': jnp.ones(
             (dummy_batch_size, 1, dummy_seq_len), dtype=jnp.bool
         ),
-    }
-
-  @staticmethod
-  def to_hf_mappings():
-    return {
-        'embedder.input_embedding': ('embed.embedding', ('model', None)),
-        'layers.*.input_layernorm.w': (
-            'model.layers.*.input_layernorm.scale',
-            (None,),
-        ),
-        'layers.*.mlp.down_proj.kernel': (
-            'model.layers.*.mlp.down_proj.kernel',
-            ('model', None),
-        ),
-        'layers.*.mlp.gate_proj.kernel': (
-            'model.layers.*.mlp.gate_proj.kernel',
-            (None, 'model'),
-        ),
-        'layers.*.mlp.up_proj.kernel': (
-            'model.layers.*.mlp.up_proj.kernel',
-            (None, 'model'),
-        ),
-        'layers.*.post_attention_layernorm.w': (
-            'model.layers.*.post_attention_layernorm.scale',
-            (None,),
-        ),
-        'layers.*.attn.k_proj.w': (
-            'model.layers.*.self_attn.k_proj.kernel',
-            (None, 'model', None),
-        ),
-        'layers.*.attn.o_proj.w': (
-            'model.layers.*.self_attn.o_proj.kernel',
-            ('model', None, None),
-        ),
-        'layers.*.attn.q_proj.w': (
-            'model.layers.*.self_attn.q_proj.kernel',
-            (None, 'model', None),
-        ),
-        'layers.*.attn.v_proj.w': (
-            'model.layers.*.self_attn.v_proj.kernel',
-            (None, 'model', None),
-        ),
-        'layers.*.attn.q_bias': (
-            'model.layers.*.self_attn.q_proj.bias',
-            ('model', None),
-        ),
-        'layers.*.attn.k_bias': (
-            'model.layers.*.self_attn.k_proj.bias',
-            ('model', None),
-        ),
-        'layers.*.attn.v_bias': (
-            'model.layers.*.self_attn.v_proj.bias',
-            ('model', None),
-        ),
-        'final_norm.w': ('model.norm.scale', (None,)),
-        'lm_head.w': ('lm_head', (None, 'model')),
-    }
-
-  @staticmethod
-  def lora_to_hf_mappings():
-    return {
-        'layers.*.mlp.gate_proj.kernel_lora_a': (
-            'model.layers.*.mlp.gate_proj.kernel_lora_a',
-            (None, None),
-        ),
-        'layers.*.mlp.gate_proj.kernel_lora_b': (
-            'model.layers.*.mlp.gate_proj.kernel_lora_b',
-            (None, 'model'),
-        ),
-        'layers.*.mlp.up_proj.kernel_lora_a': (
-            'model.layers.*.mlp.up_proj.kernel_lora_a',
-            (None, None),
-        ),
-        'layers.*.mlp.up_proj.kernel_lora_b': (
-            'model.layers.*.mlp.up_proj.kernel_lora_b',
-            (None, 'model'),
-        ),
-        'layers.*.mlp.down_proj.kernel_lora_a': (
-            'model.layers.*.mlp.down_proj.kernel_lora_a',
-            ('model', None),
-        ),
-        'layers.*.mlp.down_proj.kernel_lora_b': (
-            'model.layers.*.mlp.down_proj.kernel_lora_b',
-            (None, None),
-        ),
-        'layers.*.attn.q_proj.w_lora_a': (
-            'layers.*.self_attn.q_proj.kernel_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.q_proj.w_lora_b': (
-            'layers.*.self_attn.q_proj.kernel_lora_b',
-            (None, None),
-        ),
-        'layers.*.attn.k_proj.w_lora_a': (
-            'layers.*.self_attn.k_proj.kernel_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.k_proj.w_lora_b': (
-            'layers.*.self_attn.k_proj.kernel_lora_b',
-            (None, None),
-        ),
-        'layers.*.attn.v_proj.w_lora_a': (
-            'layers.*.self_attn.v_proj.kernel_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.v_proj.w_lora_b': (
-            'layers.*.self_attn.v_proj.kernel_lora_b',
-            (None, None),
-        ),
-        'layers.*.attn.o_proj.w_lora_a': (
-            'layers.*.self_attn.o_proj.kernel_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.o_proj.w_lora_b': (
-            'layers.*.self_attn.o_proj.kernel_lora_b',
-            (None, None),
-        ),
-        'layers.*.attn.q_bias_lora_a': (
-            'model.layers.*.self_attn.q_proj.bias_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.q_bias_lora_b': (
-            'model.layers.*.self_attn.q_proj.bias_lora_b',
-            ('model', None),
-        ),
-        'layers.*.attn.k_bias_lora_a': (
-            'model.layers.*.self_attn.k_proj.bias_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.k_bias_lora_b': (
-            'model.layers.*.self_attn.k_proj.bias_lora_b',
-            ('model', None),
-        ),
-        'layers.*.attn.v_bias_lora_a': (
-            'model.layers.*.self_attn.v_proj.bias_lora_a',
-            ('model', None),
-        ),
-        'layers.*.attn.v_bias_lora_b': (
-            'model.layers.*.self_attn.v_proj.bias_lora_b',
-            ('model', None),
-        ),
-    }
-
-  @staticmethod
-  def to_hf_transpose_keys():
-    return {
-        'embedding': (1, 0),
     }


### PR DESCRIPTION
<!--- Describe your changes in detail. -->
The current weight mapping lives in the model file. Consider we have more backends or more modes, the file size will grow much bigger. What's more important, the weight mapping should not sit in the model file directly, it's more of a extra feature we added to the model for RL.

This PR does the following:
1. Separates the mapping function to separate file outside of model.py. 
2. Use mixin to inject the API to the model, so ppl can still call llama3_model.to_hf_mapping like before.
3. Move lora config out of the mapping config, sitting directly in vllm config now. Mapping config is more for weight sync from actor to rollout model, but lora config is higly customizable and applies to rollout engine for initialization.
4. Move MappingConfig from vllm_sampler to a separate file, together with mixin setup. Consider we have more rollout engines such as SGLang, they should be able to use the same MappingConfig and Mixin class.
5. Provide the option for users to overwrite the mapping function from outside, e.g. MaxText.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
