### PR TITLE
Supports padding kwargs for samplers.

### DIFF
--- a/tests/generate/sglang_jax_sampler_test.py
+++ b/tests/generate/sglang_jax_sampler_test.py
@@ -129,6 +129,8 @@ class SglangJaxSamplerTest(absltest.TestCase):
     sgl_sampler = sglang_jax_sampler.SglangJaxSampler(
         tokenizer=model_tokenizer,
         config=sglang_jax_config,
+        # Test kwargs forwarding
+        disable_precompile=False,
     )
     self.assertNotEqual(sgl_sampler.mesh, self.mesh)
     state = nnx.state(tunix_model)

--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -177,6 +177,7 @@ class VllmSamplerTest(absltest.TestCase):
     vl_sampler = vllm_sampler.VllmSampler(
         tokenizer=model_tokenizer,
         config=vllm_config,
+        enable_prefix_caching=True,  # Test kwargs forwarding
     )
     # vLLM construct its own mesh
     self.assertNotEqual(vl_sampler.mesh, self.mesh)

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -157,6 +157,9 @@ class RolloutConfig:
   # Maximum number of concurrent sequences allowed to be processed in vLLM.
   rollout_vllm_max_num_seqs: Optional[int] = None
 
+  # Additional keyword arguments forwarded directly to the vLLM sampler/engine.
+  rollout_vllm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+
   # SG-Lang JAX specific rollout configs.
 
   # Model version for SG-Lang JAX rollout engine.
@@ -214,6 +217,11 @@ class RolloutConfig:
 
   # The log level of sglang_jax
   rollout_sglang_jax_log_level: Optional[str] = "info"
+
+  # Additional keyword arguments forwarded directly to the SG-Lang JAX sampler/engine.
+  rollout_sglang_jax_kwargs: dict[str, Any] = dataclasses.field(
+      default_factory=dict
+  )
 
 
 class BaseRollout(ABC):

--- a/tunix/rl/rollout/sglang_jax_rollout.py
+++ b/tunix/rl/rollout/sglang_jax_rollout.py
@@ -65,6 +65,7 @@ class SglangJaxRollout(base_rollout.BaseRollout):
             max_running_requests=rollout_config.rollout_sglang_jax_max_running_requests,
             log_level=rollout_config.rollout_sglang_jax_log_level,
         ),
+        **rollout_config.rollout_sglang_jax_kwargs,
     )
     state = nnx.state(model)
     self._sampler.load_checkpoint(state)
@@ -86,6 +87,7 @@ class SglangJaxRollout(base_rollout.BaseRollout):
         seed=rollout_config.seed,
         echo=False,
         pad_output=True,
+        **kwargs,
     )
 
     return base_rollout.RolloutOutput(

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -62,6 +62,7 @@ class VllmRollout(base_rollout.BaseRollout):
             hf_config_path=rollout_config.rollout_vllm_hf_config_path,
             additional_config=rollout_config.rollout_vllm_additional_config,
         ),
+        **rollout_config.rollout_vllm_kwargs,
     )
     state = nnx.state(model)
     self._sampler.load_checkpoint(state)
@@ -87,6 +88,7 @@ class VllmRollout(base_rollout.BaseRollout):
         seed=rollout_config.seed,
         echo=False,
         pad_output=True,
+        **kwargs,
     )
 
     return base_rollout.RolloutOutput(


### PR DESCRIPTION
We've been keeps updating vllm/sglang config to accept missing kwargs. This PR fixes this issue by wiring kwargs directly to the engine. For other configs that requires special handling, still need manual logic in the rollout or sampler, which is acceptable. So now you can pass in additional kwargs like following:

e.g. For SGLang:
```
    config = base_rollout.RolloutConfig(
        max_tokens_to_generate=TOTAL_GENERATION_STEPS,
        ...
        rollout_sglang_jax_mem_fraction_static=0.2,
        ...
        rollout_sglang_jax_kwargs={"disable_precompile": True},
    )
```

For vLLM:
```
base_rollout.RolloutConfig(
      max_tokens_to_generate=TOTAL_GENERATION_STEPS,
      ...
      rollout_vllm_model_version=VLLM_MODEL_VERSION,
      ...
      rollout_vllm_kwargs={"enable_prefix_cache": False},
  )
```

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
