### PR TITLE
Support custom MaxText (vLLM) models in sampler and rollout.

### DIFF
--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -67,6 +67,8 @@ class VllmConfig:
   async_scheduling: bool = False
   tensor_parallel_size: int = -1
   data_parallel_size: int = -1
+  hf_config_path: Optional[Dict[str, Any]] = None
+  additional_config: Optional[Dict[str, Any]] = None
 
 
 class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
@@ -97,12 +99,12 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
 
     # vLLM DP only works with the new model design
     if config.data_parallel_size > 1:
-      os.environ["NEW_MODEL_DESIGN"] = "True"
+      os.environ["NEW_MODEL_DESIGN"] = "1"
 
     # tpu-inference backend recently removed this environment variable, however
     # still set it here for backward compatibility.
     if config.init_with_random_weights:
-      os.environ["JAX_RANDOM_WEIGHTS"] = "True"
+      os.environ["JAX_RANDOM_WEIGHTS"] = "1"
 
     self.tokenizer = tok_adapter.TokenizerAdapter(tokenizer)
     self.config = config
@@ -134,14 +136,38 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       filter_types: Optional[Tuple[Any, ...]] = None,
   ):
     del filter_types
-    utils.transfer_state_with_mappings(
-        src_state=updated_weights,
-        dst_state=self.transformer_state,
-        key_mappings=self.to_hf_key_mappings,
-        key_mapping_hook_fns=self.to_hf_hook_fns,
-        transpose_keys=self.to_hf_transpose_keys,
-        reshard_fn=reshard.reshard_pytree,
-    )
+
+    if self.to_hf_key_mappings:
+      # Mapped Weight Sync (e.g. Vanilla -> vLLM)
+      utils.transfer_state_with_mappings(
+          src_state=updated_weights,
+          dst_state=self.transformer_state,
+          key_mappings=self.to_hf_key_mappings,
+          key_mapping_hook_fns=self.to_hf_hook_fns,
+          transpose_keys=self.to_hf_transpose_keys,
+          reshard_fn=reshard.reshard_pytree,
+      )
+    else:
+      # Direct Weight Sync (e.g. MaxText -> MaxText)
+      logging.debug(
+          "No key mappings configuration found. Proceeding with direct structural "
+          "weight synchronization (assuming matching source/target structures)."
+      )
+
+      additional_config = self.config.additional_config or {}
+      if 'maxtext_config' not in additional_config:
+        raise ValueError(
+            "Direct weight synchronization is currently supported only for "
+            "MaxText models. The required 'maxtext_config' key is missing "
+            "from 'additional_config'."
+        )
+
+      utils.transfer_state_directly(
+          src_state=updated_weights,
+          dst_state=self.transformer_state,
+          reshard_fn=reshard.reshard_pytree,
+      )
+
 
   def load_checkpoint(self, path_or_weights: str | jaxtyping.PyTree):
     # TODO(b/434741253): Consider support orbax checkpoint loading
@@ -165,19 +191,15 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       tensor_parallel_size = total_mesh_devices
       data_parallel_size = 1
     elif config.tensor_parallel_size == -1:
-      tensor_parallel_size = (
-          total_mesh_devices // data_parallel_size
-      )
+      tensor_parallel_size = total_mesh_devices // data_parallel_size
     elif config.data_parallel_size == -1:
-      data_parallel_size = (
-          total_mesh_devices // tensor_parallel_size
-      )
+      data_parallel_size = total_mesh_devices // tensor_parallel_size
 
     args = {}
     # Init vLLM model with random weights to speed up bootstrap time, because
     # model weights are synced from trainer later on
     if config.init_with_random_weights:
-      args["load_format"]="dummy"
+      args["load_format"] = "dummy"
 
     args["model"] = config.model_version
     args["max_model_len"] = config.max_model_len
@@ -197,6 +219,15 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
             "device_indexes": device_indexes,
         }
     }
+
+    # Add support for "hf_config_path" and "additional_config" which are
+    # directly passed to vLLM engine and part of the vLLM config contract.
+    if config.hf_config_path:
+      args["hf_config_path"] = config.hf_config_path
+
+    if config.additional_config:
+      args["additional_config"].update(config.additional_config)
+
     return args
 
   def _build_engine_args(self) -> EngineArgs:

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -138,6 +138,10 @@ class RolloutConfig:
   # Whether to enable asynchronous scheduling for vLLM rollout engine.
   rollout_vllm_async_scheduling: bool = False
 
+  # Configs for MaxText/Custom Model support in vLLM rollout engine.
+  rollout_vllm_hf_config_path: str | None = None
+  rollout_vllm_additional_config: dict[str, Any] | None = None
+
   # SG-Lang JAX specific rollout configs.
 
   # Model version for SG-Lang JAX rollout engine.

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -55,6 +55,8 @@ class VllmRollout(base_rollout.BaseRollout):
             async_scheduling=rollout_config.rollout_vllm_async_scheduling,
             tensor_parallel_size=rollout_config.tensor_parallel_size,
             data_parallel_size=rollout_config.data_parallel_size,
+            hf_config_path=rollout_config.rollout_vllm_hf_config_path,
+            additional_config=rollout_config.rollout_vllm_additional_config,
         ),
     )
     state = nnx.state(model)


### PR DESCRIPTION
Enables direct weight synchronization and configuration for custom MaxText models within the vLLM sampler and rollout workers. This allows users to supply a `maxtext_config` via `additional_config` without needing explicit key mappings.

<!--- Describe your changes in detail. -->

This PR enables support for the MaxText on vLLM workstream, by allowing a MaxText native model served on vLLM to be used for RL sampling in Tunix. This feature allows for custom MaxText models, which do not have a corresponding huggingface implementation, to be finetuned using Tunix + vLLM.

To do this, this PR adds support for a few new config entries required to initialize the MaxText on vLLM model. Additionally, it adds a new weight sync mapping named  `transfer_state_directly` which is used when there is no mapping required to sync weights between vLLM and the trainer.

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->
For more details please refer to [go/maxtext-vllm-eng-plan](http://goto.google.com/maxtext-vllm-eng-plan)

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
