### PR TITLE
Add qwen3 vllm/sglang weight mapping support

### DIFF
--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ from tunix.models.llama3 import model as llama_lib
 from tunix.models.llama3 import params as llama_params
 from tunix.models.qwen2 import model as qwen2_lib
 from tunix.models.qwen2 import params as qwen2_params
+from tunix.models.qwen3 import model as qwen3_lib
+from tunix.models.qwen3 import params as qwen3_params
 from tunix.rl import rl_cluster as rl_cluster_lib
 from tunix.rl.grpo import grpo_learner
 from tunix.rl.rollout import base_rollout
@@ -645,6 +647,7 @@ MODEL_CONFIG = {
     "meta-llama/Llama-3.1-8B-Instruct": llama_lib.ModelConfig.llama3p1_8b,
     "Qwen/Qwen2.5-0.5B-Instruct": qwen2_lib.ModelConfig.qwen2p5_0p5b,
     "Qwen/Qwen2.5-7B-Instruct": qwen2_lib.ModelConfig.qwen2p5_7b,
+    "Qwen/Qwen3-4B-Instruct-2507": qwen3_lib.ModelConfig.qwen3_4b,
 }
 
 
@@ -655,6 +658,10 @@ def get_trainer_model(ckpt_path, model_mesh, ref_model_config):
     )
   elif "Qwen2.5" in HF_MODEL_VERSION:
     return qwen2_params.create_model_from_safe_tensors(
+        ckpt_path, ref_model_config, model_mesh
+    )
+  elif "Qwen3" in HF_MODEL_VERSION:
+    return qwen3_params.create_model_from_safe_tensors(
         ckpt_path, ref_model_config, model_mesh
     )
   raise NotImplementedError(

--- a/tunix/models/qwen3/__init__.py
+++ b/tunix/models/qwen3/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Qwen2 API."""
+
+from tunix.models.qwen3 import mapping_sglang_jax
+from tunix.models.qwen3 import mapping_vllm_jax
+from tunix.models.qwen3 import model
+from tunix.models.qwen3 import params
+
+BACKEND_MAPPINGS = {
+    'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
+    'sglang_jax': mapping_sglang_jax.SGLANG_JAX_MAPPING,
+}
+
+
+__all__ = ['BACKEND_MAPPINGS', 'model', 'params']

--- a/tunix/models/qwen3/mapping_sglang_jax.py
+++ b/tunix/models/qwen3/mapping_sglang_jax.py
@@ -1,0 +1,214 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mappings for converting Qwen3 weights to the Sglang-jax JAX backend."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Tuple
+
+from tunix.utils.env_utils import SGLANG_JAX_TP_AXIS_NAME
+
+Sharding = Tuple[str | None, ...]
+MappingEntry = Tuple[str, Sharding]
+
+
+def _to_sglang_jax_mappings() -> Dict[str, MappingEntry]:
+  return {
+      'lm_head.w': ('lm_head.embedding', (None, SGLANG_JAX_TP_AXIS_NAME)),
+      'embedder.input_embedding': (
+          'model.embed_tokens.embedding',
+          (SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.input_layernorm.w': (
+          'model.layers.*.input_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.mlp.down_proj.kernel': (
+          'model.layers.*.mlp.down_proj.weight',
+          (SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.mlp.gate_proj.kernel': (
+          'model.layers.*.mlp.gate_proj.weight',
+          (None, SGLANG_JAX_TP_AXIS_NAME),
+      ),
+      'layers.*.mlp.up_proj.kernel': (
+          'model.layers.*.mlp.up_proj.weight',
+          (None, SGLANG_JAX_TP_AXIS_NAME),
+      ),
+      'layers.*.post_attention_layernorm.w': (
+          'model.layers.*.post_attention_layernorm.scale',
+          (None,),
+      ),
+      'layers.*.attn.k_norm.w': (
+          'model.layers.*.self_attn.k_norm.scale',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.k_proj.w': (
+          'model.layers.*.self_attn.k_proj.weight',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.k_bias': (
+          'model.layers.*.self_attn.k_proj.bias',
+          (None,),
+      ),
+      'layers.*.attn.o_proj.w': (
+          'model.layers.*.self_attn.o_proj.weight',
+          (SGLANG_JAX_TP_AXIS_NAME, None, None),
+      ),
+      'layers.*.attn.q_norm.w': (
+          'model.layers.*.self_attn.q_norm.scale',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.q_proj.w': (
+          'model.layers.*.self_attn.q_proj.weight',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.q_bias': (
+          'model.layers.*.self_attn.q_proj.bias',
+          (None,),
+      ),
+      'layers.*.attn.v_proj.w': (
+          'model.layers.*.self_attn.v_proj.weight',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.v_bias': (
+          'model.layers.*.self_attn.v_proj.bias',
+          (None,),
+      ),
+      'final_norm.w': ('model.norm.scale', (None,)),
+  }
+
+
+def _lora_to_sglang_jax_mappings() -> Dict[str, MappingEntry] | None:
+  """The lora parameter key mapping between Tunix vanilla model and Sglang-jax Jax backend"""
+  return {
+      'layers.*.mlp.gate_proj.kernel_lora_a': (
+          'model.layers.*.mlp.gate_proj.A_buffer',
+          (None, None, None),
+      ),
+      'layers.*.mlp.gate_proj.kernel_lora_b': (
+          'model.layers.*.mlp.gate_proj.B_buffer',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.mlp.up_proj.kernel_lora_a': (
+          'model.layers.*.mlp.up_proj.A_buffer',
+          (None, None, None),
+      ),
+      'layers.*.mlp.up_proj.kernel_lora_b': (
+          'model.layers.*.mlp.up_proj.B_buffer',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.mlp.down_proj.kernel_lora_a': (
+          'model.layers.*.mlp.down_proj.A_buffer',
+          (None, None, SGLANG_JAX_TP_AXIS_NAME),
+      ),
+      'layers.*.mlp.down_proj.kernel_lora_b': (
+          'model.layers.*.mlp.down_proj.B_buffer',
+          (None, None, None),
+      ),
+      'layers.*.attn.q_proj.w_lora_a': (
+          'model.layers.*.self_attn.q_proj.A_buffer',
+          (None, None, None),
+      ),
+      'layers.*.attn.q_proj.w_lora_b': (
+          'model.layers.*.self_attn.q_proj.B_buffer',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.k_proj.w_lora_a': (
+          'model.layers.*.self_attn.k_proj.A_buffer',
+          (None, None, None),
+      ),
+      'layers.*.attn.k_proj.w_lora_b': (
+          'model.layers.*.self_attn.k_proj.B_buffer',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.v_proj.w_lora_a': (
+          'model.layers.*.self_attn.v_proj.A_buffer',
+          (None, None, None),
+      ),
+      'layers.*.attn.v_proj.w_lora_b': (
+          'model.layers.*.self_attn.v_proj.B_buffer',
+          (None, SGLANG_JAX_TP_AXIS_NAME, None),
+      ),
+      'layers.*.attn.o_proj.w_lora_a': (
+          'model.layers.*.self_attn.o_proj.A_buffer',
+          (None, None, SGLANG_JAX_TP_AXIS_NAME),
+      ),
+      'layers.*.attn.o_proj.w_lora_b': (
+          'model.layers.*.self_attn.o_proj.B_buffer',
+          (None, None, None),
+      ),
+  }
+
+
+def _to_sglang_jax_transpose_keys():
+  return {
+      'lm_head.w': (1, 0),
+  }
+
+
+def _to_sglang_jax_lora_transpose_keys():
+  """
+  Tunix -> SGLangJax:
+  gate_lora_a: (hidden_size, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  gate_lora_b: (max_lora_rank, intermediate_size) -> (1, intermediate_size, max_lora_rank)
+  up_lora_a: (hidden_size, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  up_lora_b: (max_lora_rank, intermediate_size) -> (1, intermediate_size, max_lora_rank)
+  down_lora_a: (intermediate_size, max_lora_rank) -> (1, max_lora_rank, intermediate_size)
+  down_lora_b: (max_lora_rank, hidden_size) -> (1, hidden_size, max_lora_rank)
+  q_lora_a: (hidden_size, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  q_lora_b: (max_lora_rank, num_attention_heads, head_dim) -> (1, hidden_size, max_lora_rank)
+  k_lora_a: (hidden_size, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  k_lora_b: (max_lora_rank, num_key_value_heads, head_dim) -> (1, num_key_value_heads*head_dim, max_lora_rank)
+  v_lora_a: (hidden_size, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  v_lora_b: (max_lora_rank, num_key_value_heads, head_dim) -> (1, num_key_value_heads*head_dim, max_lora_rank)
+  o_lora_a: (num_attention_heads, head_dim, max_lora_rank) -> (1, max_lora_rank, hidden_size)
+  o_lora_b: (max_lora_rank, hidden_size) -> (1, hidden_size, max_lora_rank)
+  """
+  return {
+      'layers.*.mlp.gate_proj.kernel_lora_a': (0, 2, 1),
+      'layers.*.mlp.gate_proj.kernel_lora_b': (0, 2, 1),
+      'layers.*.mlp.up_proj.kernel_lora_a': (0, 2, 1),
+      'layers.*.mlp.up_proj.kernel_lora_b': (0, 2, 1),
+      'layers.*.mlp.down_proj.kernel_lora_a': (0, 2, 1),
+      'layers.*.mlp.down_proj.kernel_lora_b': (0, 2, 1),
+      'layers.*.attn.q_proj.w_lora_a': (0, 2, 1),
+      'layers.*.attn.q_proj.w_lora_b': (0, 2, 3, 1),
+      'layers.*.attn.k_proj.w_lora_a': (0, 2, 1),
+      'layers.*.attn.k_proj.w_lora_b': (0, 2, 3, 1),
+      'layers.*.attn.v_proj.w_lora_a': (0, 2, 1),
+      'layers.*.attn.v_proj.w_lora_b': (0, 2, 3, 1),
+      'layers.*.attn.o_proj.w_lora_a': (0, 3, 2, 1),
+      'layers.*.attn.o_proj.w_lora_b': (0, 2, 1),
+  }
+
+
+def _to_sglang_jax_hook_fns() -> Dict[str, Any] | None:
+  """Additional parameter manipulation hook between Tunix vanilla model and Sglang Jax backend"""
+  return None
+
+
+SGLANG_JAX_MAPPING: Dict[str, Any] = {
+    'to_hf_mappings': _to_sglang_jax_mappings(),
+    'lora_to_hf_mappings': _lora_to_sglang_jax_mappings(),
+    'to_hf_transpose_keys': _to_sglang_jax_transpose_keys(),
+    'lora_to_hf_transpose_keys': _to_sglang_jax_lora_transpose_keys(),
+    'to_hf_hook_fns': _to_sglang_jax_hook_fns(),
+}
+
+__all__ = [
+    'SGLANG_JAX_MAPPING',
+]

--- a/tunix/models/qwen3/mapping_vllm_jax.py
+++ b/tunix/models/qwen3/mapping_vllm_jax.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM JAX backend mappings for Qwen2 models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+Sharding = Tuple[str | None, ...]
+MappingEntry = Tuple[str, Sharding]
+
+
+TO_HF_MAPPINGS: Dict[str, MappingEntry] = {
+    'embedder.input_embedding': ('model.embed.embedding', ('model', None)),
+    'layers.*.input_layernorm.w': (
+        'model.layers.*.input_layernorm.scale',
+        (None,),
+    ),
+    'layers.*.mlp.down_proj.kernel': (
+        'model.layers.*.mlp.down_proj.kernel',
+        ('model', None),
+    ),
+    'layers.*.mlp.gate_proj.kernel': (
+        'model.layers.*.mlp.gate_proj.kernel',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.up_proj.kernel': (
+        'model.layers.*.mlp.up_proj.kernel',
+        (None, 'model'),
+    ),
+    'layers.*.post_attention_layernorm.w': (
+        'model.layers.*.post_attention_layernorm.scale',
+        (None,),
+    ),
+    'layers.*.attn.k_proj.w': (
+        'model.layers.*.self_attn.k_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.k_norm.w': (
+        'model.layers.*.self_attn.k_norm.scale',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.o_proj.w': (
+        'model.layers.*.self_attn.o_proj.kernel',
+        ('model', None, None),
+    ),
+    'layers.*.attn.q_proj.w': (
+        'model.layers.*.self_attn.q_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.q_norm.w': (
+        'model.layers.*.self_attn.q_norm.scale',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.v_proj.w': (
+        'model.layers.*.self_attn.v_proj.kernel',
+        (None, 'model', None),
+    ),
+    'layers.*.attn.q_bias': (
+        'model.layers.*.self_attn.q_proj.bias',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias': (
+        'model.layers.*.self_attn.k_proj.bias',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias': (
+        'model.layers.*.self_attn.v_proj.bias',
+        ('model', None),
+    ),
+    'final_norm.w': ('model.norm.scale', (None,)),
+    'lm_head.w': ('lm_head', (None, 'model')),
+}
+
+
+LORA_TO_HF_MAPPINGS: Dict[str, MappingEntry] = {
+    'layers.*.mlp.gate_proj.kernel_lora_a': (
+        'model.layers.*.mlp.gate_proj.kernel_lora_a',
+        (None, None),
+    ),
+    'layers.*.mlp.gate_proj.kernel_lora_b': (
+        'model.layers.*.mlp.gate_proj.kernel_lora_b',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.up_proj.kernel_lora_a': (
+        'model.layers.*.mlp.up_proj.kernel_lora_a',
+        (None, None),
+    ),
+    'layers.*.mlp.up_proj.kernel_lora_b': (
+        'model.layers.*.mlp.up_proj.kernel_lora_b',
+        (None, 'model'),
+    ),
+    'layers.*.mlp.down_proj.kernel_lora_a': (
+        'model.layers.*.mlp.down_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.mlp.down_proj.kernel_lora_b': (
+        'model.layers.*.mlp.down_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.q_proj.w_lora_a': (
+        'layers.*.self_attn.q_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.q_proj.w_lora_b': (
+        'layers.*.self_attn.q_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.k_proj.w_lora_a': (
+        'layers.*.self_attn.k_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.k_proj.w_lora_b': (
+        'layers.*.self_attn.k_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.v_proj.w_lora_a': (
+        'layers.*.self_attn.v_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.v_proj.w_lora_b': (
+        'layers.*.self_attn.v_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.o_proj.w_lora_a': (
+        'layers.*.self_attn.o_proj.kernel_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.o_proj.w_lora_b': (
+        'layers.*.self_attn.o_proj.kernel_lora_b',
+        (None, None),
+    ),
+    'layers.*.attn.q_bias_lora_a': (
+        'model.layers.*.self_attn.q_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.q_bias_lora_b': (
+        'model.layers.*.self_attn.q_proj.bias_lora_b',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias_lora_a': (
+        'model.layers.*.self_attn.k_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.k_bias_lora_b': (
+        'model.layers.*.self_attn.k_proj.bias_lora_b',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias_lora_a': (
+        'model.layers.*.self_attn.v_proj.bias_lora_a',
+        ('model', None),
+    ),
+    'layers.*.attn.v_bias_lora_b': (
+        'model.layers.*.self_attn.v_proj.bias_lora_b',
+        ('model', None),
+    ),
+}
+
+
+VLLM_JAX_MAPPING: Dict[str, Any] = {
+    'to_hf_mappings': TO_HF_MAPPINGS,
+    'lora_to_hf_mappings': LORA_TO_HF_MAPPINGS,
+    'to_hf_transpose_keys': {'embedding': (1, 0)},
+    'to_hf_hook_fns': None,
+}
+
+__all__ = [
+    'VLLM_JAX_MAPPING',
+]

--- a/tunix/models/qwen3/model.py
+++ b/tunix/models/qwen3/model.py
@@ -25,9 +25,9 @@ from jax import numpy as jnp
 from jax.interpreters import pxla
 import jax.sharding as shd
 import jaxtyping
+from tunix.generate.mappings import BackendMappingMixin
 from tunix.utils import compat
 from tunix.utils import env_utils
-
 
 env_utils.setup_sharding_environment()
 
@@ -659,7 +659,7 @@ class DecoderLayer(nnx.Module):
     return cache, outputs
 
 
-class Qwen3(nnx.Module):
+class Qwen3(BackendMappingMixin, nnx.Module):
   """Qwen3 model."""
 
   def __init__(


### PR DESCRIPTION
This PR adds tunix to vllm/sglang weight transfer mapping. Model loading and rollout makes sense, but running on v5e-8 hits the OOM issue for peft train_step compilation:

jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: Error loading program 'jit__train_step': Attempting to reserve 10.47G at the bottom of memory. That was not possible. There are 7.34G free, 0B reserved, and 7.34G reservable.: while running replica 0 and partition 0 of a replicated computation (other replicas may have failed as well).

Command:
python scripts/grpo_demo_llama3_qwen2.py --root-dir=/scratch  --num-batches=20 --num-test-batches=4 --rollout-engine=sglang_jax  --cluster-setup=colocated  --log-level=INFO --model-version="Qwen/Qwen3-4B-Instruct-2507"

Both vLLM and SGLang hit the same error, so it's Tunix's issue. It has nothing to do with mapping. Should fix separately.


<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
