### PR TITLE
enable proper report for learning rate during training

### DIFF
--- a/tunix/cli/config.py
+++ b/tunix/cli/config.py
@@ -462,9 +462,12 @@ class HyperParameters:
     opt_kwargs = self._extract_kwargs(
         opt_func, optimizer_config, config_path_info, learning_rate_val
     )
+    # Wrap the optimizer function with inject_hyperparams so that
+    # the learning rate can be tracked and logged during training.
+    injected_opt_func = optax.inject_hyperparams(opt_func)
     # Call the optimizer function with the extracted kwargs
     try:
-      return opt_func(**opt_kwargs)
+      return injected_opt_func(**opt_kwargs)
     except TypeError as e:
       raise TypeError(
           f"Error calling {opt_type} with arguments {opt_kwargs}. "


### PR DESCRIPTION
The learning rate was not displayed in the dashboard previously. Adding the fix here to enable proper hook and display.
<img width="460" height="265" alt="Screenshot 2025-12-25 at 10 39 37 PM" src="https://github.com/user-attachments/assets/8648107e-f008-4cb0-8447-3ac1b8dcbcdd" />


**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
