### PR TITLE
Minor Doc Fixes: Correct a typo and add a hyperlink.

### DIFF
--- a/tunix/rl/grpo/grpo_learner.py
+++ b/tunix/rl/grpo/grpo_learner.py
@@ -55,8 +55,9 @@ class GRPOConfig(algo_config_lib.AlgorithmConfig):
     loss_algo: The loss algorithm to use. To be deprecated.
     num_generations: The number of times the policy generates multiple responses
       for a given prompt within a single training step. This corresponds to 'G'
-      in Algorithm 1 in the paper. A higher value means more samples are used to
-      compute relative advantages.
+      in Algorithm 1 in the `paper
+      <https://arxiv.org/abs/2402.03300>`_.
+      A higher value means more samples are used to compute relative advantages.
     num_iterations: The number of iterations per batch (𝜇 in GRPO algo 1).
     beta: The coefficient for the KL divergence penalty (𝛽) in the GRPO loss
       function. This term prevents policy updates from deviating too far from

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -274,7 +274,7 @@ class PeftTrainer:
     """Clears the JIT cache of the train and eval step functions.
 
     This function should be called when the trainer is being reused after
-    overiding the training related states, for example, the loss function.
+    overriding the training related states, for example, the loss function.
     """
     self._jitted_train_step_fn = None
     self._jitted_eval_step_fn = None


### PR DESCRIPTION
This PR:
- Corrected a Typo in the `clear_jit_cache` method of `PeftTrainer` in `peft_trainer.py` file.
- Added a hyperlink to the original GRPO paper in the description of the arguments of `GRPOConfig` in the `grpo_learner.py` file for easy reference and attribution.