### PR TITLE
[Distillation] Enhanced Logit Strategy with Top-K and Metrics

### DIFF
--- a/tunix/distillation/strategies/base_strategy.py
+++ b/tunix/distillation/strategies/base_strategy.py
@@ -58,13 +58,13 @@ class BaseStrategy(ABC):
   @abstractmethod
   def compute_loss(
       self, student_output: Any, teacher_output: Any, labels: jax.Array
-  ) -> jax.Array:
+  ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array]]:
     """Computes the distillation loss based on model outputs and labels."""
 
   @abstractmethod
   def compute_eval_loss(
       self, student_output: Any, labels: jax.Array
-  ) -> jax.Array:
+  ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array]]:
     """Computes the distillation loss based on model outputs and labels."""
 
   def pre_process_models(
@@ -129,7 +129,7 @@ class BaseStrategy(ABC):
       student_model: nnx.Module,
       teacher_output: Any,
       inputs: dict[str, jax.Array],
-  ) -> jax.Array:
+  ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array]]:
     """Computes the distillation loss."""
     student_output = self.get_student_outputs(student_model, inputs)
     labels = self._labels_fn(**inputs)
@@ -143,7 +143,7 @@ class BaseStrategy(ABC):
       self,
       student_model: nnx.Module,
       inputs: dict[str, jax.Array],
-  ) -> jax.Array:
+  ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array]]:
     """Computes the task loss based on student model forward pass and labels."""
     student_output = self.get_student_outputs(student_model, inputs)
     student_output = jax.lax.stop_gradient(student_output)


### PR DESCRIPTION
Updates `LogitStrategy` to support top-k filtering for faster convergence and detailed metric logging.

### Changes
* **LogitStrategy:** Added `distill_top_k` argument. This filters teacher logits to the top K most probable tokens before KL divergence, reducing noise from the vocabulary tail.
* **Metrics:** Updated `compute_loss` to return a `(loss, metrics)` tuple. New metrics include:
    * `distill/soft_loss`
    * `distill/hard_loss`
    * `distill/kl_div`
    * `distill/teacher_loss`
* **Trainer:** Enabled `self._has_aux = True` in `DistillationTrainer` to support strategies returning auxiliary metrics.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/CONTRIBUTING.md).
