### PR TITLE
Support custom MaxText (vLLM) models in sampler and rollout.

### DIFF
--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -151,7 +151,7 @@ def selective_log_softmax(logits: jax.Array, input_ids: jax.Array) -> jax.Array:
     Selected log probabilities.
   """
   logps = jax.nn.log_softmax(logits, axis=-1)
-  per_token_logps = jnp.take_along_axis(logps, input_ids[..., None], axis=-1)
+  per_token_logps = jnp.take_along_axis(logps, input_ids.astype(jnp.int32)[..., None], axis=-1)
   return per_token_logps[..., 0]
 
 

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -153,6 +153,10 @@ class RolloutConfig:
   # Whether to enable deterministic sampling for SG-Lang JAX rollout engine.
   rollout_sglang_jax_enable_deterministic_sampling: bool = False
 
+  # Configs for MaxText/Custom Model support in vLLM rollout engine.
+  rollout_vllm_hf_config_path: str | None = None
+  rollout_vllm_additional_config: dict[str, Any] | None = None
+
 
 class BaseRollout(ABC):
   """Base RolloutWorker."""

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -55,6 +55,8 @@ class VllmRollout(base_rollout.BaseRollout):
             async_scheduling=rollout_config.rollout_vllm_async_scheduling,
             tensor_parallel_size=rollout_config.tensor_parallel_size,
             data_parallel_size=rollout_config.data_parallel_size,
+            hf_config_path=rollout_config.rollout_vllm_hf_config_path,
+            additional_config=rollout_config.rollout_vllm_additional_config,
         ),
     )
     state = nnx.state(model)


### PR DESCRIPTION
Enables direct weight synchronization and configuration for custom MaxText models within the vLLM sampler and rollout workers. This allows users to supply a `maxtext_config` via `additional_config` without needing explicit key mappings.

Resolves #\<issue_number_goes_here\>

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
