### PR TITLE
Auto assign github issues to all the eng.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @tianshub @wang2yn84 @lc5211 @hgao327 @sizhit2 @abheesht17
+* @tianshub @wang2yn84 @lc5211 @hgao327 @sizhit2 @abheesht17 @jiangyangmu

--- a/.github/workflows/issue-auto-assign.yaml
+++ b/.github/workflows/issue-auto-assign.yaml
@@ -1,0 +1,13 @@
+name: Auto-assign issues
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign issue
+        uses: peter-evans/assign-issue@v2
+        with:
+          assignees: tianshub, wang2yn84, lc5211, hgao327, sizhit2, abheesht17, jiangyangmu


### PR DESCRIPTION
Right now github issues are floating without assignees. This PR assigns all the new issues to all the engs. When our team grows bigger, will assign by component.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
