### PR TITLE
fix the issue when eager mode jax is triggered in undesired places

### DIFF
--- a/tunix/generate/sampler.py
+++ b/tunix/generate/sampler.py
@@ -30,6 +30,7 @@ from flax.nnx import statelib
 import jax
 import jax.numpy as jnp
 import jaxtyping
+import numpy as np
 from tunix.generate import base_sampler
 from tunix.generate import utils
 import tunix.generate.beam_search as beam_search_lib
@@ -398,8 +399,8 @@ class Sampler(base_sampler.BaseSampler):
     """Tokenizes the input string."""
     input_ids = self.tokenizer.encode(input_string)
     bos_tok = [self.tokenizer.bos_id()] if self.tokenizer.bos_id() else []
-    input_ids = jnp.array(
-      self.tokenizer.dedup_bos_ids(bos_tok + input_ids), dtype=jnp.int32
+    input_ids = np.array(
+      self.tokenizer.dedup_bos_ids(bos_tok + input_ids), dtype=np.int32
     )
     return input_ids
 
@@ -764,6 +765,7 @@ class Sampler(base_sampler.BaseSampler):
           max_prompt_length,
           max_len,
       )
+      out_tokens, lengths = jax.device_get(out_tokens), jax.device_get(lengths)
       decoded_outputs = [
           self.tokenizer.decode(tokens[:length].tolist())
           for tokens, length in zip(out_tokens, lengths)

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -26,6 +26,7 @@ from flax import nnx
 import jax
 from jax import lax
 import jax.numpy as jnp
+import numpy as np
 
 
 def compute_attention_masks(
@@ -88,12 +89,12 @@ def next_power_of_2(x: int) -> int:
 
 
 def pad_to_length(
-    x: jax.Array,
+    x: np.ndarray,
     target_length: int,
     pad_value: int = 0,
     left=False,
     axis: int = 0,
-) -> jax.Array:
+) -> np.ndarray:
   """Pads a JAX array to a specified target length along a given axis.
 
   Args:
@@ -114,12 +115,12 @@ def pad_to_length(
 
   padding_shape = list(x.shape)
   padding_shape[axis] = target_length - length
-  padding = jnp.full(padding_shape, pad_value, dtype=x.dtype)
+  padding = np.full(padding_shape, pad_value, dtype=x.dtype)
 
   if left:
-    return jnp.concatenate([padding, x], axis=axis)
+    return np.concatenate([padding, x], axis=axis)
   else:
-    return jnp.concatenate([x, padding], axis=axis)
+    return np.concatenate([x, padding], axis=axis)
 
 
 def find_first_non_pad_idx(ids, pad_id):


### PR DESCRIPTION
Existing implementation will trigger the jax eager mode, which compiles many small pieces of code on-demand  (in order to get it run on TPU) at every training iteration. This will cause several issues:

## Before the fix:

- We see a lot of complains from wandb: WARNING Tried to log to step 0 that is less than the current step xxx. Steps must be monotonically increasing, so this data will be ignored. See https://wandb.me/define-metric to log data out of order.
This is because the jax compilation message also gets monitored and logged into wandb. But jax doesn't know the step and default step 0 is used. That's why it prints a lot of these warnings during training.

- TPU utilization: the eager mode especially the re-compilation at every iteration takes time, which can make things slow and lower the TPU utilization
<img width="539" height="263" alt="Screenshot 2025-12-04 at 2 07 00 AM" src="https://github.com/user-attachments/assets/07718fb5-f692-4bbd-813d-c1829fcc3079" />


- Probably too many cached binaries will be created until all kinds of shapes have been compiled.

## After the fix:

- wandb warning is gone

- TPU utilization is higher and it should run faster
<img width="351" height="273" alt="Screenshot 2025-12-04 at 2 04 34 AM" src="https://github.com/user-attachments/assets/f3730e14-4d95-4b37-9eaf-bc3ec6112d4c" />

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
