### PR TITLE
set use_sort_for_toppk_minp to true when initialize the SglangJaxSampler

### DIFF
--- a/tunix/generate/sglang_jax_sampler.py
+++ b/tunix/generate/sglang_jax_sampler.py
@@ -42,6 +42,8 @@ class SglangJaxConfig:
   disable_radix_cache: bool
   enable_deterministic_sampling: bool
   mapping_config: mappings.MappingConfig
+  # Note: use_sort_for_toppk_minp may be removed in the future. It depends on SGLang-Jax.
+  use_sort_for_toppk_minp: bool = True
 
 
 class SglangJaxSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
@@ -119,6 +121,7 @@ class SglangJaxSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-nam
       args["enable_deterministic_sampling"] = True
     if config.init_with_random_weights:
       args["load_format"] = "dummy"
+    args["use_sort_for_toppk_minp"] = config.use_sort_for_toppk_minp
     return args
 
   @property


### PR DESCRIPTION
Resolves #695

<!--- Describe your changes in detail. -->

 I add use_sort_for_toppk_minp in SglangJaxConfig and set its default value to True.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

- [SGLang-Jax Issue288](https://github.com/sgl-project/sglang-jax/issues/288)
- [SGLang-Jax PR287](https://github.com/sgl-project/sglang-jax/pull/287) 

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
