### PR TITLE
Enable vLLM server mode

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -89,12 +89,13 @@ jobs:
         # tokenizer_adapter_test requires access to gated repo
         python -m pytest tests/generate/ -v --tb=short \
           --ignore=tests/generate/vllm_sampler_test.py \
+          --ignore=tests/generate/vllm_driver_test.py \
           --ignore=tests/generate/tokenizer_adapter_test.py
 
     - name: Run tunix SFT tests
       run: |
         python -m pytest tests/sft/ -v --tb=short
-    
+
     - name: Run tunix SFT integration tests
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -115,28 +116,28 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
       run: |
-        
+
         # Download GSM8K dataset
         mkdir -p /tmp/grpo_test/rl/grpo/data
         python3 -c "
         from datasets import load_dataset
         import json
-        
+
         # Download and save GSM8K train split
         dataset = load_dataset('openai/gsm8k', 'main', split='train')
         train_data = [{'question': item['question'], 'answer': item['answer']} for item in dataset]
         with open('/tmp/grpo_test/rl/grpo/data/gsm8k_train.json', 'w') as f:
             json.dump(train_data, f)
-        
+
         # Download and save GSM8K test split
         dataset = load_dataset('openai/gsm8k', 'main', split='test')
         test_data = [{'question': item['question'], 'answer': item['answer']} for item in dataset]
         with open('/tmp/grpo_test/rl/grpo/data/gsm8k_test.json', 'w') as f:
             json.dump(test_data, f)
-        
+
         print('GSM8K dataset downloaded successfully')
         "
-        
+
         # Run GRPO demo script with minimal configuration
         python3 scripts/grpo_demo_llama3_qwen2.py \
           --root-dir=/tmp/grpo_test \

--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -105,6 +105,13 @@ parser.add_argument(
     required=False,
     help="Rollout engine to use (vanilla or vllm).",
 )
+parser.add_argument(
+    "--rollout-server-mode",
+    type=bool,
+    default=False,
+    required=False,
+    help="Rollout engine server model.",
+)
 
 # Parse arguments
 args = parser.parse_args()
