### PR TITLE
feat: add DFT loss and refactor SFT losses into submodule

### DIFF
--- a/tests/sft/losses_test.py
+++ b/tests/sft/losses_test.py
@@ -1,0 +1,205 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SFT loss functions."""
+
+import os
+
+from absl.testing import absltest
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from tunix.sft import losses
+from tunix.sft import peft_trainer
+from tunix.tests import test_common as tc
+
+os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=4'
+
+
+def _dummy_gen_model_input_fn(x: peft_trainer.TrainingInput):
+  return {
+      'input_tokens': x.input_tokens,
+      'input_mask': x.input_mask,
+      'positions': jnp.arange(x.input_tokens.shape[1]),
+      'attention_mask': jnp.ones_like(x.input_tokens),
+  }
+
+
+def _dummy_datasets(batch_size: int, repeat: int = 1):
+  dummy_input = np.arange(128).reshape((-1, batch_size, 16))
+  return [
+      peft_trainer.TrainingInput(
+          input_tokens=x, input_mask=jnp.ones(x.shape, dtype=jnp.int32)
+      )
+      for x in dummy_input
+  ] * repeat
+
+
+def _make_model_and_inputs(seed=0):
+  model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(seed))
+  rng = jax.random.PRNGKey(42)
+  input_tokens = jax.random.randint(rng, (2, 16), 0, 256)
+  input_mask = jnp.ones((2, 16), dtype=jnp.int32)
+  positions = jnp.arange(16)
+  attention_mask = jnp.ones((2, 16), dtype=jnp.int32)
+  return model, input_tokens, input_mask, positions, attention_mask
+
+
+def _train_with_loss_fn(loss_fn):
+  config = peft_trainer.TrainingConfig(eval_every_n_steps=2, max_steps=100)
+  model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0))
+  trainer = peft_trainer.PeftTrainer(model, optax.sgd(1e-3), config)
+  trainer = trainer.with_gen_model_input_fn(
+      _dummy_gen_model_input_fn
+  ).with_loss_fn(loss_fn)
+  trainer.train(_dummy_datasets(batch_size=4))
+  return model, trainer
+
+
+class CrossEntropyLossFnTest(absltest.TestCase):
+  """Tests for cross_entropy_loss_fn (moved from peft_trainer)."""
+
+  def test_returns_scalar(self):
+    model, *args = _make_model_and_inputs()
+    loss = losses.cross_entropy_loss_fn(model, *args)
+    self.assertEqual(loss.shape, ())
+    self.assertGreater(float(loss), 0.0)
+
+  def test_training_updates_params(self):
+    model, trainer = _train_with_loss_fn(losses.cross_entropy_loss_fn)
+    original = jax.tree.map(
+        jnp.copy,
+        nnx.state(
+            tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0)),
+            nnx.Param,
+        ),
+    )
+    updated = nnx.state(model, nnx.Param)
+    jax.tree.map_with_path(tc.assert_not_equal, original, updated)
+
+
+class DFTRescaleTest(absltest.TestCase):
+  """Tests for the dft_rescale utility function."""
+
+  def test_non_negative(self):
+    xent = jnp.array([0.1, 0.5, 1.0, 2.0, 5.0])
+    rescaled = losses.dft_rescale(xent)
+    np.testing.assert_array_less(-1e-7, np.asarray(rescaled))
+
+  def test_less_than_or_equal_input(self):
+    """p(y_t) <= 1, so dft_rescale(xent) <= xent."""
+    xent = jnp.array([0.01, 0.1, 0.5, 1.0, 2.0, 5.0, 10.0])
+    rescaled = losses.dft_rescale(xent)
+    np.testing.assert_array_less(
+        np.asarray(rescaled), np.asarray(xent) + 1e-6
+    )
+
+  def test_zero_input(self):
+    xent = jnp.array([0.0, 0.0])
+    rescaled = losses.dft_rescale(xent)
+    np.testing.assert_allclose(np.asarray(rescaled), 0.0, atol=1e-7)
+
+  def test_uniform_distribution_ratio(self):
+    """For uniform predictions p=1/V, ratio should be exactly 1/V."""
+    vocab_size = 8
+    uniform_xent = jnp.array([jnp.log(vocab_size)])
+    rescaled = losses.dft_rescale(uniform_xent)
+    expected_ratio = 1.0 / vocab_size
+    actual_ratio = float(rescaled[0]) / float(uniform_xent[0])
+    self.assertAlmostEqual(actual_ratio, expected_ratio, places=5)
+
+  def test_stop_gradient_on_probability(self):
+    """Gradients must differ with and without stop_gradient on p(y_t)."""
+
+    def with_sg(xent):
+      return jnp.sum(losses.dft_rescale(xent))
+
+    def without_sg(xent):
+      return jnp.sum(jnp.exp(-xent) * xent)
+
+    xent = jnp.array([0.5, 1.0, 2.0])
+    grad_with = jax.grad(with_sg)(xent)
+    grad_without = jax.grad(without_sg)(xent)
+
+    self.assertFalse(jnp.allclose(grad_with, grad_without, atol=1e-6))
+
+  def test_gradient_differs_from_identity(self):
+    """DFT gradients should differ from unrescaled gradients."""
+
+    def standard(xent):
+      return jnp.sum(xent)
+
+    def dft(xent):
+      return jnp.sum(losses.dft_rescale(xent))
+
+    xent = jnp.array([0.5, 1.0, 2.0])
+    self.assertFalse(
+        jnp.allclose(jax.grad(standard)(xent), jax.grad(dft)(xent), atol=1e-6)
+    )
+
+  def test_batched_input(self):
+    xent = jax.random.uniform(jax.random.PRNGKey(0), (2, 4)) + 0.1
+    rescaled = losses.dft_rescale(xent)
+    self.assertEqual(rescaled.shape, xent.shape)
+    np.testing.assert_array_less(np.asarray(rescaled), np.asarray(xent) + 1e-6)
+
+
+class DFTLossFnTest(absltest.TestCase):
+  """Tests for dft_loss_fn integrated with PeftTrainer."""
+
+  def test_returns_scalar(self):
+    model, *args = _make_model_and_inputs()
+    loss = losses.dft_loss_fn(model, *args)
+    self.assertEqual(loss.shape, ())
+    self.assertGreater(float(loss), 0.0)
+
+  def test_less_than_or_equal_cross_entropy(self):
+    model, *args = _make_model_and_inputs()
+    ce = losses.cross_entropy_loss_fn(model, *args)
+    dft = losses.dft_loss_fn(model, *args)
+    self.assertLessEqual(float(dft), float(ce) + 1e-6)
+
+  def test_differs_from_cross_entropy(self):
+    model, *args = _make_model_and_inputs()
+    ce = losses.cross_entropy_loss_fn(model, *args)
+    dft = losses.dft_loss_fn(model, *args)
+    self.assertNotAlmostEqual(float(dft), float(ce), places=3)
+
+  def test_training_updates_params(self):
+    model, trainer = _train_with_loss_fn(losses.dft_loss_fn)
+    original = jax.tree.map(
+        jnp.copy,
+        nnx.state(
+            tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0)),
+            nnx.Param,
+        ),
+    )
+    updated = nnx.state(model, nnx.Param)
+    jax.tree.map_with_path(tc.assert_not_equal, original, updated)
+    self.assertGreater(trainer._train_steps, 0)
+
+  def test_training_differs_from_cross_entropy(self):
+    """Training with DFT should produce different params than CE."""
+    _, ce_trainer = _train_with_loss_fn(losses.cross_entropy_loss_fn)
+    _, dft_trainer = _train_with_loss_fn(losses.dft_loss_fn)
+
+    ce_loss = ce_trainer.metrics_logger.get_metric('', 'loss', 'train')
+    dft_loss = dft_trainer.metrics_logger.get_metric('', 'loss', 'train')
+    self.assertNotAlmostEqual(float(ce_loss), float(dft_loss), places=3)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tunix/sft/losses/__init__.py
+++ b/tunix/sft/losses/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loss functions for SFT training."""
+
+from tunix.sft.losses.cross_entropy import aggregate_loss
+from tunix.sft.losses.cross_entropy import cross_entropy_loss_fn
+from tunix.sft.losses.cross_entropy import per_token_cross_entropy
+from tunix.sft.losses.dft import dft_loss_fn
+from tunix.sft.losses.dft import dft_rescale

