### PR TITLE
Add metrics support to CheckpointManager and PeftTrainer

### DIFF
--- a/tests/sft/peft_trainer_test.py
+++ b/tests/sft/peft_trainer_test.py
@@ -476,7 +476,11 @@ class PeftTrainerTest(parameterized.TestCase):
             mock.call.maybe_restore(mock.ANY, restore_only_lora_params=True),
             *[
                 mock.call.save(
-                    i, mock.ANY, save_only_lora_params=True, custom_metadata={}
+                    i,
+                    mock.ANY,
+                    save_only_lora_params=True,
+                    custom_metadata={},
+                    metrics=mock.ANY,
                 )
                 for i in expected_save_steps
             ],

--- a/tunix/sft/checkpoint_manager.py
+++ b/tunix/sft/checkpoint_manager.py
@@ -82,6 +82,7 @@ class CheckpointManager:
       save_only_lora_params: bool = False,
       force: bool = False,
       custom_metadata: dict[str, Any] | None = None,
+      metrics: dict[str, Any] | None = None,
   ) -> bool:
     """Saves the params for the given step.
 
@@ -92,6 +93,7 @@ class CheckpointManager:
       force: Whether to save the checkpoint regardless of the save decision
         policy.
       custom_metadata: Custom metadata to save with the checkpoint.
+      metrics: Metrics to save with the checkpoint.
 
     Returns:
       Whether the checkpoint was saved.
@@ -113,6 +115,7 @@ class CheckpointManager:
             model_params=checkpoint_args,
         ),
         custom_metadata=custom_metadata or {},
+        metrics=metrics,
         force=force,
     )
 

--- a/tunix/sft/metrics_logger.py
+++ b/tunix/sft/metrics_logger.py
@@ -151,6 +151,24 @@ class MetricsLogger:
       )
     return np.stack(self._metrics[metrics_prefix][mode][metric_name])
 
+  def get_latest_metrics(
+      self, metrics_prefix: str, mode: Mode | str
+  ) -> dict[str, float]:
+    """Returns the latest metrics for the given mode."""
+    if metrics_prefix not in self._metrics:
+      return {}
+    if mode not in self._metrics[metrics_prefix]:
+      return {}
+
+    metrics = {}
+    for metric_name in self._metrics[metrics_prefix][mode]:
+      values = self._metrics[metrics_prefix][mode][metric_name]
+      if values:
+        metrics[f"{metrics_prefix}/{mode}/{metric_name}"] = np.array(
+            values[-1]
+        ).item()
+    return metrics
+
   def close(self):
     """Closes all registered logging backends."""
     for backend in self._backends:


### PR DESCRIPTION
Enhance the CheckpointManager to support saving metrics alongside model checkpoints. Introduce a method in MetricsLogger to retrieve the latest metrics and integrate metrics logging during training and evaluation steps in PeftTrainer. This improves the tracking of model performance over time.


**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
