### PR TITLE
Fix AttributeError in is_positive_integer on Python 3.11

### DIFF
--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -31,11 +31,14 @@ import numpy as np
 Mesh = jax.sharding.Mesh
 NamedSharding = jax.sharding.NamedSharding
 
-
-def is_positive_integer(value: int | None, name: str):
+def is_positive_integer(value: int | float | None, name: str) -> None:
   """Checks if the value is a positive integer."""
-  if value is not None and value <= 0:
+  if value is not None and (not is_integer_value(value) or value <= 0):
     raise ValueError(f"{name} must be a positive integer. Got: {value}")
+
+def is_integer_value(value) -> bool:
+  """Checks if the value is an integer"""
+  return (isinstance(value, int) and not isinstance(value, bool)) or (isinstance(value, float) and value.is_integer())
 
 
 def check_divisibility(

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -33,8 +33,8 @@ NamedSharding = jax.sharding.NamedSharding
 
 
 def is_positive_integer(value: int | None, name: str):
-  """Checks if the value is positive."""
-  if value is not None and (not value.is_integer() or value <= 0):
+  """Checks if the value is a positive integer."""
+  if value is not None and value <= 0:
     raise ValueError(f"{name} must be a positive integer. Got: {value}")
 
 


### PR DESCRIPTION
Remove .is_integer() call as int.is_integer() was only added in Python 3.12.
pyproject.toml specifies: requires-python = ">=3.11", yet according to https://docs.python.org/3.12/library/stdtypes.html  `int.is_integer()` was only added in Python 3.12 for duck-type compatibility with `float.is_integer()

Resolves #\<[902](https://github.com/google/tunix/issues/902)\>