--- a/tunix/sft/losses/cross_entropy.py
+++ b/tunix/sft/losses/cross_entropy.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Standard cross-entropy loss for next-token prediction."""
+
+from typing import Tuple
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+import optax
+
+
+def per_token_cross_entropy(
+    model: nnx.Module,
+    input_tokens: jax.Array,
+    input_mask: jax.Array,
+    positions: jax.Array,
+    attention_mask: jax.Array,
+) -> Tuple[ArrayLike, jax.Array]:
+  """Computes per-token cross-entropy for next-token prediction.
+
+  This is the shared building block for all SFT loss functions. It
+  runs the forward pass, shifts targets by one position, and returns
+  the raw per-token losses together with the target mask.
+
+  Args:
+    model: The model to compute logits from.
+    input_tokens: Input token IDs, shape ``(batch, seq_len)``.
+    input_mask: Binary mask for valid tokens, shape ``(batch, seq_len)``.
+    positions: Position indices, shape ``(seq_len,)`` or
+      ``(batch, seq_len)``.
+    attention_mask: Attention mask, shape matching model expectations.
+
+  Returns:
+    A tuple ``(per_token_xent, target_mask)`` where
+    ``per_token_xent`` has shape ``(batch, seq_len - 1)`` and
+    ``target_mask`` has the same shape.
+  """
+  logits, _ = model(input_tokens, positions, None, attention_mask)
+
+  # Exclude the last step as it does not appear in the targets.
+  logits = logits[:, :-1, :]
+  target_tokens = input_tokens[:, 1:]
+  target_mask = input_mask[:, 1:]
+
+  # Per-token cross-entropy: -log p(y_t).
+  xent = optax.softmax_cross_entropy_with_integer_labels(
+      logits, target_tokens
+  )
+
+  return xent, target_mask
+
+
+def aggregate_loss(
+    per_token_loss: ArrayLike,
+    mask: jax.Array,
+) -> ArrayLike:
+  """Masks and averages per-token losses over valid tokens.
+
+  Args:
+    per_token_loss: Per-token loss values, shape ``(batch, seq_len)``.
+    mask: Binary mask for valid tokens, same shape.
+
+  Returns:
+    Scalar mean loss over valid tokens.
+  """
+  norm_factor = 1 / (jnp.sum(mask) + 1e-8)
+  return jnp.sum(per_token_loss * mask) * norm_factor
+
+
+def cross_entropy_loss_fn(
+    model: nnx.Module,
+    input_tokens: jax.Array,
+    input_mask: jax.Array,
+    positions: jax.Array,
+    attention_mask: jax.Array,
+) -> ArrayLike:
+  """Standard next-token prediction loss (negative log-likelihood).
+
+  Computes per-token cross-entropy between the model's predictions and
+  the shifted target tokens, masks out padding, and returns the mean
+  loss over valid tokens.
+
+  Args:
+    model: The model to compute logits from.
+    input_tokens: Input token IDs, shape ``(batch, seq_len)``.
+    input_mask: Binary mask for valid tokens, shape ``(batch, seq_len)``.
+    positions: Position indices, shape ``(seq_len,)`` or
+      ``(batch, seq_len)``.
+    attention_mask: Attention mask, shape matching model expectations.
+
+  Returns:
+    Scalar NLL loss.
+  """
+  xent, target_mask = per_token_cross_entropy(
+      model, input_tokens, input_mask, positions, attention_mask
+  )
+  return aggregate_loss(xent, target_mask)

--- a/tunix/sft/losses/dft.py
+++ b/tunix/sft/losses/dft.py
@@ -1,0 +1,87 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dynamic Fine-Tuning (DFT) loss.
+
+Reference:
+  *On the Generalization of Supervised Fine-Tuning: A Reinforcement
+  Learning Perspective with Reward Rectification*
+  (https://arxiv.org/abs/2508.05629)
+"""
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+from tunix.sft.losses.cross_entropy import aggregate_loss
+from tunix.sft.losses.cross_entropy import per_token_cross_entropy
+
+
+def dft_rescale(per_token_loss: ArrayLike) -> ArrayLike:
+  """Applies Dynamic Fine-Tuning (DFT) rescaling to per-token losses.
+
+  DFT rescales each token's cross-entropy loss by the model's own
+  predicted probability for that token (with ``stop_gradient``),
+  down-weighting tokens the model is already uncertain about:
+
+  .. math::
+
+      \\mathcal{L}^{\\text{DFT}}_t
+        = \\operatorname{sg}\\bigl(p(y_t)\\bigr)\\,
+          \\bigl(-\\log p(y_t)\\bigr)
+
+  Since :math:`p(y_t) = \\exp(-\\text{xent})`, this is equivalent to::
+
+      stop_gradient(exp(-xent)) * xent
+
+  Args:
+    per_token_loss: Per-token cross-entropy losses, shape ``(...,)``.
+
+  Returns:
+    DFT-rescaled per-token losses with the same shape.
+  """
+  return jax.lax.stop_gradient(jnp.exp(-per_token_loss)) * per_token_loss
+
+
+def dft_loss_fn(
+    model: nnx.Module,
+    input_tokens: jax.Array,
+    input_mask: jax.Array,
+    positions: jax.Array,
+    attention_mask: jax.Array,
+) -> ArrayLike:
+  """Next-token prediction loss with DFT rescaling.
+
+  Computes standard per-token cross-entropy (same as
+  :func:`~tunix.sft.losses.cross_entropy.cross_entropy_loss_fn`),
+  applies :func:`dft_rescale`, then masks and aggregates.  Drop-in
+  replacement::
+
+      trainer.with_loss_fn(dft_loss_fn)
+
+  Args:
+    model: The model to compute logits from.
+    input_tokens: Input token IDs, shape ``(batch, seq_len)``.
+    input_mask: Binary mask for valid tokens, shape ``(batch, seq_len)``.
+    positions: Position indices, shape ``(seq_len,)`` or
+      ``(batch, seq_len)``.
+    attention_mask: Attention mask, shape matching model expectations.
+
+  Returns:
+    Scalar DFT-rescaled NLL loss.
+  """
+  xent, target_mask = per_token_cross_entropy(
+      model, input_tokens, input_mask, positions, attention_mask
+  )
+  return aggregate_loss(dft_rescale(xent), target_mask)

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -36,6 +36,7 @@ from tunix.perf import trace as perf_trace
 from tunix.sft import checkpoint_manager
 from tunix.sft import hooks
 from tunix.sft import inflight_throttler