@@ -796,6 +803,7 @@ cluster_config = rl_cluster_lib.ClusterConfig(
     rollout_vllm_model_version=VLLM_MODEL_VERSION,
     rollout_vllm_hbm_utilization=0.2,
     rollout_vllm_tpu_backend_type="jax",
+    rollout_vllm_server_mode=args.rollout_server_mode,
 )
 
 grpo_config = grpo_learner.GRPOConfig(

--- a/tests/generate/vllm_driver_test.py
+++ b/tests/generate/vllm_driver_test.py
@@ -1,0 +1,138 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import threading
+import time
+from typing import Iterable
+
+from absl.testing import absltest
+
+from tunix.generate.vllm_driver import VLLMInProcessDriver
+
+
+class _DummyCompletionOutput:
+
+  def __init__(self, request_id: str):
+    self.token_ids = [request_id]
+    self.logprobs = [0.0]
+    self.text = f"response_for_{request_id}"
+
+
+class _DummyRequestOutput:
+
+  def __init__(self, request_id: str):
+    self.request_id = request_id
+    self.prompt = None
+    self.prompt_token_ids = [request_id]
+    self.prompt_logprobs = None
+    self.outputs = [_DummyCompletionOutput(request_id)]
+    self.finished = True
+    self.kv_transfer_params = None
+    self.num_cached_tokens = 0
+    self.metrics = None
+
+
+class _StubEngineCore:
+
+  def shutdown(self):
+    pass
+
+
+class _FakeLLMEngine:
+  """Minimal synchronous engine that emits completions in a fixed order."""
+
+  def __init__(self, completion_order: Iterable[str]):
+    self._completion_order = list(completion_order)
+    self._pending: list[str] = []
+    self._lock = threading.Lock()
+    self.engine_core = _StubEngineCore()
+
+  # The driver only exercises a subset of the LLMEngine surface.
+  def add_request(self, request_id: str, *_, **__):
+    with self._lock:
+      self._pending.append(request_id)
+
+  def has_unfinished_requests(self) -> bool:
+    with self._lock:
+      return bool(self._pending)
+
+  def step(self):
+    with self._lock:
+      if not self._completion_order or not self._pending:
+        return []
+
+      next_request = self._completion_order[0]
+      if next_request not in self._pending:
+        # Wait for the next request in the completion order to arrive.
+        time.sleep(0.001)
+        return []
+
+      self._completion_order.pop(0)
+      self._pending.remove(next_request)
+
+    return [_DummyRequestOutput(next_request)]
+
+  def abort_request(self, *_args, **_kwargs):
+    pass
+
+
+class VllmDriverAsyncTest(absltest.TestCase):
+
+  def test_out_of_order_completions_preserved(self):
+    request_ids = [f"req-{i}" for i in range(10)]
+    completion_order = [
+        "req-0",
+        "req-3",
+        "req-1",
+        "req-7",
+        "req-2",
+        "req-9",
+        "req-4",
+        "req-6",
+        "req-5",
+        "req-8",
+    ]
+
+    engine = _FakeLLMEngine(completion_order)
+    driver = VLLMInProcessDriver(llm_engine=engine, auto_start=True)
+    self.addCleanup(driver.shutdown)
+
+    finished_order: list[str] = []
+    futures = []
+    for request_id in request_ids:
+      future = driver.submit_request(
+          request_id=request_id,
+          prompt={"prompt_token_ids": [1]},
+          params=object(),
+      )
+      future.add_done_callback(
+          lambda f: finished_order.append(f.result().request_id)
+      )
+      futures.append(future)
+
+    results = [future.result(timeout=5.0) for future in futures]
+
+    # Ensure all requests completed.
+    self.assertCountEqual(
+        [res.request_id for res in results],
+        request_ids,
+    )
+
+    # All completions should be observed, but not necessarily in submit order.
+    self.assertEqual(finished_order, completion_order)
+    self.assertNotEqual(finished_order, request_ids)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -12,9 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import concurrent.futures
 import os
 import re
+import socket
 import tempfile
+import threading
+import time
+from unittest import mock
 from absl.testing import absltest
 from flax import nnx
 import jax
@@ -26,6 +31,8 @@ from tunix.generate import vllm_sampler
 from tunix.generate import mappings
 from tunix.models.llama3 import model as llama_lib
 from tunix.models.llama3 import params as llama_params
+from vllm.inputs import TokensPrompt
+from vllm.sampling_params import SamplingParams
 from tunix.tests import test_common as tc
 from tunix.sft import utils as base_utils
 
@@ -39,10 +46,6 @@ class VllmSamplerTest(absltest.TestCase):
   @classmethod
   def setUpClass(cls) -> None:
     super().setUpClass()
-    mesh_shape = (1, len(jax.devices()))  # e.g., (1, 8) for v2-8
-    axis_names = ("fsdp", "tp")
-    cls.mesh = jax.make_mesh(mesh_shape, axis_names, devices=jax.devices())
-
     cls.repo_id = "meta-llama/Llama-3.2-1B-Instruct"
     temp_dir = tempfile.gettempdir()
     cls.model_path = os.path.join(temp_dir, "models", cls.repo_id)
@@ -51,6 +54,10 @@ class VllmSamplerTest(absltest.TestCase):
 
     # TODO(b/432096319): Enable after LoRA support in vLLM
     cls.enable_lora = False
+
+    mesh_shape = (1, len(jax.devices()))  # e.g., (1, 8) for v2-8
+    axis_names = ("fsdp", "tp")
+    cls.mesh = jax.make_mesh(mesh_shape, axis_names, devices=jax.devices())
 
   def load_llama3_model(self, model_version: str, enable_lora: bool = False):
     model_config = {
@@ -77,9 +84,22 @@ class VllmSamplerTest(absltest.TestCase):
     # nnx.display(llama3)
     return llama3, model_config
 
-  def test_vllm_sampler(self):
+  # Parametized test always fails on vLLM HBM usage exceeding limit, no matter how much HBM we allocated to it, and no matter how we clear the Jax cache (delete all the live arrays, gc collect, clear cache, clear test cache). vLLM will allocate all the assigned HBM to weights + KV cache. The conclusion is parametized test doesn't reset Jax properly, therefore the 2nd test adds on top of the previous HBM usage. This is the workaround for that.
+  def test_vllm_sampler_batch_mode(self):
+    self._run_vllm_sampler(server_mode=False)
+
+  def test_vllm_sampler_server_mode(self):
+    self._run_vllm_sampler(server_mode=True)
+
+  def _run_vllm_sampler(self, server_mode):
     tunix_model, model_config = self.load_llama3_model(
         self.repo_id, enable_lora=self.enable_lora
+    )
+
+    base_utils.show_hbm_usage("After loading tunix model")
+
+    model_tokenizer = transformers.AutoTokenizer.from_pretrained(
+        self.model_path
     )
 
     args = {}
@@ -95,8 +115,7 @@ class VllmSamplerTest(absltest.TestCase):
           # "bias": "none",
       }
 
-    base_utils.show_hbm_usage("After loading tunix model")
-
+    # Sampler setup
     model_tokenizer = transformers.AutoTokenizer.from_pretrained(
         self.model_path
     )
@@ -144,6 +163,7 @@ class VllmSamplerTest(absltest.TestCase):
         tpu_backend_type="jax",
         mapping_config=mapping_config,
         lora_config=args["additional_config"]["lora_config"],
+        server_mode=server_mode,
     )
 
     vl_sampler = vllm_sampler.VllmSampler(
@@ -200,6 +220,92 @@ class VllmSamplerTest(absltest.TestCase):
               vllm_state["model"]["embed"]["embedding"].value,
           )
       )
