### PR TITLE
refactor rl config: 1) remove unnecessary params; 2) model_config consistency

### DIFF
--- a/tunix/cli/base_config.yaml
+++ b/tunix/cli/base_config.yaml
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+################################# LoRa #################################
+_lora_config: &base_lora_config
+  module_path: ".*q_einsum|.*kv_einsum|.*gate_proj|.*down_proj|.*up_proj"
+  rank: 16
+  alpha: 2.0
+  weight_qtype: "nf4"
+  tile_size: 256
+
+################################## MESH ##################################
+_mesh: &base_mesh
+  shape: "(2,2)"
+  # "('fsdp',)"
+  axis_names: "('fsdp','tp')"
+
+
 ################################## LOAD MODEL ##################################
 model_config: &base_model_config
   # Specify model name in style of {model_version}-{model size}, this will use to invoke model config
@@ -45,28 +61,26 @@ model_config: &base_model_config
 
   # Directory used for NNX conversion if downloaded Gemma/Gemma2 from Kaggle source. 
   intermediate_ckpt_dir: "/tmp/intermediate_ckpt/"
-  ################################# LoRa #################################
-  lora_config:
-    module_path: ".*q_einsum|.*kv_einsum|.*gate_proj|.*down_proj|.*up_proj"
-    rank: 16
-    alpha: 2.0
-    weight_qtype: "nf4"
-    tile_size: 256
 
-  ################################## MESH ##################################
+  lora_config:
+    <<: *base_lora_config
   mesh:
-    shape: "(2,2)"
-    # "('fsdp',)"
-    axis_names: "('fsdp','tp')"
+    <<: *base_mesh
+
 
 actor_model_config:
-  <<: *base_model_config
+  lora_config:
+    <<: *base_lora_config
+  mesh:
+    <<: *base_mesh
 
 reference_model_config:
  <<: *base_model_config
 
 rollout_model_config:
- <<: *base_model_config
+  mesh:
+    <<: *base_mesh
+
 
 ################################## Tokenizer ##################################
 tokenizer_config:


### PR DESCRIPTION
There are actor_model_config, reference_model_config and rollout_model_config where there value might conflict with each other, if user don't overwrite them all explicitly. The benefits are:

# Consistency

Current
<img width="601" height="1158" alt="Screenshot 2025-12-20 at 3 38 54 PM" src="https://github.com/user-attachments/assets/6cc6c89e-cee1-4c02-a886-7dbe532a3f0a" />
where user overwrites the model to qwen-0.6b but the rest of the configs still show llama-8b, which is very confusing. 

After this patch
<img width="544" height="838" alt="Screenshot 2025-12-20 at 2 00 35 PM" src="https://github.com/user-attachments/assets/e861be44-5773-4c22-8865-f94fbc294cab" />

# Reusing checks in cli/config.py

A lot of checks / validations are based on model_config. Right now it seems for RL the config is set through reference_model_config. So to make it consistent, we can overwrite the model_config when no explicit configuration are set to model_config.

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
