### PR TITLE
expert parallelism config in base rollout

### DIFF
--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -111,6 +111,7 @@ class RolloutConfig:
   # Parallelism configs.
   tensor_parallel_size: int = -1
   data_parallel_size: int = -1
+  expert_parallel_size: int = 1
 
   # vLLM specific rollout configs.
 

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -61,6 +61,7 @@ class VllmRollout(base_rollout.BaseRollout):
                 ),
                 "tensor_parallel_size": rollout_config.tensor_parallel_size,
                 "data_parallel_size": rollout_config.data_parallel_size,
+                "expert_parallel_size": rollout_config.expert_parallel_size,
                 "max_num_batched_tokens": (
                     rollout_config.rollout_vllm_max_num_batched_tokens
                 ),


### PR DESCRIPTION
- Add expert parallelism support for vLLM rollout: Introduces expert_parallel_size and enable_expert_parallelism configuration options across VllmConfig, RolloutConfig, and VllmRollout, enabling      
  expert-parallel sharding for Mixture-of-Experts (MoE) models.                                                                                                                                           
- Update device partitioning logic to account for expert parallelism: Tensor parallel and data parallel size calculations now divide by expert_parallel_size, ensuring correct device allocation when
  expert parallelism is enabled.
- Pass expert parallelism config into vLLM sharding strategy: When enable_expert_parallelism is set, the expert_parallelism size is included in the sharding strategy passed to vLLM's
  additional_config.
- Add stop strings support for vLLM sampling: Introduces stop_strings config option (rollout_vllm_stop_strings) that allows specifying custom stop strings for generation, with automatic detokenization
   enabled when stop strings are set
   

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