+    if vllm_config.server_mode:
+      vl_sampler.stop()
+
+  def test_server_mode_e2e_real_model_out_of_order(self):
+    tunix_model, _ = self.load_llama3_model(
+        self.repo_id, enable_lora=self.enable_lora
+    )
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(self.model_path)
+
+    prompts = [
+        "Please summarize the following text concisely:\n"
+        + " ".join(["alpha"] * length)
+        for length in [320, 80, 400, 40, 360, 20, 300, 120, 340, 60]
+    ]
+
+    mapping_config = mappings.MappingConfig.build(tunix_model)
+    vllm_config = vllm_sampler.VllmConfig(
+        model_version=self.model_path,
+        max_model_len=512,
+        mesh=self.mesh,
+        hbm_utilization=0.2,
+        init_with_random_weights=True,
+        tpu_backend_type=None,
+        mapping_config=mapping_config,
+        server_mode=True,
+    )
+
+    vl_sampler = vllm_sampler.VllmSampler(
+        tokenizer=tokenizer,
+        config=vllm_config,
+    )
+    self.addCleanup(vl_sampler.stop)
+
+    state = nnx.state(tunix_model)
+    vl_sampler.load_checkpoint(state)
+
+    driver = vl_sampler._driver
+    self.assertIsNotNone(driver)
+
+    base_params = SamplingParams()
+    base_params.detokenize = True
+    base_params.max_tokens = 64
+    base_params.n = 1
+    base_params.temperature = 0.0
+    base_params.top_k = 1
+    base_params.stop_token_ids = [tokenizer.eos_token_id]
+    base_params.skip_special_tokens = True
+
+    submitted_order = [str(i) for i in range(len(prompts))]
+    futures = []
+    for idx, prompt in enumerate(prompts):
+      token_ids = vl_sampler.tokenize(prompt)
+      prompt_obj = TokensPrompt(prompt_token_ids=token_ids)
+      params = base_params.clone()
+      future = driver.submit_request(
+          request_id=str(idx),
+          prompt=prompt_obj,
+          params=params,
+      )
+      futures.append(future)
+
+    completion_order = []
+    results_by_request: dict[str, object] = {}
+    for future in concurrent.futures.as_completed(futures, timeout=600):
+      output = future.result()
+      completion_order.append(output.request_id)
+      results_by_request[output.request_id] = output
+
+    self.assertCountEqual(completion_order, submitted_order)
+    self.assertNotEqual(
+        completion_order,
+        submitted_order,
+        msg=(
+            "Completions arrived strictly in submission order; "
+            "continuous batching did not reorder responses."
+        ),
+    )
+
+    for request_id in submitted_order:
+      output = results_by_request[request_id]
+      self.assertTrue(output.finished)
+      self.assertGreater(len(output.outputs), 0)
+
+    if vllm_config.server_mode:
+      vl_sampler.stop()
 
 
 if __name__ == "__main__":

