### PR TITLE
fix expert_parallel_size to not pass through to vLLM args

### DIFF
--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -395,6 +395,21 @@ class VllmSamplerConfigTest(absltest.TestCase):
     self.assertEqual(sampler.args["tensor_parallel_size"], 4)
     self.assertEqual(sampler.args["data_parallel_size"], 1)
 
+  def test_reserved_keys_in_engine_kwargs_raise_value_error(self):
+    # Reserved VllmConfig fields (e.g. tp, dp, ep) must be set directly on
+    # VllmConfig, not smuggled through engine_kwargs. Passing them via
+    # engine_kwargs should raise a ValueError at config construction time
+    # before any vLLM engine args are assembled.
+    mesh = self._make_mock_mesh(8)
+    for key in ("expert_parallel_size", "tensor_parallel_size", "data_parallel_size"):
+      with self.subTest(key=key):
+        with self.assertRaisesRegex(ValueError, key):
+          vllm_sampler.VllmConfig(
+              mesh=mesh,
+              init_with_random_weights=False,
+              engine_kwargs={key: 2},
+          )
+
   def test_default_expert_parallel_size_is_one(self):
     mesh = self._make_mock_mesh(8)
     config = vllm_sampler.VllmConfig(

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -71,8 +71,26 @@ class VllmConfig:
       init=False, default_factory=dict
   )
 
+  # VllmConfig fields that require special processing before being passed to
+  # vLLM and must not be passed via engine_kwargs, which is a raw pass-through
+  # to vLLM EngineArgs.
+  _RESERVED_KEYS: frozenset[str] = dataclasses.field(
+      default=frozenset(
+          {"tensor_parallel_size", "data_parallel_size", "expert_parallel_size"}
+      ),
+      init=False,
+      repr=False,
+      compare=False,
+  )
+
   def __post_init__(self, engine_kwargs: Optional[Dict[str, Any]]):
     engine_kwargs = engine_kwargs or {}
+    illegal = self._RESERVED_KEYS & engine_kwargs.keys()
+    if illegal:
+      raise ValueError(
+          f"VllmConfig fields must be set directly on VllmConfig, not passed"
+          f" via engine_kwargs: {sorted(illegal)}"
+      )
     self._processed_engine_kwargs = engine_kwargs
     if engine_kwargs:
       for key, value in engine_kwargs.items():

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -52,6 +52,9 @@ class VllmRollout(base_rollout.BaseRollout):
             hbm_utilization=rollout_config.rollout_vllm_hbm_utilization,
             lora_config=rollout_config.rollout_vllm_lora_config,
             mesh=mesh,
+            tensor_parallel_size=rollout_config.tensor_parallel_size,
+            data_parallel_size=rollout_config.data_parallel_size,
+            expert_parallel_size=rollout_config.expert_parallel_size,
             engine_kwargs={
                 "model": rollout_config.rollout_vllm_model_version,
                 "max_model_len": cache_config_or_size,
@@ -59,9 +62,6 @@ class VllmRollout(base_rollout.BaseRollout):
                 "async_scheduling": (
                     rollout_config.rollout_vllm_async_scheduling
                 ),
-                "tensor_parallel_size": rollout_config.tensor_parallel_size,
-                "data_parallel_size": rollout_config.data_parallel_size,
-                "expert_parallel_size": rollout_config.expert_parallel_size,
                 "max_num_batched_tokens": (
                     rollout_config.rollout_vllm_max_num_batched_tokens
                 ),


### PR DESCRIPTION

                                                                                                                                                                                                           
  **Fix** (tunix/generate/vllm_sampler.py): Added args.pop("expert_parallel_size", None) at the top of _vllm_config, immediately after copying _processed_engine_kwargs. This strips the key before it can     
  reach LLM(**self.args) / EngineArgs(**engine_kwargs), while ep is still correctly derived via resolve_parallelism_sizes and placed into `additional_config["sharding"]["sharding_strategy"]["expert_parallelism"]`.

**Test** (tests/generate/vllm_sampler_test.py): Added test_expert_parallel_size_via_engine_kwargs_not_leaked_to_vllm which passes expert_parallel_size=2 via engine_kwargs and asserts it does not appear as a top-level key in sampler.args — confirmed failing before the fix (the key was present in args).

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
