### PR TITLE
Adding dtype casting for direct state transfer.

### DIFF
--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -915,7 +915,11 @@ def transfer_state_directly(
     for key_tuple, tgt_val in tgt_flat.items():
       # Try Direct Match
       if key_tuple in src_flat:
-        filtered_src_flat[key_tuple] = src_flat[key_tuple]
+        src_val = src_flat[key_tuple]
+        if hasattr(src_val, 'dtype'):
+          src_val = _apply_dtype_cast(src_val, tgt_val.dtype, str(key_tuple))
+
+        filtered_src_flat[key_tuple] = src_val
         filtered_tgt_flat[key_tuple] = tgt_val
         continue
 
@@ -954,9 +958,16 @@ def transfer_state_directly(
 
         if found_candidate:
           src_val = src_flat[found_candidate]
-          filtered_src_flat[key_tuple] = _slice_scanned_param(
+          # Slice the scanned parameter
+          sliced_val = _slice_scanned_param(
               src_val, tgt_val, layer_idx, str(key_tuple)
           )
+          if hasattr(sliced_val, 'dtype'):
+            sliced_val = _apply_dtype_cast(
+                sliced_val, tgt_val.dtype, str(key_tuple)
+            )
+
+          filtered_src_flat[key_tuple] = sliced_val
           filtered_tgt_flat[key_tuple] = tgt_val
           continue
 


### PR DESCRIPTION
This PR adds support for dtype casting in the `direct_state_transfer` method if we have different dtypes for identical keys in source and target pytrees. This is useful for the case where we want to train a model with a certain dtype precision and then serve the same model with lower precision. 

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
