### PR TITLE
Fix the dataset post initialization

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -166,36 +166,15 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-
-          # Download GSM8K dataset
-          mkdir -p /tmp/grpo_test/rl/grpo/data
-          python3 -c "
-          from datasets import load_dataset
-          import json
-
-          # Download and save GSM8K train split
-          dataset = load_dataset('openai/gsm8k', 'main', split='train')
-          train_data = [{'question': item['question'], 'answer': item['answer']} for item in dataset]
-          with open('/tmp/grpo_test/rl/grpo/data/gsm8k_train.json', 'w') as f:
-              json.dump(train_data, f)
-
-          # Download and save GSM8K test split
-          dataset = load_dataset('openai/gsm8k', 'main', split='test')
-          test_data = [{'question': item['question'], 'answer': item['answer']} for item in dataset]
-          with open('/tmp/grpo_test/rl/grpo/data/gsm8k_test.json', 'w') as f:
-              json.dump(test_data, f)
-
-          print('GSM8K dataset downloaded successfully')
-          "
-
-          # TODO(lancewang): Re-enable this test once the segfault is fixed.
           # Run GRPO demo script with minimal configuration
-          # python3 scripts/grpo_demo_llama3_qwen2.py \
-          #   --root-dir=/tmp/grpo_test \
-          #   --model-version=Qwen/Qwen2.5-0.5B-Instruct \
-          #   --num-batches=1 \
-          #   --num-test-batches=1 \
-          #   --rollout-engine=vanilla
+          python3 scripts/grpo_demo_llama3_qwen2.py \
+            --root-dir=/tmp/grpo_test \
+            --num-batches=2 \
+            --num-test-batches=1 \
+            --global-batch-size=2 \
+            --train-mini-batch-size=2 \
+            --train-micro-batch-size=2 \
+            --rollout-engine=vanilla
       - name: Run vllm tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/tests/cli/utils/data_test.py
