### PR TITLE
Use Exception instead BaseException in Tunix

### DIFF
--- a/tunix/generate/vllm_async_driver.py
+++ b/tunix/generate/vllm_async_driver.py
@@ -73,7 +73,7 @@ class VLLMInProcessDriver:
     self._log_stats_interval_s: float = log_stats_interval_s
 
     self._pending: Dict[str, RequestFuture] = {}
-    self._last_error: Optional[BaseException] = None
+    self._last_error: Optional[Exception] = None
 
     if auto_start:
       self.start()
@@ -157,7 +157,7 @@ class VLLMInProcessDriver:
     while not self._stop_event.is_set():
       try:
         self._llm_engine.do_log_stats()
-      except BaseException:  # pylint: disable=broad-exception-caught
+      except Exception:  # pylint: disable=broad-exception-caught
         logging.exception("log_stats failed")
       self._stop_event.wait(self._log_stats_interval_s)
 
@@ -214,7 +214,7 @@ class VLLMInProcessDriver:
             self._handle_output(output)
         else:
           time.sleep(self._poll_interval_s)
-    except BaseException as exc:  # pylint: disable=broad-exception-caught
+    except Exception as exc:  # pylint: disable=broad-exception-caught
       self._record_error(exc)
 
   def _wait_for_work(self) -> bool:
@@ -264,7 +264,7 @@ class VLLMInProcessDriver:
     )
     future.set_result(output)
 
-  def _record_error(self, exc: BaseException) -> None:
+  def _record_error(self, exc: Exception) -> None:
     logging.debug("VLLMInProcessDriver encountered an error: %s", exc)
     self._last_error = exc
     with self._engine_lock:
@@ -279,7 +279,7 @@ class VLLMInProcessDriver:
     return self._llm_engine
 
   @property
-  def last_error(self) -> Optional[BaseException]:
+  def last_error(self) -> Optional[Exception]:
     return self._last_error
 
   def __enter__(self) -> "VLLMInProcessDriver":

--- a/tunix/rl/agentic/queue_manager/group_queue_manager.py
+++ b/tunix/rl/agentic/queue_manager/group_queue_manager.py
@@ -15,11 +15,13 @@
 """Manages queues of trajectory items, grouping them by group_id and episode_id."""
 
 from __future__ import annotations
+
 import asyncio
 import collections
 from collections.abc import Hashable
 import dataclasses
 from typing import Deque, Dict, List, Optional
+
 from tunix.rl.agentic.agents import agent_types
 
 TrajectoryItem = agent_types.TrajectoryItem
@@ -46,12 +48,12 @@ class GroupQueueManager:
     self._buckets: Dict[Hashable, List[TrajectoryItem]] = {}
     self._ready_groups: Deque[List[TrajectoryItem]] = collections.deque()
     self._clearing = False
-    self._exc: Optional[BaseException] = None
+    self._exc: Optional[Exception] = None
     self._lock = asyncio.Lock()
     self._have_ready = asyncio.Event()
     self._batch_buf: List[TrajectoryItem] = []
 
-  async def put_exception(self, exc: BaseException):
+  async def put_exception(self, exc: Exception):
     self._exc = exc
     self._have_ready.set()
 
@@ -78,7 +80,7 @@ class GroupQueueManager:
       item: The TrajectoryItem to add.
 
     Raises:
-      BaseException: If an exception has been set via `put_exception`.
+      Exception: If an exception has been set via `put_exception`.
     """
     if self._clearing:
       return
@@ -138,5 +140,3 @@ class GroupQueueManager:
         out.extend(group[:room])
         self._batch_buf.extend(group[room:])
     return out
-
-


### PR DESCRIPTION
BaseException includes system interrupt and we don't have any logic that's necessary for this kind of scenarios. The exception handling logics here are simply logging. This PR switches to Exception for safer interrupt handling.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
