### PR TITLE
[Script] merge grpo_demo_sglang_jax_rollout.py into grpo_demo_llama3_qwen2.py

### DIFF
--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -694,13 +694,6 @@ if DO_MODEL_DISPLAY:
 
 show_hbm_usage("After creating the reference lora model")
 
-# Rollout mesh
-# rollout_mesh = jax.make_mesh(
-#     *ROLLOUT_MESH,
-#     devices=jax.devices()[ROLLOUT_DEVICE_START_IDX:ROLLOUT_DEVICE_END_IDX],
-#     axis_types=(jax.sharding.AxisType.Auto,) * len(ROLLOUT_MESH[0]),
-# )
-
 rollout_device_arrays = mesh_utils.create_device_mesh(
     ROLLOUT_MESH[0],
     devices=jax.devices()[ROLLOUT_DEVICE_START_IDX:ROLLOUT_DEVICE_END_IDX],
@@ -1004,19 +997,16 @@ def evaluate(
 show_hbm_usage("After creating a raw sampler")
 
 
-print(f"before initialize ckpt", flush=True)
 # Ckpt saving
 checkpointing_options = ocp.CheckpointManagerOptions(
     save_interval_steps=SAVE_INTERVAL_STEPS, max_to_keep=MAX_TO_KEEP
 )
-print(f"before initialize metrics_logger", flush=True)
 # Metrics logger
 metrics_logging_options = metrics_logger.MetricsLoggerOptions(
     log_dir="/tmp/tensorboard/grpo", flush_every_n_steps=20
 )
 
 
-print(f"before initialize optimizer", flush=True)
 show_hbm_usage("After creating a new rollout worker")
 # Optimizer, learning rate scheduler, gradient clipping
 optimizer = optax.adamw(
@@ -1117,7 +1107,6 @@ grpo_config = grpo_learner.GRPOConfig(
 )
 
 
-print(f"before initialize rlcluster", flush=True)
 # RL cluster
 rl_cluster = rl_cluster_lib.RLCluster(
     actor=training_model,
@@ -1126,7 +1115,6 @@ rl_cluster = rl_cluster_lib.RLCluster(
     cluster_config=cluster_config,
 )
 
-print(f"before initialize grpolearner", flush=True)
 # GRPO Trainer
 grpo_trainer = grpo_learner.GRPOLearner(
     rl_cluster=rl_cluster,
@@ -1141,7 +1129,6 @@ grpo_trainer = grpo_learner.GRPOLearner(
 
 show_hbm_usage("After creating the learner")
 
-print(f"before eval 1149", flush=True)
 
 rollout_sampler = rl_cluster._rollout._sampler  # pylint: disable=protected-access
 (eval_corr, eval_total, eval_accuracy, eval_partial_accuracy, eval_format_accuracy) = evaluate(  # pylint: disable=unbalanced-tuple-unpacking
@@ -1173,7 +1160,6 @@ print(
 
 show_hbm_usage("Right before training")
 with training_mesh:
-  print(f"before grpo_trainer.train", flush=True)
   grpo_trainer.train(train_dataset, eval_ds=val_dataset)
 
 # Load checkpoint first.

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -199,7 +199,6 @@ class RLCluster:
     self._init_backbone_sharing_map(actor, reference)
 
     self._default_memory_kind = jax.devices()[0].default_memory().kind
-    print(f"[RLCluster] before load_model for actor", flush=True)
     self.train_actor = self._load_model(actor, self.r2m[Role.ACTOR])
 
     if Role.ROLLOUT in self._backbone_sharing_map[Role.ACTOR]:
@@ -219,7 +218,6 @@ class RLCluster:
       # Provide initial weights for non vanilla rollout engines.
       self.rollout_actor = self.train_actor
 
-    print(f"[RLCluster] before load_model for ref", flush=True)
     if reference:
       self.reference = self._load_model(reference, self.r2m[Role.REFERENCE])
       if Role.REFERENCE in self._backbone_sharing_map[Role.ACTOR]:
@@ -231,14 +229,12 @@ class RLCluster:
           )
     else:
       self.reference = None
-    print(f"[RLCluster] before load_model for critic", flush=True)
     self.critic = (
         self._load_model(critic, self.r2m[Role.CRITIC]) if critic else None
     )
     if Role.CRITIC in self._backbone_sharing_map[Role.ACTOR]:
       critic_state = nnx.state(self.train_actor, filterlib.Not(nnx.LoRAParam))
       nnx.update(self.critic, critic_state)
-    print(f"[RLCluster] before load_model for reward", flush=True)
     self.reward = (
         self._load_model(reward, self.r2m[Role.REWARD]) if reward else None
     )
@@ -438,7 +434,6 @@ class RLCluster:
       else:
         raise ValueError("Rollout sglang jax model config is missing!")
 
-      print(f"[RLCluster] before initialize rollout", flush=True)
       self._rollout = sglang_jax_rollout.SglangJaxRollout(
           self.rollout_actor,
           self.tokenizer,
@@ -467,7 +462,6 @@ class RLCluster:
       raise NotImplementedError(
           f"Rollout engine {self.cluster_config.rollout_engine} not supported"
       )
-    print(f"[RLCluster] after initialize rollout", flush=True)
 
     # 2. Initialize inference worker.
     inference_models = {}
@@ -482,7 +476,6 @@ class RLCluster:
     self._inference_worker = inference_worker.InferenceWorker(inference_models)
 
     # 3. Initialize trainer.
-    print(f"[RLCluster] before initialize critic trainer", flush=True)
     if (
         self.critic
         and Role.CRITIC not in self._backbone_sharing_map[Role.ACTOR]
@@ -505,8 +498,6 @@ class RLCluster:
       )
       del self.critic
       self._maybe_offload_model_to_cpu(self._critic_trainer.model, Role.CRITIC)
-
-    print(f"[RLCluster] before initialize actor trainer", flush=True)
 
     self._maybe_load_model_from_cpu(self.train_actor, Role.ACTOR)
     actor_config = copy.deepcopy(self.cluster_config.training_config)


### PR DESCRIPTION
Resolves #867.

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).

**Results**

*Single Host with Pathways*

Environment: topology: 2x2, hosts: 1, machine_type: ct6e-standard-4t.

```bash
JAX_PLATFORMS=proxy \
JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 \
python3 scripts/grpo_demo_llama3_qwen2.py \
--num-batches 4 \
--num-test-batches 1  \
--root-dir=/home/gcpuser/aolemila \
--model-version=meta-llama/Llama-3.2-1B-Instruct \
--data-source tfds \
--dataset gsm8k \
--rollout-engine sglang_jax
```
<img width="1919" height="154" alt="image" src="https://github.com/user-attachments/assets/23a00c97-67ff-4baa-862e-74bb5fa65319" />


*Multi Hosts with Pathways*

Environment: topology: 4x4, hosts: 2, machine_type: ct6e-standard-4t.

```bash
JAX_PLATFORMS=proxy \
JAX_BACKEND_TARGET=grpc://127.0.0.1:29000 \
python3 scripts/grpo_demo_llama3_qwen2.py \
--num-batches 4 \
--num-test-batches 1  \
--root-dir=/home/gcpuser/aolemila \
--model-version=meta-llama/Llama-3.2-1B-Instruct \
--data-source tfds \
--dataset gsm8k \
--rollout-engine sglang_jax  \
--rollout-tp 8 \
--cluster-setup disaggregated-2-way
```

<img width="952" height="341" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/988abdb1-3b8f-4487-b0fa-ed96c91c1d50" />


Note: `--rollout-tp 8` and `--cluster-setup disaggregated-2-way` are required due to SGLangJax lacks to support DP now. It will support DP soon.