### PR TITLE
Fix broken example script references in CLI README

### DIFF
--- a/tunix/cli/README.md
+++ b/tunix/cli/README.md
@@ -15,9 +15,9 @@ The Python scripts in this folder are the entry points for initiating training a
 ## Usage
 While you can run these scripts directly, the intended workflow is to use the wrapper scripts in the examples folder. These examples show how to pass the correct arguments and configurations for various use cases.
 
-For sft, we provide scripts running on mtnt translation dataset. See available [scripts](examples/sft/mtnt)
+For sft, we provide scripts running on mtnt translation dataset. See available [scripts](../../examples/sft/mtnt)
 
-For rl, we provide scripts running grpo on gsm8k math dataset. See available [scripts](examples/rl/gsm8k)
+For rl, we provide scripts running grpo on gsm8k math dataset. See available [scripts](../../examples/rl/gsm8k)
 
 For launching shell scripts from examples, you would navigate to the examples directory and execute a script like this:
 


### PR DESCRIPTION
This PR fixes incorrect references in `tunix/cli/README.md` to example scripts that do not exist in the repository.

The README previously pointed to `examples/sft/mtnt` and `examples/rl/gsm8k`.
These links have been replaced with the correct references `../../examples/sft/mtnt` and  `../../examples/rl/gsm8k` respectively.
