### PR TITLE
fix: Add truncation support to pad_to_length for consistent prompt shapes

### DIFF
--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -94,6 +94,7 @@ def pad_to_length(
     pad_value: int = 0,
     left=False,
     axis: int = 0,
+    truncate: bool = False,
 ) -> np.ndarray:
   """Pads a numpy array to a specified target length along a given axis.
 
@@ -103,14 +104,30 @@ def pad_to_length(
       pad_value: The value to use for padding (default: 0).
       left: If True, add padding tokens to the left of the array.
       axis: The axis along which to pad (default: 0).
+      truncate: If True, truncate x if it's longer than target_length.
+        When left=True, keeps the last target_length elements (left truncation).
+        When left=False, keeps the first target_length elements (right truncation).
 
   Returns:
-      A new numpy array that is padded to the target length along the specified
-      axis. Returns original array if it is already longer than the target
-      length.
+      A new numpy array that is padded/truncated to the target length along
+      the specified axis. If truncate=False and x is longer than target_length,
+      returns x unchanged.
   """
   length = x.shape[axis]
   if length >= target_length:
+    if truncate:
+      # Truncate to target_length
+      if left:
+        # Keep the last target_length elements (for prompts, keep the end)
+        start_idx = length - target_length
+        indices = [slice(None)] * x.ndim
+        indices[axis] = slice(start_idx, None)
+        return x[tuple(indices)]
+      else:
+        # Keep the first target_length elements
+        indices = [slice(None)] * x.ndim
+        indices[axis] = slice(0, target_length)
+        return x[tuple(indices)]
     return x
 
   padding_shape = list(x.shape)


### PR DESCRIPTION
## Problem

When `max_prompt_length` is explicitly specified (e.g., 128), the sampler could produce inconsistent prompt shapes across batches:

1. `pad_to_length()` in `generate/utils.py` returned inputs unchanged if they exceeded `target_length`
2. The sampler auto-increased `max_prompt_length` via `next_power_of_2()` when prompts were longer
3. Different micro-batches could have different prompt shapes (e.g., batch 1: `(N, 128)`, batch 2: `(N, 256)`)
4. `rl_cluster.generate()` failed when concatenating micro-batch outputs due to shape mismatch


## Solution

### 1. Add `truncate` parameter to `pad_to_length()` (`generate/utils.py`)

```python
def pad_to_length(x, target_length, pad_value=0, left=False, axis=0, truncate=False):
    # When truncate=True and left=True: keeps last target_length elements
    # When truncate=True and left=False: keeps first target_length elements
```

### 2. Update sampler to use truncation when length is specified (`generate/sampler.py`)

```python
user_specified_length = max_prompt_length is not None
if max_prompt_length is None or max_prompt_length < max_tokens_length:
    if user_specified_length:
        pass  # Keep user-specified length, will truncate
    else:
        max_prompt_length = utils.next_power_of_2(max_tokens_length)

all_input_ids = np.array([
    utils.pad_to_length(x, ..., truncate=user_specified_length)
    for x in tokens
])
```

## Backward Compatibility

- If `max_prompt_length` is `None`, the sampler still auto-sizes to accommodate all prompts (original behavior)
- If `max_prompt_length` is explicitly specified, it's now respected via truncation (new behavior)

## Testing

- All existing sampler tests pass
- All GRPO learner tests pass
- Verified truncation behavior with unit tests

## Related

Fixes the shape mismatch error when using `MAX_PROMPT_LENGTH <= 128` in GRPO training.