### PR TITLE
Set the max worker number in asyncio loop.

### DIFF
--- a/tunix/rl/experimental/agentic_rl_learner.py
+++ b/tunix/rl/experimental/agentic_rl_learner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import abc
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import copy
 import dataclasses
@@ -48,7 +49,6 @@ from tunix.rl.agentic.rewards import reward
 from tunix.rl.agentic.trajectory import trajectory_collect_engine
 from tunix.rl.queue import data_queue as queue_lib
 from tunix.sft import utils as sft_utils
-
 
 ArrayLike = typing.ArrayLike
 TrainingInputT = Dict[str, List[str] | ArrayLike]
@@ -220,6 +220,9 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
 
     def run_loop_forever():
       loop = agentic_utils.get_or_create_loop()
+      loop.set_default_executor(
+          ThreadPoolExecutor(max_workers=algo_config.max_concurrency + 1)
+      )
       loop_queue.put(loop)
       loop.run_forever()
 


### PR DESCRIPTION
Right now our asyncio loop is capped by the default max number of workers, which is 32. That aligns with what we observed in both sglang and vllm backend. This PR fixes the issue and now our agentic training loop is no longer capped by this any more.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