--- a/tunix/generate/vllm_async_driver.py
+++ b/tunix/generate/vllm_async_driver.py
@@ -1,0 +1,237 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-process driver for the vLLM V1 EngineCore.
+
+This driver keeps the EngineCore inside the current process and runs the
+continuous batching loop on a Python thread. It is intended for TPU setups
+where multiprocessing is undesirable (e.g. JAX integration).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from concurrent.futures import Future
+from typing import Any, Callable, Dict, Optional, Union
+
+import vllm.envs as envs
+from vllm.engine.arg_utils import EngineArgs
+from vllm.inputs import PromptType
+from vllm.lora.request import LoRARequest
+from vllm.outputs import PoolingRequestOutput, RequestOutput
+from vllm.pooling_params import PoolingParams
+from vllm.sampling_params import SamplingParams
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine import EngineCoreRequest
+from vllm.v1.engine.llm_engine import LLMEngine
+
+# Ensure multiprocessing is disabled before the engine is constructed.
+if os.environ.get("VLLM_ENABLE_V1_MULTIPROCESSING") != "0":
+    os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+envs.VLLM_ENABLE_V1_MULTIPROCESSING = False
+
+StreamCallback = Callable[[Union[RequestOutput, PoolingRequestOutput]], None]
+RequestFuture = Future
+
+
+class VLLMInProcessDriver:
+    """Runs a V1 LLMEngine in-process and polls for finished outputs."""
+
+    def __init__(
+        self,
+        llm_engine: LLMEngine,
+        *,
+        poll_interval_s: float = 0.005,
+        stream_callback: Optional[StreamCallback] = None,
+        auto_start: bool = True,
+    ) -> None:
+        self._llm_engine = llm_engine
+        self._poll_interval_s = poll_interval_s
+        self._stream_callback = stream_callback
+
+        self._engine_lock = threading.Lock()
+        self._work_event = threading.Event()
+        self._stop_event = threading.Event()
+        self._loop_thread: Optional[threading.Thread] = None
+
+        self._pending: Dict[str, RequestFuture] = {}
+        self._last_error: Optional[BaseException] = None
+
+        if auto_start:
+            self.start()
+
+    @classmethod
+    def from_engine_args(
+        cls,
+        engine_args: EngineArgs,
+        *,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        poll_interval_s: float = 0.005,
+        stream_callback: Optional[StreamCallback] = None,
+        auto_start: bool = True,
+    ) -> "VLLMInProcessDriver":
+        llm_engine = LLMEngine.from_engine_args(
+            engine_args,
+            usage_context=usage_context,
+            enable_multiprocessing=False,
+        )
+        return cls(
+            llm_engine,
+            poll_interval_s=poll_interval_s,
+            stream_callback=stream_callback,
+            auto_start=auto_start,
+        )
+
+    def submit_request(
+        self,
+        request_id: str,
+        prompt: Union[EngineCoreRequest, PromptType],
+        params: Union[SamplingParams, PoolingParams],
+        *,
+        arrival_time: Optional[float] = None,
+        lora_request: Optional[LoRARequest] = None,
+        tokenization_kwargs: Optional[dict[str, Any]] = None,
+        trace_headers: Optional[dict[str, str]] = None,
+        priority: int = 0,
+    ) -> RequestFuture:
+        future: RequestFuture = Future()
+        with self._engine_lock:
+            if request_id in self._pending:
+                raise ValueError(f"Request {request_id} already pending.")
+            self._pending[request_id] = future
+            self._llm_engine.add_request(
+                request_id=request_id,
+                prompt=prompt,
+                params=params,
+                arrival_time=arrival_time,
+                lora_request=lora_request,
+                tokenization_kwargs=tokenization_kwargs,
+                trace_headers=trace_headers,
+                priority=priority,
+            )
+            self._work_event.set()
+        return future
+
+    def start(self) -> None:
+        if self._loop_thread and self._loop_thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._loop_thread = threading.Thread(
+            target=self._loop, name="VLLMInProcessDriverLoop", daemon=False
+        )
+        self._loop_thread.start()
+
+    def cancel(self, request_id: str) -> None:
+        with self._engine_lock:
+            future = self._pending.pop(request_id, None)
+            if future is not None and not future.done():
+                future.cancel()
+            self._llm_engine.abort_request([request_id])
+            if not self._llm_engine.has_unfinished_requests():
+                self._work_event.clear()
+
+    def shutdown(self) -> None:
+        self.stop()
+        with self._engine_lock:
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for future in pending:
+            if not future.done():
+                future.set_exception(RuntimeError("Driver shut down."))
+        with self._engine_lock:
+            self._llm_engine.engine_core.shutdown()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._work_event.set()
+        if self._loop_thread is not None:
+            self._loop_thread.join()
+            self._loop_thread = None
+
+    def pause(self) -> None:
+      raise RuntimeError("Pause feature WIP")
+
+    def resume(self) -> None:
+      raise RuntimeError("Resume feature WIP")
+
+    def _loop(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                if not self._wait_for_work():
+                    continue
+                outputs = self._step_engine()
+                if outputs:
+                    for output in outputs:
+                        self._handle_output(output)
+                else:
+                    time.sleep(self._poll_interval_s)
+        except BaseException as exc:  # pylint: disable=broad-exception-caught
+            self._record_error(exc)
+
+    def _wait_for_work(self) -> bool:
+        with self._engine_lock:
+            has_work = self._llm_engine.has_unfinished_requests()
+            if not has_work:
+                self._work_event.clear()
+        if has_work:
+            return True
+        self._work_event.wait(timeout=self._poll_interval_s)
+        return not self._stop_event.is_set()
+
+    def _step_engine(
+        self,
+    ) -> list[Union[RequestOutput, PoolingRequestOutput]]:
+        with self._engine_lock:
+            if not self._llm_engine.has_unfinished_requests():
+                return []
+            return self._llm_engine.step()
+
+    def _handle_output(
+        self, output: Union[RequestOutput, PoolingRequestOutput]
+    ) -> None:
+        if not output.finished:
+            callback = self._stream_callback
+            if callback is not None:
+                callback(output)
+            return
+        with self._engine_lock:
+            future = self._pending.pop(output.request_id, None)
+        if future is None or future.done():
+            return
+        future.set_result(output)
+
+    def _record_error(self, exc: BaseException) -> None:
+        self._last_error = exc
+        with self._engine_lock:
+            pending = list(self._pending.values())
+            self._pending.clear()
+        for future in pending:
+            if not future.done():
+                future.set_exception(exc)
+
+    @property
+    def llm_engine(self) -> LLMEngine:
+        return self._llm_engine
+
+    @property
+    def last_error(self) -> Optional[BaseException]:
+        return self._last_error
+
+    def __enter__(self) -> "VLLMInProcessDriver":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001, ANN201
+        self.shutdown()

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -17,7 +17,8 @@
 import dataclasses
 import math
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from itertools import count
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from absl import logging
 import jax
@@ -29,8 +30,13 @@ from tunix.generate.mappings import MappingConfig
 import tunix.generate.tokenizer_adapter as tok_adapter
 from tunix.rl import reshard
 from vllm import LLM
+from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import TokensPrompt
 from vllm.outputs import RequestOutput
+from vllm.sampling_params import BeamSearchParams, SamplingParams
+from vllm.usage.usage_lib import UsageContext
+
+from .vllm_async_driver import VLLMInProcessDriver
 
 # Colocate vllm engine and worker in the main process
 os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
@@ -56,6 +62,7 @@ class VllmConfig:
   # transferring data between CPU and TPU/GPU memory.
   swap_space: float = 4.0  # in GiB
   lora_config: Optional[Dict[str, Any]] = None
+  server_mode: bool = False
 
 
 class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
@@ -89,8 +96,16 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       os.environ["JAX_RANDOM_WEIGHTS"] = "True"
 
     self.tokenizer = tok_adapter.TokenizerAdapter(tokenizer)
+    self.config = config
     self.args = self._vllm_config(config)
-    self.llm = LLM(**self.args)
+    self._driver: VLLMInProcessDriver | None = None
+    self.llm: LLM | None = None
+    self._request_counter = count()
+
+    if config.server_mode:
+      self._driver = self._create_driver()
+    else:
+      self.llm = LLM(**self.args)
 
     self.to_hf_key_mappings = dict(config.mapping_config.to_hf_mappings or {})
     self.to_hf_transpose_keys = config.mapping_config.to_hf_transpose_keys
@@ -136,6 +151,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     args["additional_config"] = {}
     args["model"] = config.model_version
     args["max_model_len"] = config.max_model_len
+    args["tensor_parallel_size"] = self._find_tp_size(config.mesh)
     args["gpu_memory_utilization"] = config.hbm_utilization
     args["swap_space"] = config.swap_space
     if config.lora_config is not None:
@@ -149,9 +165,29 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     }
     return args
 