+from tunix.sft import losses
 from tunix.sft import metrics_logger as sft_metrics_logger
 from tunix.sft import profiler
 from tunix.sft import progress_bar
@@ -206,8 +207,8 @@ class PeftTrainer:
     else:
       self.optimizer = nnx.Optimizer(self.model, optimizer, wrt=nnx.Param)
 
-    self.loss_fn = _default_loss_fn
-    self.eval_loss_fn = _default_loss_fn
+    self.loss_fn = losses.cross_entropy_loss_fn
+    self.eval_loss_fn = losses.cross_entropy_loss_fn
     self.gen_model_input_fn = lambda x: x
     self.checkpoint_manager = checkpoint_manager.CheckpointManager(
         root_directory=self.config.checkpoint_root_directory,
@@ -822,32 +823,3 @@ class PeftTrainer:
       self._buffered_eval_metrics = None
       if self.training_hooks:
         self.training_hooks.on_eval_step_end(self, eval_loss)
-
-
-def _default_loss_fn(
-    model: nnx.Module,
-    input_tokens: jax.Array,
-    input_mask: jax.Array,
-    positions: jax.Array,
-    attention_mask: jax.Array,
-) -> ArrayLike:
-  """Default loss function for PEFT training."""
-  logits, _ = model(input_tokens, positions, None, attention_mask)
-
-  # Exclude the last step as it does not appear in the targets.
-  logits = logits[:, :-1, :]
-  target_tokens = input_tokens[:, 1:]
-  target_mask = input_mask[:, 1:]
-
-  # Convert the target labels to one-hot encoded vectors.
-  one_hot = jax.nn.one_hot(target_tokens, logits.shape[-1])
-
-  # Don't update on unwanted tokens.
-  one_hot = one_hot * target_mask.astype(one_hot.dtype)[..., None]
-
-  # Define the normalization factor.
-  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)
-
-  # Return the negative log likelihood (NLL) loss.
-  # Equivalent to: optax.softmax_cross_entropy(logits, one_hot).mean()
-  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor


