### PR TITLE
Extending scanned to unscanned support for GPT-OSS like models.

### DIFF
--- a/tests/generate/utils_test.py
+++ b/tests/generate/utils_test.py
@@ -1187,6 +1187,131 @@ class UtilsTest(parameterized.TestCase):
         atol=1e-2
     )
 
+  def test_transfer_state_directly_gpt_oss_scanned_format(self):
+    """Tests GPT-OSS scanned format: source layers.layers_Y with axis!=0 scan to individual layers_X."""
+    n_scan = 3  # layers per scan group
+    n_heads, head_dim = 4, 8
+
+    # Single scan group: shape (n_heads, n_scan, head_dim), layers at axis 1
+    stacked_group0 = jnp.stack(
+        [jnp.full((n_heads, head_dim), float(i + 1)) for i in range(n_scan)],
+        axis=1,
+    )  # shape: (4, 3, 8); layer 0 = 1.0, layer 1 = 2.0, layer 2 = 3.0
+
+    # Part 1: single group
+    src_single = nnx.Dict(
+        base=nnx.Dict(
+            decoder=nnx.Dict(
+                layers=nnx.Dict(
+                    layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(stacked_group0)))
+                )
+            )
+        )
+    )
+    dst_single = nnx.Dict(
+        decoder=nnx.Dict(
+            layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_1=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_2=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+        )
+    )
+    mock_reshard = lambda source, target: source
+    utils.transfer_state_directly(src_single, dst_single, reshard_fn=mock_reshard)
+
+    for i in range(n_scan):
+      expected = jnp.full((n_heads, head_dim), float(i + 1))
+      np.testing.assert_array_equal(
+          dst_single['decoder'][f'layers_{i}']['Attn']['bias'][...],
+          expected,
+          err_msg=f'Single-group: layer {i} mismatch',
+      )
+
+    # Part 2: two scan groups (group 0 -> layers 0-2, group 1 -> layers 3-5)
+    stacked_group1 = jnp.stack(
+        [jnp.full((n_heads, head_dim), float(i + 10)) for i in range(n_scan)],
+        axis=1,
+    )  # layer 3 = 10.0, layer 4 = 11.0, layer 5 = 12.0
+
+    src_two = nnx.Dict(
+        base=nnx.Dict(
+            decoder=nnx.Dict(
+                layers=nnx.Dict(
+                    layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(stacked_group0))),
+                    layers_1=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(stacked_group1))),
+                )
+            )
+        )
+    )
+    dst_two = nnx.Dict(
+        decoder=nnx.Dict(
+            layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_1=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_2=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_3=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_4=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_5=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+        )
+    )
+    utils.transfer_state_directly(
+        src_two, dst_two, reshard_fn=mock_reshard, scan_group_ordering='sequential'
+    )
+
+    expected_values = [1.0, 2.0, 3.0, 10.0, 11.0, 12.0]
+    for i, val in enumerate(expected_values):
+      np.testing.assert_array_equal(
+          dst_two['decoder'][f'layers_{i}']['Attn']['bias'][...],
+          jnp.full((n_heads, head_dim), val),
+          err_msg=f'Two-group: layer {i} mismatch',
+      )
+
+  def test_transfer_state_directly_gpt_oss_scanned_format_interleaved(self):
+    """Tests interleaved scan group ordering: group = layer_idx % n_groups."""
+    n_scan = 3
+    n_heads, head_dim = 4, 8
+
+    stacked_group0 = jnp.stack(
+        [jnp.full((n_heads, head_dim), float(i + 1)) for i in range(n_scan)],
+        axis=1,
+    )  # local 0=1.0, 1=2.0, 2=3.0
+    stacked_group1 = jnp.stack(
+        [jnp.full((n_heads, head_dim), float(i + 10)) for i in range(n_scan)],
+        axis=1,
+    )  # local 0=10.0, 1=11.0, 2=12.0
+
+    src = nnx.Dict(
+        base=nnx.Dict(
+            decoder=nnx.Dict(
+                layers=nnx.Dict(
+                    layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(stacked_group0))),
+                    layers_1=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(stacked_group1))),
+                )
+            )
+        )
+    )
+    dst = nnx.Dict(
+        decoder=nnx.Dict(
+            layers_0=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_1=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_2=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_3=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_4=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+            layers_5=nnx.Dict(Attn=nnx.Dict(bias=nnx.Param(jnp.zeros((n_heads, head_dim))))),
+        )
+    )
+    mock_reshard = lambda source, target: source
+    utils.transfer_state_directly(
+        src, dst, reshard_fn=mock_reshard, scan_group_ordering='interleaved'
+    )
+
+    # Interleaved: layers_0→g0l0=1.0, layers_1→g1l0=10.0, layers_2→g0l1=2.0, ...
+    expected_values = [1.0, 10.0, 2.0, 11.0, 3.0, 12.0]
+    for i, val in enumerate(expected_values):
+      np.testing.assert_array_equal(
+          dst['decoder'][f'layers_{i}']['Attn']['bias'][...],
+          jnp.full((n_heads, head_dim), val),
+          err_msg=f'Interleaved: layer {i} mismatch',
+      )
+
   def test_sglang_jax_1d_kv_bias_alignment(self):
     """Test 1-D KV bias alignment for sglang_jax rollout engine."""
     src_key = "layers.0.attn.k_bias"

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -817,6 +817,161 @@ def transfer_state_with_mappings(
   return dst_state.from_flat_path(tgt_flat_list)
 
 
+def _try_map_to_standard_layers(
+    key_tuple: Tuple[str | int, ...],
+    match_index: int,
+    layer_idx: int,
+    src_flat: Mapping[Tuple[str | int, ...], Any],
+    tgt_val: Any,
+) -> Optional[Any]:
+  """Tries mapping by replacing 'layers_X' with 'layers' (Standard MaxText).
+
+  This candidate handles the standard MaxText scanned format where all layers
+  are stacked into a single 'layers' container in the source. For example, if
+  the target expects 'model.layers_0.attn.q_proj', this function tries to map
+  it to 'model.layers.attn.q_proj' in the source and then slices the 'layer'
+  dimension at index 0.
+
+  Args:
+      key_tuple: The path to the parameter in the target state.
+      match_index: The index of the 'layers_X' part in the key_tuple.
+      layer_idx: The index of the layer extracted from 'layers_X'.
+      src_flat: The flattened source state.
+      tgt_val: The target parameter value/spec.
+
+  Returns:
+      The sliced and casted source value if found, else None.
+  """
+  candidate = list(key_tuple)
+  candidate[match_index] = 'layers'
+  cand = tuple(candidate)
+  if cand in src_flat:
+    src_val = src_flat[cand]
+    # Slice the scanned parameter
+    sliced_val = _slice_scanned_param(src_val, tgt_val, layer_idx, str(key_tuple))
+    return _apply_dtype_cast(sliced_val, tgt_val.dtype, str(key_tuple))
+
+  return None
+
+
+def _try_map_by_removing_layer_index(
+    key_tuple: Tuple[str | int, ...],
+    match_index: int,
+    layer_idx: int,
+    src_flat: Mapping[Tuple[str | int, ...], Any],
+    tgt_val: Any,
+) -> Optional[Any]:
+  """Tries mapping by removing 'layers_X' (Implicit Container).
+
+  This candidate handles architectures where layers are implicitly stacked
+  without a dedicated 'layers' container in the source path. For example, if
+  the target expects 'model.layers_0.attn.q_proj', this function tries to map
+  it to 'model.attn.q_proj' in the source (where 'attn.q_proj' is a scanned
+  array) and then slices the 'layer' dimension at index 0.
+
+  Args:
+      key_tuple: The path to the parameter in the target state.
+      match_index: The index of the 'layers_X' part in the key_tuple.
+      layer_idx: The index of the layer extracted from 'layers_X'.
+      src_flat: The flattened source state.
+      tgt_val: The target parameter value/spec.
+
+  Returns:
+      The sliced and casted source value if found, else None.
+  """
+  candidate = list(key_tuple)
+  candidate.pop(match_index)
+  cand = tuple(candidate)
+  if cand in src_flat:
+    src_val = src_flat[cand]
+    # Slice the scanned parameter
+    sliced_val = _slice_scanned_param(src_val, tgt_val, layer_idx, str(key_tuple))
+    return _apply_dtype_cast(sliced_val, tgt_val.dtype, str(key_tuple))
+
+  return None
+
+
+def _try_map_to_scanned_groups(
+    key_tuple: Tuple[str | int, ...],
+    match_index: int,
+    layer_idx: int,
+    src_flat: Mapping[Tuple[str | int, ...], Any],
+    tgt_val: Any,
+    scan_group_ordering: str,
+) -> Optional[Any]:
+  """Tries mapping using the GPT-OSS like scanned format (layers.layers_Y).
+
+  This candidate handles grouped scanned formats common in GPT-OSS and similar
+  implementations. The source state organizes layers into groups (e.g.,
+  'layers.layers_0', 'layers.layers_1'), where each group contains multiple
+  stacked layers.
+
+  This function calculates the correct source group index and the local index
+  within that group for a given global `layer_idx` based on the
+  `scan_group_ordering`.
+
+  - 'sequential': Layers are grouped contiguously (e.g., layers 0-3 in group 0,
+    4-7 in group 1).
+  - 'interleaved': Layers are distributed across groups (e.g., layers 0, 2, 4
+    in group 0; 1, 3, 5 in group 1).
+
+  Args:
+      key_tuple: The path to the parameter in the target state.
+      match_index: The index of the 'layers_X' part in the key_tuple.
+      layer_idx: The index of the layer extracted from 'layers_X'.
+      src_flat: The flattened source state.
+      tgt_val: The target parameter value/spec.
+      scan_group_ordering: How scan groups are ordered relative to layer
+        indices. 'sequential' (default) or 'interleaved'.
+
+  Returns:
+      The sliced and casted source value if found, else None.
+  """
+  prefix = key_tuple[:match_index]
+  suffix = key_tuple[match_index + 1:]
+
+  # Count available scan groups
+  n_groups = 0
+  while prefix + ('layers', f'layers_{n_groups}') + suffix in src_flat:
+    n_groups += 1
+
+  if n_groups > 0:
+    first_val = src_flat[prefix + ('layers', 'layers_0') + suffix]
+    if hasattr(first_val, 'shape') and hasattr(tgt_val, 'shape'):
+      if len(first_val.shape) == len(tgt_val.shape) + 1:
+        for axis in range(len(first_val.shape)):
+          remaining = first_val.shape[:axis] + first_val.shape[axis + 1:]
+          # Check if removing this axis matches the target shape
+          if remaining == tgt_val.shape:
+            n_scan_steps = first_val.shape[axis]
+            # For interleaved ordering, layer_idx 0, n_groups, 2*n_groups... go
+            # to group 0; layer_idx 1, n_groups+1, 2*n_groups+1... go to group
+            # 1, etc.
+            if scan_group_ordering == 'interleaved':
+              src_group_idx = layer_idx % n_groups
+              local_idx = layer_idx // n_groups
+            # For sequential ordering, layers 0-N in group 0, then N+1-2N in
+            # group 1, etc.
+            else:
+              src_group_idx = layer_idx // n_scan_steps
+              local_idx = layer_idx % n_scan_steps
+
+            # We only slice if the calculated group index and local index are
+            # within bounds
+            if src_group_idx < n_groups and local_idx < n_scan_steps:
+              candidate_c = (
+                  prefix + ('layers', f'layers_{src_group_idx}') + suffix
+              )
+              src_val = src_flat[candidate_c]
+              sliced_val = _slice_scanned_param(
+                  src_val, tgt_val, local_idx, str(key_tuple)
+              )
+              return _apply_dtype_cast(sliced_val, tgt_val.dtype, str(key_tuple))
+            break
+
+  return None
+
+
 def _slice_scanned_param(
     src_val: jax.Array | np.ndarray | Any,
     tgt_val: jax.Array | np.ndarray | Any,
@@ -885,6 +1040,7 @@ def transfer_state_directly(
     src_state: Mapping[str, Any],
     dst_state: Mapping[str, Any],
     reshard_fn: Callable[..., Mapping[str, Any]],
+    scan_group_ordering: str = 'sequential',
 ) -> None:
   """Transfers state directly by matching structure, stripping wrappers.
 
@@ -899,6 +1055,10 @@ def transfer_state_directly(
     src_state: The source state to transfer from.
     dst_state: The destination state to transfer to.
     reshard_fn: A function to shard the values.
+    scan_group_ordering: How scan groups are ordered relative to layer indices.
+      'sequential' (default): group = layer_idx // n_scan_steps (e.g. layers 0-N in
+      group 0, then layers N+1-2N in group 1). 'interleaved': group = layer_idx %
+      n_groups (e.g. even layers in group 0, odd layers in group 1).
   """
 
   def safe_has_key(obj: Mapping[str, Any], key: str) -> bool:
@@ -992,29 +1152,34 @@ def transfer_state_directly(
       if match_index != -1:
         # Check different candidate path formats for scanned layers
         # Candidate A: Replace 'layers_X' with 'layers' (Standard MaxText)
-        candidate_a = list(key_tuple)
-        candidate_a[match_index] = 'layers'
+        src_val = _try_map_to_standard_layers(
+            key_tuple, match_index, layer_idx, src_flat, tgt_val
+        )
+        if src_val is not None:
+          filtered_src_flat[key_tuple] = src_val
+          filtered_tgt_flat[key_tuple] = tgt_val
+          continue
 
-        # Candidate B: Remove 'layers_X' (Implicit Container / GPT-OSS)
-        candidate_b = list(key_tuple)
-        candidate_b.pop(match_index)
+        # Candidate B: Remove 'layers_X' (Implicit Container)
+        src_val = _try_map_by_removing_layer_index(
+            key_tuple, match_index, layer_idx, src_flat, tgt_val
+        )
+        if src_val is not None:
+          filtered_src_flat[key_tuple] = src_val
+          filtered_tgt_flat[key_tuple] = tgt_val
+          continue
 
-        found_candidate = None
-        for cand in [tuple(candidate_a), tuple(candidate_b)]:
-          if cand in src_flat:
-            found_candidate = cand
-            break
-
-        if found_candidate:
-          src_val = src_flat[found_candidate]
-          # Slice the scanned parameter
-          sliced_val = _slice_scanned_param(
-              src_val, tgt_val, layer_idx, str(key_tuple)
-          )
-          sliced_val = _apply_dtype_cast(
-              sliced_val, tgt_val.dtype, str(key_tuple)
-          )
-          filtered_src_flat[key_tuple] = sliced_val
+        # Candidate C: GPT-OSS like scanned format
+        src_val = _try_map_to_scanned_groups(
+            key_tuple,
+            match_index,
+            layer_idx,
+            src_flat,
+            tgt_val,
+            scan_group_ordering,
+        )
+        if src_val is not None:
+          filtered_src_flat[key_tuple] = src_val
           filtered_tgt_flat[key_tuple] = tgt_val
           continue
 

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -64,6 +64,7 @@ class VllmConfig:
   data_parallel_size: int = -1
   tensor_parallel_size: int = -1
   expert_parallel_size: int = 1
+  scan_group_ordering: str = "sequential"
 
   # vLLM engine args that can be directly passed in without additional processing, e.g. max_model_len, async_scheduling, etc.
   engine_kwargs: dataclasses.InitVar[Optional[Dict[str, Any]]] = None
@@ -220,6 +221,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           src_state=updated_weights,
           dst_state=self.transformer_state,
           reshard_fn=reshard.reshard_pytree,
+          scan_group_ordering=self.config.scan_group_ordering,
       )
 
   def load_checkpoint(self, path_or_weights: str | jaxtyping.PyTree):

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -159,6 +159,14 @@ class RolloutConfig:
   rollout_vllm_max_num_seqs: Optional[int] = None
 
   # Additional keyword arguments forwarded directly to the vLLM engine constructor.
+  # The ordering to use when assigning layers to scan groups in vLLM rollout engine.
+  # "interleaved" means layers are assigned to groups in a round-robin fashion,
+  # while "sequential" means layers are assigned to groups in contiguous blocks.
+  # This is used when transferring weights from a MaxText / out-of-tree vLLM model
+  # to the rollout engine, to ensure that layers are assigned to the same scan group in both models.
+  rollout_vllm_scan_group_ordering: str = "sequential"
+
+  # Additional keyword arguments forwarded directly to the vLLM engine constructor.
   rollout_vllm_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
 
   # Additional keyword arguments forwarded directly to the vLLM sampling params.

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -55,6 +55,7 @@ class VllmRollout(base_rollout.BaseRollout):
             tensor_parallel_size=rollout_config.tensor_parallel_size,
             data_parallel_size=rollout_config.data_parallel_size,
             expert_parallel_size=rollout_config.expert_parallel_size,
+            scan_group_ordering=rollout_config.rollout_vllm_scan_group_ordering,
             engine_kwargs={
                 "model": rollout_config.rollout_vllm_model_version,
                 "max_model_len": cache_config_or_size,


### PR DESCRIPTION
Adding support to `transfer_state_directly` to handle models with multiple scanned blocks.

**Checklist**
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
