### PR TITLE
Remove the pinned qwix version

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [linux-x86-ct5lp-224-8tpu]
     environment: testing
     container:
-      image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:jax0.7.1_rev1
+      image: us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/candidate/tpu:latest
       options: --privileged
       env:
         CLOUD_TPU_ACCELERATOR: v5e-8
@@ -221,8 +221,13 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
+          # Reinstall Tunix with prod dependencies
+          pip install -e .[prod] --force-reinstall
+
           # Loading tfds requires tensorflow.
           pip install tensorflow
+
+          export JAX_PLATFORMS=tpu,cpu
           ./tests/sft/sft_tpu_smoke_test.sh
       - name: Run tunix cli tests
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-tunix"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name = "Tunix Developers", email = "tunix-dev@google.com" },
 ]
@@ -31,7 +31,7 @@ dependencies = [
   "omegaconf", # CLI config
   "pylatexenc",  # Eval result parsing
   "python-dotenv",  # Huggingface API key
-  "qwix<=0.1.1",  # Newer version of qwix depends on unreleased flax beyond 0.12.0
+  "qwix",
   "sentencepiece",
   "sympy",  # Eval result parsing
   "tensorflow_datasets",


### PR DESCRIPTION
This PR does the following:
1. Bumps up the Tunix version (we should've done this right after the previous release)
2. Remove the qwix version pin because flax released 0.12.1
3. Reinstall tunix and dependencies after vLLM and SGLang tests are done.
4. Fix the failing orpo test, root cause is because the test tries to mock the function called within jitted function, which doesn't really work, the return values looks weird. Not exactly sure why it doesn't failed before.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
