### PR TITLE
fix(utils): correct positive integer validation

### DIFF
--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -34,7 +34,7 @@ NamedSharding = jax.sharding.NamedSharding
 
 def is_positive_integer(value: int | None, name: str):
   """Checks if the value is positive."""
-  if value is not None and (not value.is_integer() or value <= 0):
+  if value is not None and (not isinstance(value, int) or value <= 0):
     raise ValueError(f"{name} must be a positive integer. Got: {value}")
 
 


### PR DESCRIPTION
Fixes #902 

The previous implementation incorrectly called `is_integer()` on Python
ints, which raises an AttributeError. This change replaces the check
with a proper `isinstance(value, int)` validation.
