### PR TITLE
Update gitignore to ignore venv folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@
 /include/
 /lib/
 /share/
-
+.venv/
 # Documentation
 /docs/_build/
 /docs/_collections/


### PR DESCRIPTION
<img width="713" height="172" alt="image" src="https://github.com/user-attachments/assets/247cfbc6-107d-481e-91f3-a420581bf990" />

Hello, today i was just setting up the project locally on my windows system. 

Felt adding this to gitignore would be good for future 

Thanks!