### PR TITLE
Apply transpose rule to safetensor saver function

### DIFF
--- a/tunix/models/gemma3/params.py
+++ b/tunix/models/gemma3/params.py
@@ -28,11 +28,9 @@ from flax import nnx
 import jax
 from jax import numpy as jnp
 from orbax import checkpoint as ocp
+import sentencepiece as spm
 from tunix.models import safetensors_saver
 from tunix.models.gemma3 import model as model_lib
-
-import sentencepiece as spm
-
 
 # Pretrained
 GEMMA3_270M_PT = 'gs://gemma-data/checkpoints/gemma3-270m-pt'
@@ -188,6 +186,17 @@ def _gemma3_state_key_to_safetensors_key(lora_name: str) -> str:
   )
 
 
+_GEMMA3_HUGGINGFACE_TRANSPOSE_RULES = {
+    'q_proj': (1, 0),
+    'k_proj': (1, 0),
+    'v_proj': (1, 0),
+    'o_proj': (1, 0),
+    'up_proj': (1, 0),
+    'down_proj': (1, 0),
+    'gate_proj': (1, 0),
+}
+
+
 def save_lora_merged_model_as_safetensors(
     local_model_path: str,
     output_dir: str,
@@ -212,4 +221,5 @@ def save_lora_merged_model_as_safetensors(
       alpha=alpha,
       state_key_transform_fn=_gemma3_state_key_to_safetensors_key,
       custom_layer_extractor_fn=_extract_gemma3_lora_layers,
+      transpose_rules=_GEMMA3_HUGGINGFACE_TRANSPOSE_RULES,
   )

--- a/tunix/models/qwen3/params.py
+++ b/tunix/models/qwen3/params.py
@@ -141,6 +141,18 @@ def _qwen3_state_key_to_safetensors_key(lora_name: str) -> str:
   return f"model.{lora_name}.weight".replace(".attn.", ".self_attn.")
 
 
+_QWEN3_HUGGINGFACE_TRANSPOSE_RULES = {
+    "q_proj": (1, 0),
+    "k_proj": (1, 0),
+    "v_proj": (1, 0),
+    "o_proj": (1, 0),
+    "up_proj": (1, 0),
+    "down_proj": (1, 0),
+    "gate_proj": (1, 0),
+    "gate": (1, 0),
+}
+
+
 def save_lora_merged_model_as_safetensors(
     local_model_path: str,
     output_dir: str,
@@ -164,4 +176,5 @@ def save_lora_merged_model_as_safetensors(
       rank=rank,
       alpha=alpha,
       state_key_transform_fn=_qwen3_state_key_to_safetensors_key,
+      transpose_rules=_QWEN3_HUGGINGFACE_TRANSPOSE_RULES,
   )


### PR DESCRIPTION
The current safetensor saver blindly saves merged tensor with tranpose. The transposition should be applied based on the huggingface vs tunix model implementation. This PR applies the transposition based on transpose rule instead, makes the logic more robust. The existing test covers saving and loading the checkpoint back.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
