### PR TITLE
Adding back test_logprobs_extraction_with_missing_token.

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -90,15 +90,11 @@ jobs:
     - name: Run tunix generation tests (PASSED only)
       run: |
         # tokenizer_adapter_test requires access to gated repo
-        # TODO(b/459824938) Add back test_logprobs_extraction_with_missing_token after fixing the issue
         python -m pytest tests/generate/ -v --tb=short \
           --ignore=tests/generate/vllm_sampler_test.py \
           --ignore=tests/generate/vllm_driver_test.py \
           --ignore=tests/generate/tokenizer_adapter_test.py \
-          --ignore=tests/generate/sglang_jax_sampler_test.py \
-          --ignore=tests/generate/utils_test.py
-
-        python -m pytest tests/generate/utils_test.py -k "not test_logprobs_extraction_with_missing_token"
+          --ignore=tests/generate/sglang_jax_sampler_test.py
 
     - name: Run tunix SFT tests
       run: |
@@ -130,7 +126,7 @@ jobs:
     runs-on: [linux-x86-ct5lp-224-8tpu]
     environment: testing
     container:
-      image: vllm/vllm-tpu:nightly-88f2071263f19a2f7c2e812036fc93537dd7a621
+      image: vllm/vllm-tpu:nightly
       options: --privileged
       env:
         CLOUD_TPU_ACCELERATOR: v5e-8

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -316,12 +316,10 @@ def get_logprobs_from_vllm_output(
     if tok_id in tok_logprobs:
       extracted.append(tok_logprobs[tok_id].logprob)
     else:
-      # TODO(b/459824938): Add back the value error after fixing the logprobs mismatch issue in vLLM
-      logging.warning(f"Token id {tok_id} not in the return log probs list {tok_logprobs}")
-      # raise ValueError(
-      #     f'The selected token id {tok_id} not in the return log probs list'
-      #     f' {tok_logprobs}'
-      # )
+      raise ValueError(
+          f'The selected token id {tok_id} not in the return log probs list'
+          f' {tok_logprobs}'
+      )
   return extracted
 
 


### PR DESCRIPTION
The issue is fixed in  https://github.com/vllm-project/tpu-inference/pull/1106/files#.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