+  def _build_engine_args(self) -> EngineArgs:
+    engine_kwargs = dict(self.args)
+    engine_kwargs.setdefault("disable_log_stats", True)
+    return EngineArgs(**engine_kwargs)
+
+  def _create_driver(self) -> VLLMInProcessDriver:
+    engine_args = self._build_engine_args()
+    return VLLMInProcessDriver.from_engine_args(
+        engine_args,
+    )
+
+  def stop(self):
+    if self._driver is not None:
+      self._driver.shutdown()
+      self._driver = None
+
   @property
   def _model_runner(self):
-    return self.llm.llm_engine.model_executor.driver_worker.model_runner
+    if self.llm is not None:
+      return self.llm.llm_engine.model_executor.driver_worker.model_runner
+    if self._driver is not None:
+      return self._driver.llm_engine.model_executor.driver_worker.model_runner
+    raise RuntimeError("vLLM engine is not initialized.")
 
   @property
   def transformer(self):
@@ -212,6 +248,38 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
         )
     return decoded_outputs, out_logprobs, out_tokens
 
+  def _generate_server_mode(
+      self,
+      prompts: List[TokensPrompt],
+      sampling_params: Union[SamplingParams, BeamSearchParams],
+  ) -> List[RequestOutput]:
+    """Generate the response in server mode."""
+    if self._driver is None:
+      raise RuntimeError("vLLM in-process driver is not initialized.")
+
+    futures = []
+    for idx, prompt in enumerate(prompts):
+      request_id = str(next(self._request_counter))
+      params = sampling_params
+      if idx > 0 and hasattr(sampling_params, "clone"):
+        params = sampling_params.clone()
+      future = self._driver.submit_request(
+          request_id=request_id,
+          prompt=prompt,
+          params=params,
+      )
+      futures.append(future)
+
+    outputs: List[RequestOutput] = []
+    for future in futures:
+      result = future.result()
+      if not isinstance(result, RequestOutput):
+        raise TypeError(
+            f"Expected RequestOutput from driver, received {type(result)}."
+        )
+      outputs.append(result)
+    return outputs
+
   def __call__(
       self,
       input_strings: List[str],
@@ -227,6 +295,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       echo: bool = False,
       pad_output: bool = False,
   ) -> base_sampler.SamplerOutput:
