### PR TITLE
Fix #802: Add google-cloud-storage and gcsfs to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
   "datasets",
   "flax>=0.11.1",
   "fsspec",  # notebook dependency
+  "gcsfs",  # Required for accessing gs:// URIs via fsspec
+  "google-cloud-storage",  # Required for GCS file operations in OSS environment
   "google-metrax>=0.2.3",
   "grain",
   "huggingface_hub",


### PR DESCRIPTION
Resolves #802

## Description

This PR fixes missing dependencies that caused `ImportError` when running example scripts in OSS environment.

**Issues Fixed:**
1. `ImportError: cannot import name 'storage' from 'google.cloud'` at `train_deepscaler_nb.py:151`
2. `ModuleNotFoundError: No module named 'gcsfs'` at `train_deepscaler_nb.py:234`

**Changes:**
- Added `google-cloud-storage` to dependencies (required for GCS file operations in OSS environment)
- Added `gcsfs` to dependencies (required for accessing `gs://` URIs via fsspec)

Both dependencies are used by example notebooks (`train_deepscaler_nb.py`, `math_eval_nb.py`) to access Google Cloud Storage buckets for data and models.

**Reference**
- Issue: #802
- Affected files: `examples/deepscaler/train_deepscaler_nb.py`, `examples/deepscaler/math_eval_nb.py`

**Colab Notebook**
N/A - This is a dependency fix, not a new API addition.

**Checklist**

- [ ] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
