### PR TITLE
allow user to config project name and run name in wandb

### DIFF
--- a/tunix/cli/base_config.yaml
+++ b/tunix/cli/base_config.yaml
@@ -127,6 +127,8 @@ training_config: &base_training_config
     max_to_keep: 1
     save_interval_steps: 180
   metrics_logging_options:
+    project_name: "tunix"
+    run_name: ""
     log_dir: "/tmp/logging"
     flush_every_n_steps: 20
   profiler_options:

--- a/tunix/sft/metrics_logger.py
+++ b/tunix/sft/metrics_logger.py
@@ -25,6 +25,8 @@ class MetricsLoggerOptions:
   """Metrics Logger options."""
 
   log_dir: str
+  project_name: str = "tunix"
+  run_name: str = ""
   flush_every_n_steps: int = 100
   backend_factories: list[BackendFactory] | None = None
 
@@ -55,7 +57,7 @@ class MetricsLoggerOptions:
           )
       )
       try:
-        active_backends.append(WandbBackend(project="tunix"))
+        active_backends.append(WandbBackend(project=self.project_name, name=self.run_name))
       except ImportError:
         logging.info("WandbBackend skipped: 'wandb' library not installed.")
     return active_backends


### PR DESCRIPTION
<!--- Describe your changes in detail. -->

Previously the project name is hard-coded to tunix and run_name falls back to timestamp. Now we allow users to config that.

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