+    """The entry point API for vLLM Sampler"""
     # max_tokens: maximum number of tokens to generate
     if max_generation_steps > self.args["max_model_len"]:
       raise ValueError(
@@ -236,34 +305,49 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           f"{self.args['max_model_len']}."
       )
     if beam_size is not None:
-      self.sampling_params = self.llm.sampling_params.BeamSearchParams(
+      self.sampling_params = BeamSearchParams(
           beam_width=beam_size,
           max_tokens=max_generation_steps,
           ignore_eos=False,
           temperature=temperature,
       )
     else:
-      self.sampling_params = self.llm.get_default_sampling_params()
-      self.sampling_params.detokenize = False
-      self.sampling_params.max_tokens = max_generation_steps
-      self.sampling_params.n = multi_sampling
-      self.sampling_params.temperature = temperature
-      self.sampling_params.logprobs = 1  # b/428730696
-      self.sampling_params.prompt_logprobs = 1  # b/428730696
-      self.sampling_params.stop_token_ids = [self.tokenizer.eos_id()]
-      self.sampling_params.skip_special_tokens = True
+      if self._driver is not None:
+        diff_params = (
+            self._driver.llm_engine.model_config.get_diff_sampling_param()
+        )
+        if diff_params:
+          sampling_params = SamplingParams.from_optional(**diff_params)
+        else:
+          sampling_params = SamplingParams()
+      else:
+        sampling_params = self.llm.get_default_sampling_params()
+      sampling_params.detokenize = False
+      sampling_params.max_tokens = max_generation_steps
+      sampling_params.n = multi_sampling
+      sampling_params.temperature = temperature
+      sampling_params.logprobs = 1  # b/428730696
+      sampling_params.prompt_logprobs = 1  # b/428730696
+      sampling_params.stop_token_ids = [self.tokenizer.eos_id()]
+      sampling_params.skip_special_tokens = True
 
       if top_p is not None:
-        self.sampling_params.top_p = top_p
+        sampling_params.top_p = top_p
       if top_k is not None:
-        self.sampling_params.top_k = top_k
+        sampling_params.top_k = top_k
+
+      self.sampling_params = sampling_params
 
     prompt_ids = [self.tokenize(x) for x in input_strings]
-    outputs = self.llm.generate(
-        prompts=[TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids],
-        sampling_params=self.sampling_params,
-        use_tqdm=True,
-    )
+    prompt_objects = [TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids]
+    if self._driver is not None:
+      outputs = self._generate_server_mode(prompt_objects, self.sampling_params)
+    else:
+      outputs = self.llm.generate(
+          prompts=prompt_objects,
+          sampling_params=self.sampling_params,
+          use_tqdm=True,
+      )
     decoded_outputs, out_logprobs, out_tokens = self.detokenize(
         input_strings, outputs
     )

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -182,6 +182,7 @@ class ClusterConfig:
   )
   rollout_mapping_config: mappings.MappingConfig | None = None
 
