### PR TITLE
Let each process reports local devices' HBM usage in multi-process SPMD

### DIFF
--- a/tunix/sft/utils.py
+++ b/tunix/sft/utils.py
@@ -141,12 +141,12 @@ def show_hbm_usage(title=""):
     title: The title to print before the HBM usage.
   """
   fmt_size = functools.partial(humanize.naturalsize, binary=True)
-  devices = jax.devices()
   # Force a GC sweep to catch recently deallocated arrays
   gc.collect()
 
   if google_utils.pathways_available():
     logging.info("%s - Using Pathways compatible HBM stats collector", title)
+    devices = jax.devices()
     hbm_stats = _pathways_hbm_usage_gb(devices)
     for i, (used, _) in enumerate(hbm_stats):
       logging.info("Using %s on %s", fmt_size(used), devices[i])
@@ -154,6 +154,7 @@ def show_hbm_usage(title=""):
     logging.info(
         "%s - Pathways not available. Using default HBM stats collector", title
     )
+    devices = jax.local_devices()
     hbm_stats = _jax_hbm_usage_gb(devices)
 
     for i, (used, limit) in enumerate(hbm_stats):


### PR DESCRIPTION
Ensures each process only reports HBM usage for its addressable devices in multi-process SPMD.

- Problem: `show_hbm_usage` queried all devices, then called `memory_stats()` on devices that may not be addressable by the current process, triggering:
  ```
  jax.errors.JaxRuntimeError: INVALID_ARGUMENT: MemoryStats is only supported for addressable PjRt devices.
  ```
- Change:
  - Moves device selection inside each branch, preventing cross-host queries in JAX multi-process SPMD mode.
  - Pathways branch: unchanged
  - Non-Pathways branch: switches to `jax.local_devices()` before calling `memory_stats()`, ensuring only addressable devices are queried.
- Impact:
  - Fixes crashes during `RLLearner` initialization (and other callers of `show_hbm_usage`) on multi-host setups.
  - No behavior change for single-process runs or Pathways environments; logs now correctly reflect per-process HBM usage in SPMD.

Fixes the issue observed in:
```
0: Traceback (most recent call last):
0:     grpo_trainer = GRPOLearner(
0:                    ^^^^^^^^^^^^
0:   File "/opt/tunix/tunix/rl/grpo/grpo_learner.py", line 133, in __init__
0:     super().__init__(
0:   File "/opt/tunix/tunix/rl/rl_learner.py", line 124, in __init__
0:     sft_utils.show_hbm_usage(title="RLLearner init")
0:   File "/opt/tunix/tunix/sft/utils.py", line 157, in show_hbm_usage
0:     hbm_stats = _jax_hbm_usage_gb(devices)
0:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
0:   File "/opt/tunix/tunix/sft/utils.py", line 130, in _jax_hbm_usage_gb
0:     stats = device.memory_stats()
0:             ^^^^^^^^^^^^^^^^^^^^^
0: jax.errors.JaxRuntimeError: INVALID_ARGUMENT: MemoryStats is only supported for addressable PjRt devices.
```

**Reference**
- Error context: `memory_stats()` requires addressable PjRt devices.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).