### PR DESCRIPTION
# PR: Add Dynamic Fine-Tuning (DFT) loss and refactor SFT losses into submodule

## Description

This PR introduces **Dynamic Fine-Tuning (DFT)** loss support.

### Refactor: `tunix/sft/losses/` submodule

The existing `_default_loss_fn` is moved into a proper `losses/` package with shared building blocks:

- `per_token_cross_entropy(model, ...)` - runs the forward pass and returns raw per-token cross-entropy values with the target mask.
- `aggregate_loss(per_token_loss, mask)` - masks and averages per-token losses over valid tokens.
- `cross_entropy_loss_fn(model, ...)` - standard next-token prediction NLL (drop-in replacement for the old `_default_loss_fn`).

### New: DFT loss

Based on the paper [*On the Generalization of Supervised Fine-Tuning: A Reinforcement Learning Perspective with Reward Rectification*](https://arxiv.org/abs/2508.05629), DFT rescales the per-token cross-entropy loss by the model's own predicted probability (with stop-gradient):

```
dft_loss_t = stop_gradient(p(y_t)) * (-log p(y_t))
```

The implementation composes on top of the standard cross-entropy building blocks:

- `dft_rescale(per_token_loss)` - applies the per-token rescaling, usable with any per-token loss computation.
- `dft_loss_fn(model, ...)` - drop-in replacement for `cross_entropy_loss_fn`:

**Reference**

- Paper: [On the Generalization of Supervised Fine-Tuning: A Reinforcement Learning Perspective with Reward Rectification](https://arxiv.org/abs/2508.05629)

**Checklist**

- [X] I have added all the necessary unit tests for my change.
- [X] I have verified that my change does not break existing code and all unit tests pass.
- [X] I have added all appropriate doc-strings/documentation.
- [X] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [X] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