+  rollout_vllm_server_mode: bool = False
   rollout_vllm_model_version: str = ""
   rollout_vllm_lora_config: dict[str, Any] | None = None
   rollout_vllm_hbm_utilization: float = 0.2
@@ -414,6 +415,7 @@ class RLCluster:
           lora_config=self.cluster_config.rollout_vllm_lora_config,
           rollout_engine=backend,
           mapping_config=self.cluster_config.rollout_mapping_config,
+          server_mode=self.cluster_config.rollout_vllm_server_mode,
       )
     else:
       raise NotImplementedError(

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -38,6 +38,7 @@ class VllmRollout(base_rollout.BaseRollout):
       init_with_random_weights: bool,
       tpu_backend_type: str,
       swap_space: float = 4.0,  # in GiB
+      server_mode: bool = False,
       lora_config: Optional[Dict[str, str]] = None,
       mapping_config: Optional[mappings.MappingConfig] = None,
       rollout_engine: str = "vllm_jax",
@@ -58,6 +59,7 @@ class VllmRollout(base_rollout.BaseRollout):
             mapping_config=mapping_config,
             lora_config=lora_config,
             swap_space=swap_space,
+            server_mode=server_mode,
         ),
     )
     state = nnx.state(model)


### PR DESCRIPTION
This PR enables vLLM server mode in a single process. vLLM OpenAI server employs multi processing which is incompatible with Jax/Pathways requirements. Developed a simple front end driver to encapsulate all the server side, and part of vLLM engine management in the main python process. Details in [Tunix V3 + Async vLLM Design](https://docs.google.com/document/d/1Ddz0_qsvi_IOQMeQYY67iHyI5bqLOnDX4QUu7U4lQCs/edit?tab=t.0#heading=h.j7n9nrsl2k22)

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
