### PR TITLE
Bump up Jax version to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "gcsfs",
   "grain",
   "huggingface_hub",
+  "jax[tpu]>=0.6.0,!=0.7.2", # Jax 0.7.2 has performance regression on OSS
   "jaxtyping",
   "kagglehub",
   "omegaconf",
@@ -48,11 +49,9 @@ docs = [
     "sphinx_contributors",
 ]
 prod = [
-    "jax[tpu]>=0.6.0,<=0.7.1", # Newer libtpu version has some perf regression on cloud TPU, pin to <=0.7.1 for now. b/448646341
     "flax>=0.11.2",
 ]
 dev = [
-    "jax[tpu]>=0.7.2",  # vLLM TPU backend only works with latest Jax
     "flax>=0.11.2",
     "numba",
     "vllm",


### PR DESCRIPTION
Verified GRPO script works with Jax 0.8.0, vLLM backend also works, therefore bump up the Jax to 0.8.0 for both prod and dev mode.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
