### PR TITLE
Add Qwen3 235B-A22B model config

### DIFF
--- a/tunix/models/qwen3/model.py
+++ b/tunix/models/qwen3/model.py
@@ -172,6 +172,21 @@ class ModelConfig:
         num_experts_per_tok=8,
     )
 
+  @classmethod
+  def qwen3_235b_a22b(cls):  # qwen3-235B-A22B (MoE)
+    return cls(
+      num_layers=94,
+      vocab_size=151936,
+      embed_dim=4096,
+      hidden_dim=1536,
+      num_heads=64,
+      head_dim=128,
+      num_kv_heads=4,
+      norm_eps=1e-06,
+      rope_theta=1_000_000,
+      num_experts=128,
+      num_experts_per_tok=8,
+    )
 
 def shard(x: jnp.ndarray, s: Tuple[str, ...]):
   mesh = pxla.thread_resources.env.physical_mesh


### PR DESCRIPTION
Add model config for the Qwen3-235B-A22B MoE model. This is implemented as a new `qwen3_235b_a22b` classmethod on `tunix.models.qwen3.model.ModelConfig`, modeled after the existing `qwen3_30b` classmethod and parameterized from the upstream HF config.

**Reference**

The [raw specs from HF](https://huggingface.co/Qwen/Qwen3-235B-A22B/raw/main/config.json) are:
```
{
  "architectures": [
    "Qwen3MoeForCausalLM"
  ],
  "attention_bias": false,
  "attention_dropout": 0.0,
  "bos_token_id": 151643,
  "decoder_sparse_step": 1,
  "eos_token_id": 151645,
  "head_dim": 128,
  "hidden_act": "silu",
  "hidden_size": 4096,
  "initializer_range": 0.02,
  "intermediate_size": 12288,
  "max_position_embeddings": 40960,
  "max_window_layers": 94,
  "mlp_only_layers": [],
  "model_type": "qwen3_moe",
  "moe_intermediate_size": 1536,
  "norm_topk_prob": true,
  "num_attention_heads": 64,
  "num_experts": 128,
  "num_experts_per_tok": 8,
  "num_hidden_layers": 94,
  "num_key_value_heads": 4,
  "output_router_logits": false,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 1000000.0,
  "router_aux_loss_coef": 0.001,
  "sliding_window": null,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.51.0",
  "use_cache": true,
  "use_sliding_window": false,
  "vocab_size": 151936
}
```

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
