### PR TITLE
Use the rollout engine construct mesh.

### DIFF
--- a/tests/generate/sglang_jax_sampler_test.py
+++ b/tests/generate/sglang_jax_sampler_test.py
@@ -130,6 +130,7 @@ class SglangJaxSamplerTest(absltest.TestCase):
         tokenizer=model_tokenizer,
         config=sglang_jax_config,
     )
+    self.assertNotEqual(sgl_sampler.mesh, self.mesh)
     state = nnx.state(tunix_model)
     sgl_sampler.load_checkpoint(state)
 

--- a/tunix/generate/sglang_jax_sampler.py
+++ b/tunix/generate/sglang_jax_sampler.py
@@ -228,6 +228,18 @@ class SglangJaxSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-nam
       return None
 
   @property
+  def mesh(self) -> jax.sharding.Mesh:
+    if hasattr(self._model_runner, "mesh") and isinstance(
+        self._model_runner.mesh, jax.sharding.Mesh
+    ):
+      return self._model_runner.mesh
+    else:
+      raise AttributeError(
+          "SGLang model runner doesn't have mesh or mesh is not a"
+          " jax.sharding.Mesh."
+      )
+
+  @property
   def transformer(self):
     # sglang-jax doesn't expose the underlying model
     return None

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -38,7 +38,6 @@ from vllm.outputs import RequestOutput
 from vllm.sampling_params import BeamSearchParams
 from vllm.sampling_params import SamplingParams
 
-
 # Colocate vllm engine and worker in the main process
 os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 
@@ -130,6 +129,18 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     # lora.
     if config.lora_config and config.mapping_config.lora_to_hf_mappings:
       self.to_hf_key_mappings |= config.mapping_config.lora_to_hf_mappings
+
+  @property
+  def mesh(self) -> jax.sharding.Mesh:
+    if hasattr(self._model_runner, "mesh") and isinstance(
+        self._model_runner.mesh, jax.sharding.Mesh
+    ):
+      return self._model_runner.mesh
+    else:
+      raise AttributeError(
+          "vLLM model runner doesn't have mesh or mesh is not a"
+          " jax.sharding.Mesh."
+      )
 
   # TODO(b/434969743): Optimize weight sharing between trainer and vllm sampler.
   # TODO(b/434975493): Consider Release KV cache on the fly

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -143,7 +143,7 @@ class RolloutConfig:
   rollout_vllm_additional_config: dict[str, Any] | None = None
 
   # Whether to enable data parallel in attention for vLLM rollout engine.
-  # The "attn_dp" mesh axis is used when the degree of tensor parallelism 
+  # The "attn_dp" mesh axis is used when the degree of tensor parallelism
   # specified is more than the number of KV heads in the model. Enabling this
   # allows for non-attention tensors to be sharded across "attn_dp" and "model"
   # axes, which can help reduce memory usage for large models with few KV heads.
@@ -256,3 +256,8 @@ class BaseRollout(ABC):
   @abstractmethod
   def model(self) -> Any:
     """Returns the rollout model."""
+
+  @property
+  def mesh(self) -> Optional[jax.sharding.Mesh]:
+    """Returns the mesh used by the rollout model, if applicable."""
+    return None

--- a/tunix/rl/rollout/sglang_jax_rollout.py
+++ b/tunix/rl/rollout/sglang_jax_rollout.py
@@ -35,7 +35,6 @@ class SglangJaxRollout(base_rollout.BaseRollout):
       mesh: jax.sharding.Mesh,
       rollout_config: base_rollout.RolloutConfig,
   ):
-    self.mesh = mesh
     mapping_config = mappings.MappingConfig.build(
         mapping_obj=rollout_config.rollout_mapping_config,
         model=model,

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -35,9 +35,10 @@ class VllmRollout(base_rollout.BaseRollout):
       mesh: jax.sharding.Mesh,
       rollout_config: base_rollout.RolloutConfig,
   ):
-    self.mesh = mesh
     mapping_config = mappings.MappingConfig.build(
-        mapping_obj=rollout_config.rollout_mapping_config, model=model, backend="vllm_jax",
+        mapping_obj=rollout_config.rollout_mapping_config,
+        model=model,
+        backend="vllm_jax",
     )
     self._sampler = vllm_sampler.VllmSampler(
         tokenizer=tokenizer,
@@ -64,6 +65,10 @@ class VllmRollout(base_rollout.BaseRollout):
     )
     state = nnx.state(model)
     self._sampler.load_checkpoint(state)
+
+  @property
+  def mesh(self) -> Optional[jax.sharding.Mesh]:
+    return self._sampler.mesh
 
   def generate(
       self,

--- a/tunix/tests/test_common.py
+++ b/tunix/tests/test_common.py
@@ -28,11 +28,11 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import qwix
+import sentencepiece as spm
 import tenacity
 from tunix.rl import reshard
+from tunix.utils import compat
 from tunix.utils import env_utils
-
-import sentencepiece as spm
 
 env_utils.setup_sharding_environment()
 
@@ -122,7 +122,7 @@ class ToyTransformer(nnx.Module):
   ):
     self.config = config
     self.emb = nnx.Embed(config.vocab_size, 16, rngs=rngs)
-    self.layers = nnx.List(
+    self.layers = compat.ModuleList(
         [Decoder(rngs=rngs) for _ in range(config.num_layers)]
     )
     self.lm_head = nnx.Linear(


### PR DESCRIPTION
We see quite a few breakages around how mesh is constructed differently in rollout engine. This PR fixes this issue by using the mesh constructed by rollout engine to get rid of this discrepancies completely.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
