### PR TITLE
Fix the vllm server mode not finish issue.

### DIFF
--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -48,8 +48,8 @@ from tunix.rl.rollout import base_rollout
 from tunix.sft import metrics_logger
 from tunix.sft import utils
 from tunix.tests import test_common as tc
+from tunix.utils import script_utils
 
-logging.set_verbosity(logging.INFO)
 
 show_hbm_usage = utils.show_hbm_usage
 
@@ -147,10 +147,18 @@ parser.add_argument(
     required=False,
     help="Rollout engine data parallel size.",
 )
-
+parser.add_argument(
+    "--log-level",
+    type=str,
+    default="WARNING",
+    required=False,
+    help="Logging level.",
+)
 
 # Parse arguments
 args = parser.parse_args()
+
+logging.set_verbosity(script_utils.DEBUG_LEVELS.get(args.log_level.upper(), logging.WARNING))
 
 # ====== Data ======
 # The data is not available in gcs bucket yet, please manually copy the

--- a/tests/generate/vllm_driver_test.py
+++ b/tests/generate/vllm_driver_test.py
@@ -69,6 +69,10 @@ class _FakeLLMEngine:
     with self._lock:
       return bool(self._pending)
 
+  def get_num_unfinished_requests(self) -> int:
+    with self._lock:
+      return len(self._pending)
+
   def step(self):
     with self._lock:
       if not self._completion_order or not self._pending:

--- a/tunix/generate/vllm_async_driver.py
+++ b/tunix/generate/vllm_async_driver.py
@@ -22,6 +22,7 @@ where multiprocessing is undesirable (e.g. JAX integration).
 from __future__ import annotations
 
 from concurrent.futures import Future
+from absl import logging
 import os
 import threading
 import time
@@ -84,6 +85,7 @@ class VLLMInProcessDriver:
       stream_callback: Optional[StreamCallback] = None,
       auto_start: bool = True,
   ) -> "VLLMInProcessDriver":
+    logging.debug(f"Creating VLLMInProcessDriver with engine_args: {engine_args} and usage_context: {usage_context}")
     llm_engine = LLMEngine.from_engine_args(
         engine_args,
         usage_context=usage_context,
@@ -113,6 +115,7 @@ class VLLMInProcessDriver:
       if request_id in self._pending:
         raise ValueError(f"Request {request_id} already pending.")
       self._pending[request_id] = future
+      logging.debug(f"VLLMInProcessDriver submitting request {request_id} with prompt {prompt} and sampling params {params} to vLLM engine.")
       self._llm_engine.add_request(
           request_id=request_id,
           prompt=prompt,
@@ -131,7 +134,7 @@ class VLLMInProcessDriver:
       return
     self._stop_event.clear()
     self._loop_thread = threading.Thread(
-        target=self._loop, name="VLLMInProcessDriverLoop", daemon=False
+        target=self._loop, name="VLLMInProcessDriverLoop", daemon=True
     )
     self._loop_thread.start()
 
@@ -174,6 +177,7 @@ class VLLMInProcessDriver:
         if not self._wait_for_work():
           continue
         outputs = self._step_engine()
+        logging.log_every_n(logging.DEBUG, f"VLLMInProcessDriver loop step outputs: {[output.request_id for output in outputs]}", 40)
         if outputs:
           for output in outputs:
             self._handle_output(output)
@@ -195,7 +199,9 @@ class VLLMInProcessDriver:
   def _step_engine(
       self,
   ) -> list[Union[RequestOutput, PoolingRequestOutput]]:
+    logging.log_every_n(logging.DEBUG, f"VLLMInProcessDriver loop waking up to process one step of requests.", 100)
     with self._engine_lock:
+      logging.log_every_n(logging.DEBUG, f"VLLMInProcessDriver has {self._llm_engine.get_num_unfinished_requests()} pending requests.", 100)
       if self._llm_engine.has_unfinished_requests():
         return self._llm_engine.step()
       return []
@@ -212,9 +218,11 @@ class VLLMInProcessDriver:
       future = self._pending.pop(output.request_id, None)
     if future is None or future.done():
       return
+    logging.debug(f"VLLMInProcessDriver completed request id: {output.request_id}.")
     future.set_result(output)
 
   def _record_error(self, exc: BaseException) -> None:
+    logging.debug("VLLMInProcessDriver encountered an error: %s", exc)
     self._last_error = exc
     with self._engine_lock:
       pending = list(self._pending.values())

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -14,6 +14,7 @@
 
 """Sampler for vLLM-style autoregressive decoding using JAX and NNX models."""
 
+import atexit
 import dataclasses
 from itertools import count
 import math
@@ -111,6 +112,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
 
     if config.server_mode:
       self._driver = self._create_driver()
+      atexit.register(self.stop)
     else:
       self.llm = LLM(**self.args)
 
@@ -208,6 +210,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     )
 
   def stop(self):
+    logging.debug("Shutting down VLLMInProcessDriver.")
     if self._driver is not None:
       self._driver.shutdown()
       self._driver = None

--- a/tunix/rl/rl_learner.py
+++ b/tunix/rl/rl_learner.py
@@ -606,6 +606,7 @@ class RLLearner(abc.ABC, Generic[TConfig]):
           )
 
           if self.should_sync_weights:
+            logging.debug(f"Syncing weights at global step {self.rl_cluster.global_steps} mini batch step {self._iter_steps}")
             with self.rl_cluster.perf.span(
                 "weight_sync", self.rl_cluster.perf.all_devices
             ):

--- a/tunix/utils/script_utils.py
+++ b/tunix/utils/script_utils.py
@@ -6,6 +6,15 @@ import logging
 import os
 import grain
 
+
+DEBUG_LEVELS = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "FATAL": logging.FATAL,
+}
+
 try:
   # This is a g3-only import.
   from GOOGLE_INTERNAL_PACKAGE_PATH.perftools.accelerators.xprof.api.python import xprof_session  # pytype: disable=import-error


### PR DESCRIPTION
vLLM server mode is working but cannot stop properly, script will hang after finishing everything. This PR changes the vLLM thread to daemon thread so that atexit will be invoked to properly stop the driver. Tested that script can finish properly even when it's interrupted from keyboard.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
