### PR TITLE
add qwen2 sglang jax mapping

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -209,8 +209,6 @@ jobs:
           pip uninstall torch libtpu jax jaxlib -y
           pip install tpu-inference==v0.11.1 --force-reinstall
           pip install pytest pytest-xdist
-          
-          git clone https://github.com/sgl-project/sglang-jax.git && cd sglang-jax/python && pip install -e .
 
       - name: Run tests
         env:
@@ -221,4 +219,14 @@ jobs:
           while read -r test; do
             pytest "$test" -v --tb=short
           done < test_collections.txt
-          pytest tests/generate/sglang_jax_sampler_test.py -v --tb=short
+
+      - name: Run install sglang-jax && test
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          ## because sglang-jax has codes like jax.local_devices('cpu')
+          unset JAX_PLATFORMS 
+          cd ..
+          git clone https://github.com/sgl-project/sglang-jax.git && cd sglang-jax/python && pip install -e . && cd ../..
+          cd tunix && python tests/generate/sglang_jax_sampler_test.py 
+          

--- a/tunix/models/qwen2/__init__.py
+++ b/tunix/models/qwen2/__init__.py
@@ -14,12 +14,14 @@
 
 """Qwen2 API."""
 
+from tunix.models.qwen2 import mapping_sglang_jax
 from tunix.models.qwen2 import mapping_vllm_jax
 from tunix.models.qwen2 import model
 from tunix.models.qwen2 import params
 
 BACKEND_MAPPINGS = {
     'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
+    'sglang_jax': mapping_sglang_jax.SGLANG_JAX_MAPPING,
 }
 
 

--- a/tunix/models/qwen2/mapping_sglang_jax.py
+++ b/tunix/models/qwen2/mapping_sglang_jax.py
@@ -1,0 +1,96 @@
+"""Mappings for converting Qwen2 weights to the Sglang-jax JAX backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Tuple
+
+Sharding = Tuple[str | None, ...]
+MappingEntry = Tuple[str, Sharding]
+
+
+def _to_sglang_jax_mappings() -> Dict[str, MappingEntry]:
+  return {
+      'lm_head.w': ('lm_head.embedding', (None, 'model')),
+      'embedder.input_embedding': (
+          'transformer.embed_tokens.embedding',
+          ('model', None),
+      ),
+      'layers.*.input_layernorm.w': (
+          'transformer.layers.*.input_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.mlp.down_proj.kernel': (
+          'transformer.layers.*.mlp.down_proj.weight',
+          ('model', None),
+      ),
+      'layers.*.mlp.gate_proj.kernel': (
+          'transformer.layers.*.mlp.gate_proj.weight',
+          (None, 'model'),
+      ),
+      'layers.*.mlp.up_proj.kernel': (
+          'transformer.layers.*.mlp.up_proj.weight',
+          (None, 'model'),
+      ),
+      'layers.*.post_attention_layernorm.w': (
+          'transformer.layers.*.post_attention_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.attn.k_proj.w': (
+          'transformer.layers.*.self_attn.k_proj.weight',
+          (None, 'model', None),
+      ),
+      'layers.*.attn.k_bias': (
+          'transformer.layers.*.self_attn.k_proj.bias',
+          (None,),
+      ),
+      'layers.*.attn.o_proj.w': (
+          'transformer.layers.*.self_attn.o_proj.weight',
+          ('model', None, None),
+      ),
+      'layers.*.attn.q_proj.w': (
+          'transformer.layers.*.self_attn.q_proj.weight',
+          (None, 'model', None),
+      ),
+      'layers.*.attn.q_bias': (
+          'transformer.layers.*.self_attn.q_proj.bias',
+          (None,),
+      ),
+      'layers.*.attn.v_proj.w': (
+          'transformer.layers.*.self_attn.v_proj.weight',
+          (None, 'model', None),
+      ),
+      'layers.*.attn.v_bias': (
+          'transformer.layers.*.self_attn.v_proj.bias',
+          (None,),
+      ),
+      'final_norm.w': ('transformer.norm.scale', (None,)),
+  }
+
+
+def _lora_to_sglang_jax_mappings() -> Dict[str, MappingEntry] | None:
+  """The lora parameter key mapping between Tunix vanilla model and Sglang-jax Jax backend"""
+  return None
+
+
+def _to_sglang_jax_transpose_keys():
+  return {
+      'lm_head.w': (1, 0),
+  }
+
+
+def _to_sglang_jax_hook_fns() -> Dict[str, Any] | None:
+  """Additional parameter manipulation hook between Tunix vanilla model and Sglang Jax backend"""
+  return None
+
+
+SGLANG_JAX_MAPPING: Dict[str, Any] = {
+    'to_hf_mappings': _to_sglang_jax_mappings(),
+    'lora_to_hf_mappings': _lora_to_sglang_jax_mappings(),
+    'to_hf_transpose_keys': _to_sglang_jax_transpose_keys(),
+    'to_hf_hook_fns': _to_sglang_jax_hook_fns(),
+}
+
+__all__ = [
+    'SGLANG_JAX_MAPPING',
+]


### PR DESCRIPTION
Resolves #\<issue_number_goes_here\>

> It's a good idea to open an issue first for discussion.

this pr add mapping from tunix to sglang_jax for qwen2, grpo can run with deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B model using the follow command
```
python grpo_demo_sglang_jax_rollout.py --model-version deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B
```
and the result is


<img width="1651" height="147" alt="image" src="https://github.com/user-attachments/assets/bd290f01-d33b-407c-96b3-0e388b625a13" />


<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
