### PR TITLE
Fix broken CI due to vllm.

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -213,5 +213,9 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          pytest tests/generate/vllm_sampler_test.py -v --tb=short
+          pytest tests/generate/vllm_sampler_test.py --collect-only -q > test_collections.txt
+          while read -r test; do
+            pytest "$test" -v --tb=short
+          done < test_collections.txt
+
 

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -25,9 +25,10 @@ import jax
 import jax.numpy as jnp
 import jaxtyping
 from tunix.generate import base_sampler
+from tunix.generate import tokenizer_adapter as tok_adapter
 from tunix.generate import utils
 from tunix.generate.mappings import MappingConfig
-import tunix.generate.tokenizer_adapter as tok_adapter
+from tunix.generate.vllm_async_driver import VLLMInProcessDriver
 from tunix.rl import reshard
 from vllm import LLM
 from vllm.engine.arg_utils import EngineArgs
@@ -35,7 +36,6 @@ from vllm.inputs import TokensPrompt
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams
 from vllm.sampling_params import SamplingParams
-from vllm_async_driver import VLLMInProcessDriver
 
 # Colocate vllm engine and worker in the main process
 os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"


### PR DESCRIPTION
This PR fixes the following:
1. The import path is wrong
2. vLLM cannot get reset properly between tests. Adopted an alternative to invoke 1 test in a single command and use multiple commands to run all the vllm tests to guarantee the resource separation.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
