### PR TITLE
Fix the wrong and broken links in README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ tuning workflows on top of the XLA and JAX infrastructure. See [Design Overview]
           Sequence Policy Optimization)
       -   [DAPO](https://arxiv.org/abs/2503.14476) (Direct Alignment via Preference
           Optimization)
-      -   [Dr.GRPO](https://arxiv.org/abs/2503.14476) (Distributionally Robust
+      -   [Dr.GRPO](https://arxiv.org/abs/2503.20783) (Distributionally Robust
           GRPO)
 -   **[Agentic RL](https://tunix.readthedocs.io/en/latest/agentic_rl.html)**:
     -   Multi-turn tool use
@@ -93,9 +93,8 @@ See [Models](https://tunix.readthedocs.io/en/latest/models.html) for a full list
 ## Contributing and Feedbacks
 We welcome contributions! As Tunix is in early development, the contribution
 process is still being formalized. A rough draft of the contribution process is
-present [here](https://github.com/google/tunix/blob/main/CONTRIBUTING.md). In
-the meantime, you can make feature requests, report issues and ask questions in
-our
+present [here](docs/contributing.md). In the meantime, you can make feature
+requests, report issues and ask questions in our
 [Tunix GitHub discussion forum](https://github.com/google/tunix/discussions).
 
 ## Collaborations and Partnership


### PR DESCRIPTION
- Link to the Dr.GRPO is redirecting to the research paper on DAPO instead of Dr.GRPO's.
- Link to the contributing.md is broken in README.md file.

This PR fixes the above two issues.

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
