### PR TITLE
[Tunix] Support scanned to unscanned weight transfer in transfer_state_directly

### DIFF
--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -15,6 +15,7 @@
 
 """Utility functions for sampler."""
 
+from collections import abc
 import functools
 import gc
 import logging
@@ -23,6 +24,7 @@ import re
 from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple
 
 from flax import nnx
+from flax import traverse_util
 import jax
 from jax import lax
 import jax.numpy as jnp
@@ -756,6 +758,70 @@ def transfer_state_with_mappings(
   return dst_state.from_flat_path(tgt_flat_list)
 
 
+def _slice_scanned_param(
+    src_val: jax.Array | np.ndarray | Any,
+    tgt_val: jax.Array | np.ndarray | Any,
+    slice_idx: int,
+    key_path: str,
+) -> jax.Array | np.ndarray | Any:
+  """Slices a scanned parameter dynamically detecting the scan axis.
+
+  This helper finds the dimension in src_val that needs to be sliced to match
+  tgt_val's shape. It is used when transferring weights from a scanned
+  representation (e.g., MaxText) to an unrolled one (e.g., vLLM).
+
+  Args:
+      src_val: The source array (scanned) to slice from.
+      tgt_val: The target array whose shape we want to match.
+      slice_idx: The index along the scanned axis to extract.
+      key_path: The dot-separated path to the parameter for debugging.
+
+  Returns:
+      The sliced array matching the target shape, or the original src_val if
+      slicing failed or was unnecessary.
+  """
+  if not (hasattr(src_val, 'shape') and hasattr(tgt_val, 'shape')):
+    return src_val
+
+  src_shape = src_val.shape
+  tgt_shape = tgt_val.shape
+
+  if src_shape == tgt_shape:
+    return src_val
+
+  if len(src_shape) == len(tgt_shape) + 1:
+    scan_axis = None
+    # Check which dimension, when removed, matches the target shape
+    for i in range(len(src_shape)):
+      if src_shape[:i] + src_shape[i + 1 :] == tgt_shape:
+        scan_axis = i
+        break
+
+    if scan_axis is not None:
+      # Construct slice: (:, :, slice_idx, :, :)
+      slicer = [slice(None)] * len(src_shape)
+      slicer[scan_axis] = slice_idx
+      return src_val[tuple(slicer)]
+
+    logging.warning(
+        "Shape mismatch in scanned param '%s'. Src: %s, Tgt: %s. Cannot"
+        ' determine scan axis.',
+        key_path, src_shape, tgt_shape,
+    )
+
+  # Fallback to direct slicing if the above logic fails, which may work for simple cases
+  try:
+    return src_val[slice_idx]
+
+  except (IndexError, TypeError) as e:
+    logging.debug(
+        "Direct slicing fallback failed for '%s' (slice_idx=%d). "
+        "Error: %s. Using original value.",
+        key_path, slice_idx, e
+    )
+    return src_val
+
+
 def transfer_state_directly(
     src_state: Mapping[str, Any],
     dst_state: Mapping[str, Any],
@@ -783,14 +849,14 @@ def transfer_state_directly(
     return hasattr(obj, key)
 
   # Unwrap Source (Remove 'base' wrapper from MaxText)
-  if isinstance(src_state, (dict, nnx.State, nnx.Dict)) and safe_has_key(
+  if isinstance(src_state, abc.Mapping) and safe_has_key(
       src_state, 'base'
   ):
     logging.info("Unwrapping 'base' key from source state.")
     src_state = src_state['base']
 
   # Unwrap Target (Remove nested 'model' wrappers from vLLM)
-  while isinstance(dst_state, (dict, nnx.State, nnx.Dict)) and safe_has_key(
+  while isinstance(dst_state, abc.Mapping) and safe_has_key(
       dst_state, 'model'
   ):
     logging.info("Unwrapping nested 'model' key from target state.")
@@ -802,11 +868,9 @@ def transfer_state_directly(
     # Unwrap NNX containers
     if hasattr(node, 'to_pure_dict'):
       node = node.to_pure_dict()
-    elif isinstance(node, (nnx.Dict, nnx.State)):
-      node = dict(node)
 
     # Recurse into dicts
-    if isinstance(node, dict):
+    if isinstance(node, abc.Mapping):
       return {k: to_pure_spec(v) for k, v in node.items()}
 
     # Unwrap Variables
@@ -817,44 +881,88 @@ def transfer_state_directly(
 
     return node
 
-  # Helper: Intersect Trees (Handle KVCache/RNG mismatches)
   def intersect_trees(
-      src: Any, tgt_spec: Any, path: str = ''
-  ) -> Tuple[Any, Any]:
-    # Stop recursion if we hit a leaf (non-dict)
-    if not isinstance(src, dict) or not isinstance(tgt_spec, dict):
+      src: Mapping[str, Any],
+      tgt_spec: Mapping[str, Any],
+  ) -> Tuple[Mapping[str, Any], Mapping[str, Any]]:
+    """Optimized intersection (Handle KVCache/RNG mismatches and Scanned Layers).
+
+    Uses flat dictionary traversal for efficiency.
+    """
+    # Fast path for non-dict inputs (leaves)
+    if not isinstance(src, abc.Mapping) or not isinstance(tgt_spec, abc.Mapping):
       return src, tgt_spec
 
-    src_keys = set(src.keys())
-    tgt_keys = set(tgt_spec.keys())
-    common_keys = src_keys & tgt_keys
+    # Flatten both structures to (path_tuple) -> value
+    # usage of sep='/' is optional, but tuples are faster for manipulation
+    src_flat = traverse_util.flatten_dict(src)
+    tgt_flat = traverse_util.flatten_dict(tgt_spec)
 
-    # Debug Logging for dropped keys
-    if src_keys - tgt_keys:
-      logging.debug(
-          "Ignored checkpoint keys at '%s': %s", path, src_keys - tgt_keys
-      )
-    if tgt_keys - src_keys:
-      logging.debug(
-          "Unmatched model keys at '%s': %s", path, tgt_keys - src_keys
-      )
+    filtered_src_flat = {}
+    filtered_tgt_flat = {}
 
-    filtered_src = {}
-    filtered_tgt = {}
+    # Compile regex once
+    layer_pattern = re.compile(r'^layers_(\d+)$')
 
-    for k in common_keys:
-      new_path = f'{path}/{k}' if path else k
-      s_val, t_val = intersect_trees(src[k], tgt_spec[k], new_path)
-      filtered_src[k] = s_val
-      filtered_tgt[k] = t_val
+    for key_tuple, tgt_val in tgt_flat.items():
+      # Try Direct Match
+      if key_tuple in src_flat:
+        filtered_src_flat[key_tuple] = src_flat[key_tuple]
+        filtered_tgt_flat[key_tuple] = tgt_val
+        continue
 
-    return filtered_src, filtered_tgt
+      # Try Scanned Layer Mapping
+      # We look for 'layers_X' in the path and try to map it to 'layers' (MaxText)
+      # or remove it (GPT-OSS / implicit stack).
+
+      # Locate which part of the path is 'layers_X'
+      layer_idx = -1
+      match_index = -1
+
+      for i, part in enumerate(key_tuple):
+        # Optimization: Only check strings that look like layers
+        if isinstance(part, str) and part.startswith('layers_'):
+          m = layer_pattern.match(part)
+          if m:
+            layer_idx = int(m.group(1))
+            match_index = i
+            break
+
+      if match_index != -1:
+        # Check different candidate path formats for scanned layers
+        # Candidate A: Replace 'layers_X' with 'layers' (Standard MaxText)
+        candidate_a = list(key_tuple)
+        candidate_a[match_index] = 'layers'
+
+        # Candidate B: Remove 'layers_X' (Implicit Container / GPT-OSS)
+        candidate_b = list(key_tuple)
+        candidate_b.pop(match_index)
+
+        found_candidate = None
+        for cand in [tuple(candidate_a), tuple(candidate_b)]:
+          if cand in src_flat:
+            found_candidate = cand
+            break
+
+        if found_candidate:
+          src_val = src_flat[found_candidate]
+          filtered_src_flat[key_tuple] = _slice_scanned_param(
+              src_val, tgt_val, layer_idx, str(key_tuple)
+          )
+          filtered_tgt_flat[key_tuple] = tgt_val
+          continue
+
+    # Unflatten back to nested structure
+    return (
+        traverse_util.unflatten_dict(filtered_src_flat),
+        traverse_util.unflatten_dict(filtered_tgt_flat),
+    )
 
   # Prepare clean source and target specs
   full_source_dict = to_pure_spec(src_state)
   full_target_spec = to_pure_spec(dst_state)
 
-  # Filter both to their intersection
+  # Filter both to their intersection / mapping
   final_source, final_spec = intersect_trees(full_source_dict, full_target_spec)
 
   # Reshard and Update
@@ -863,6 +971,10 @@ def transfer_state_directly(
       target=final_spec,
   )
   nnx.update(dst_state, resharded_weights)
+
+  # Explicitly free memory
+  del final_source
+  gc.collect()
 
 
 def verify_state_closeness(golden_state, state, atol=1e-2):


### PR DESCRIPTION
This PR extends the `transfer_state_directly` utility to support weight synchronization from scanned MaxText model (where layers are stacked in a single tensor) to unscanned MaxText + vLLM models (where layers are separate parameters).

Previously, `transfer_state_directly` only supported 1-to-1 mapping (Unscanned -> Unscanned). This change adds logic to detect and unroll scanned layers during the transfer process.

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