+++ b/tests/cli/utils/data_test.py
@@ -1,0 +1,181 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tunix.cli.utils.data.post_init_dataset."""
+
+from __future__ import annotations
+
+from absl.testing import absltest
+from tunix.cli.utils import data as data_lib
+
+
+class _FakeTokenizer:
+
+  def tokenize(self, text: str):
+    # Simple tokenization: one token per whitespace-separated chunk
+    return text.split()
+
+
+class _BaseDataset:
+  """Minimal dataset to mimic grain interfaces used in post_init_dataset."""
+
+  def __init__(self, records):
+    self._records = list(records)
+
+  def __len__(self):
+    return len(self._records)
+
+  def __getitem__(self, idx):
+    if isinstance(idx, slice):
+      return _BaseDataset(self._records[idx])
+    return self._records[idx]
+
+  def filter(self, fn):
+    return _BaseDataset([x for x in self._records if fn(x)])
+
+  def repeat(self, n):
+    return _RepeatDataset(self, n)
+
+  def to_iter_dataset(self):
+    return _IterDataset(self._records)
+
+  def map(self, fn):  # Not used in tests, but kept for fidelity.
+    return _BaseDataset([fn(x) for x in self._records])
+
+
+class _RepeatDataset:
+
+  def __init__(self, base: _BaseDataset, n: int):
+    self._base = base
+    self._n = n
+
+  def __len__(self):
+    return len(self._base) * self._n
+
+  def to_iter_dataset(self):
+    return _IterDataset(self._base._records * self._n)
+
+
+class _IterDataset:
+
+  def __init__(self, records):
+    self._records = list(records)
+
+  def batch(self, batch_size: int):
+    return _BatchedDataset(self._records, batch_size)
+
+
+class _BatchedDataset:
+
+  def __init__(self, records, batch_size: int):
+    self._records = records
+    self._batch_size = batch_size
+
+  def __iter__(self):
+    for i in range(0, len(self._records), self._batch_size):
+      yield self._records[i : i + self._batch_size]
+
+
+class PostInitDatasetTest(absltest.TestCase):
+
+  def test_filters_by_prompt_length(self):
+    tokenizer = _FakeTokenizer()
+    dataset = _BaseDataset([
+        {"prompts": "short", "answer": 1},
+        {"prompts": "this is too long", "answer": 2},
+    ])
+
+    first, second = data_lib.post_init_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        batch_size=2,
+        num_batches=None,
+        max_prompt_length=2,  # only the first record should remain
+    )
+
+    batches = list(first)
+    self.assertIsNone(second)
+    self.assertLen(batches, 1)
+    self.assertEqual(batches[0], [{"prompts": "short", "answer": 1}])
+
+  def test_limits_num_batches(self):
+    tokenizer = _FakeTokenizer()
+    dataset = _BaseDataset(
+        [{"prompts": f"p{i}", "answer": i} for i in range(10)]
+    )
+
+    first, _ = data_lib.post_init_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        batch_size=3,
+        num_batches=2,  # keep at most 2 batches * 3 = 6 examples
+        max_prompt_length=None,
+    )
+
+    batches = list(first)
+    self.assertLen(batches, 2)
+    self.assertEqual([len(b) for b in batches], [3, 3])
+    self.assertEqual(batches[0][0]["prompts"], "p0")
+    self.assertEqual(batches[-1][-1]["prompts"], "p5")
+
+  def test_fraction_split_and_repeat(self):
+    tokenizer = _FakeTokenizer()
+    dataset = _BaseDataset(
+        [{"prompts": f"p{i}", "answer": i} for i in range(8)]
+    )
+
+    first, second = data_lib.post_init_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        batch_size=2,
+        num_batches=None,
+        max_prompt_length=None,
+        fraction=0.5,
+        num_epochs=1,
+    )
+
+    first_batches = list(first)
+    second_batches = list(second)
+
+    self.assertLen(first_batches, 2)  # 4 items / batch_size 2
+    self.assertLen(second_batches, 2)  # remaining 4 items / batch_size 2
+    self.assertEqual(first_batches[0][0]["prompts"], "p0")
+    self.assertEqual(second_batches[-1][-1]["prompts"], "p7")
+
+  def test_num_epochs_repeats_dataset(self):
+    tokenizer = _FakeTokenizer()
+    dataset = _BaseDataset(
+        [{"prompts": "p0", "answer": 0}, {"prompts": "p1", "answer": 1}]
+    )
+
+    first, second = data_lib.post_init_dataset(
+        dataset,
+        tokenizer=tokenizer,
+        batch_size=1,
+        num_batches=None,
+        max_prompt_length=None,
+        num_epochs=3,
+    )
+
+    self.assertIsNone(second)
+    batches = list(first)
+    # 2 items * 3 epochs = 6 batches of size 1
+    self.assertLen(batches, 6)
+    self.assertEqual(
+        [b[0]["prompts"] for b in batches], ["p0", "p1", "p0", "p1", "p0", "p1"]
+    )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/examples/data/math_dataset_test.py
+++ b/tests/examples/data/math_dataset_test.py
@@ -1,0 +1,140 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tunix.examples.data.math_dataset.apply_template."""
+
+from __future__ import annotations
+
+from absl.testing import absltest
+from absl.testing import parameterized
+from tunix.examples.data import math_dataset
+
+
+class _FakeTokenizer:
+
+  def __init__(self, template_suffix=""):  # suffix helps distinguish calls
+    self.calls = []
+    self.template_suffix = template_suffix
+
+  def apply_chat_template(
+      self, msgs, tokenize=False, add_generation_prompt=True
+  ):
+    # Capture call arguments for assertion
+    self.calls.append({
+        "msgs": msgs,
+        "tokenize": tokenize,
+        "add_generation_prompt": add_generation_prompt,
+    })
+    # Return a simple rendered string to check wiring
+    user_msg = next(m["content"] for m in msgs if m["role"] == "user")
+    return f"templated:{user_msg}{self.template_suffix}"
+
+
+class _BaseDataset:
+
+  def __init__(self, records):
+    self._records = list(records)
+
+  def map(self, fn):
+    return _BaseDataset([fn(x) for x in self._records])
+
+  def __iter__(self):
+    return iter(self._records)
+
+  def __getitem__(self, idx):
+    return self._records[idx]
+
+
+class ApplyTemplateTest(parameterized.TestCase):
+
+  def test_with_tokenizer_uses_apply_chat_template_and_preserves_fields(self):
+    ds = _BaseDataset([
+        {"question": "Q1", "answer": "#### A1", "extra": 7},
+    ])
+    tok = _FakeTokenizer(template_suffix="!call")
+
+    out = math_dataset.apply_template(
+        ds, tokenizer=tok, tokenize=True, add_generation_prompt=False
+    )
+    result = out[0]
+
+    # Prompts rendered via tokenizer
+    self.assertEqual(result["prompts"], "templated:Q1!call")
+    # Original fields preserved
+    self.assertEqual(result["question"], "Q1")
+    self.assertEqual(result["answer"], "A1")
+    # Extra fields are dropped by apply_template
+    self.assertNotIn("extra", result)
+
+    # Tokenizer called once with expected messages and flags
+    self.assertLen(tok.calls, 1)
+    call = tok.calls[0]
+    self.assertEqual(call["tokenize"], True)
+    self.assertEqual(call["add_generation_prompt"], False)
+    self.assertEqual(len(call["msgs"]), 2)
+    self.assertEqual(call["msgs"][1]["content"], "Q1")
+    self.assertIn(math_dataset.SYSTEM_PROMPT, call["msgs"][0]["content"])
+
+  def test_without_tokenizer_falls_back_to_plain_template(self):
+    ds = _BaseDataset([
+        {"question": "Q2", "answer": "#### A2"},
+    ])
+
+    out = math_dataset.apply_template(
+        ds, tokenizer=None, tokenize=False, add_generation_prompt=True
+    )
+    result = out[0]
+
+    # Prompts rendered via fallback TEMPLATE
+    self.assertIn("<start_of_turn>user", result["prompts"])
+    self.assertIn("Q2", result["prompts"])
+    self.assertIn(math_dataset.SYSTEM_PROMPT, result["prompts"])
+    self.assertEqual(result["answer"], "A2")
+
+  def test_no_valid_answer(self):
+    ds = _BaseDataset([
+        {"question": "Q2", "answer": "A2"},
+    ])
+
+    out = math_dataset.apply_template(
+        ds, tokenizer=None, tokenize=False, add_generation_prompt=True
+    )
+    result = out[0]
+
+    # Prompts rendered via fallback TEMPLATE
+    self.assertIn("<start_of_turn>user", result["prompts"])
+    self.assertIn("Q2", result["prompts"])
+    self.assertIn(math_dataset.SYSTEM_PROMPT, result["prompts"])
+    self.assertIsNone(result["answer"])
+
+  @parameterized.parameters(True, False)
+  def test_bytes_are_decoded_to_str(self, use_tokenizer):
+    ds = _BaseDataset([
+        {"question": b"byte-q", "answer": b"#### byte-a"},
+    ])
+    tok = _FakeTokenizer() if use_tokenizer else None
+
+    out = math_dataset.apply_template(
+        ds, tokenizer=tok, tokenize=False, add_generation_prompt=True
+    )
+    result = out[0]
+
+    self.assertIsInstance(result["question"], str)
+    self.assertIsInstance(result["answer"], str)
+    self.assertEqual(result["question"], "byte-q")
+    self.assertEqual(result["answer"], "byte-a")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tunix/cli/grpo_main.py
+++ b/tunix/cli/grpo_main.py
@@ -137,7 +137,7 @@ class GrpoPipeline(config.HyperParameters):
           dataset=self.config["dataset_name"],
           tfds_download=self.config["tfds_download"],
       )
-    dataset = data_lib.post_init_dataset(
+    dataset, _ = data_lib.post_init_dataset(
         dataset,
         tokenizer,
         batch_size=self.config["batch_size"],


### PR DESCRIPTION
The nightly regression script is broken due to the recent changes to create_dataset. In the script we split the train dataset and validation dataset. However, post_init_dataset creates the IterDataset which can't be random accessed and split like that. 

1. Refactored the post_init_dataset to include the validation dataset split and epoch repeat. 
2. Refactored the apply_template to include both custom template and transformer tokenizer provided template.
3. Add extensive tests for apply_template and post_init_dataset
4. The reason why the script was broken silently is because it's not included in the CI. Add the minimal run to CI to avoid future breakage.

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
