### PR TITLE
Harden calculate_reward: replace unsafe eval() with safe arithmetic evaluator

### DIFF
--- a/tests/rl/agentic/rewards/reward_test.py
+++ b/tests/rl/agentic/rewards/reward_test.py
@@ -86,6 +86,8 @@ class RewardTest(parameterized.TestCase):
       ("parsing_error", "10 / 2 = ?", "five", 0.0),
       # eval() will raise ZeroDivisionError, which is caught by the try-except
       ("eval_error", "10 / 0 = ?", "1", 0.0),
+        ("unsafe_expression", "__import__('os').system('echo SHOULD_NOT_RUN') = ?", "0", 0.0),
+        ("pow_too_large", "2 ** 5000 = ?", "0", 0.0),
   )
   def test_calculate_reward(self, question, action, expected_score):
     """Tests the calculate_reward function."""

--- a/tunix/rl/agentic/rewards/reward.py
+++ b/tunix/rl/agentic/rewards/reward.py
@@ -25,10 +25,14 @@ from typing import Any, Callable, Dict
 import ast
 
 from tunix.rl.agentic.rewards import reward_types
+_REGISTRY: Dict[
+    str, Callable[[Dict[str, Any], str], reward_types.RewardOutput]
+] = {}
 
-_REGISTRY:
+
 class UnsafeExpressionError(ValueError):
   """Raised when an expression contains disallowed syntax."""
+
 
 def _safe_eval_math(expr: str) -> float:
   """Safely evaluate a simple numeric arithmetic expression.
@@ -91,10 +95,6 @@ def _safe_eval_math(expr: str) -> float:
     raise UnsafeExpressionError(f"Disallowed expression node: {type(n).__name__}")
 
   return float(_eval(node))
- Dict[
-    str, Callable[[Dict[str, Any], str], reward_types.RewardOutput]
-] = {}
-
 
 def register(name: str):
   """Decorator for registering reward functions into the global registry.

--- a/tunix/rl/agentic/rewards/reward.py
+++ b/tunix/rl/agentic/rewards/reward.py
@@ -30,7 +30,6 @@ _REGISTRY:
 class UnsafeExpressionError(ValueError):
   """Raised when an expression contains disallowed syntax."""
 
-
 def _safe_eval_math(expr: str) -> float:
   """Safely evaluate a simple numeric arithmetic expression.
 
@@ -112,7 +111,6 @@ def register(name: str):
   Raises:
       ValueError: If a reward function with the given name already exists
   """
-
   def _wrap(fn):
     if name in _REGISTRY:
 
@@ -190,7 +188,6 @@ def combine_rewards(
   Example:
       composite_fn = combine_rewards({"exact_match": 1.0, "zero": 0.0})
   """
-
   def _fn(task: Dict[str, Any], action: str):
     total, meta = 0.0, {}
     for name, w in weights.items():

--- a/tunix/rl/agentic/rewards/reward.py
+++ b/tunix/rl/agentic/rewards/reward.py
@@ -113,7 +113,6 @@ def register(name: str):
   """
   def _wrap(fn):
     if name in _REGISTRY:
-
       raise ValueError(f"Reward {name} already registered.")
     _REGISTRY[name] = fn
     return fn
@@ -134,7 +133,6 @@ def unregister(name: str) -> bool:
       bool: True if the function was removed, False if it wasn't registered
   """
   if name in _REGISTRY:
-
     del _REGISTRY[name]
     return True
   return False

--- a/tunix/rl/agentic/rewards/reward.py
+++ b/tunix/rl/agentic/rewards/reward.py
@@ -22,9 +22,77 @@ metadata.
 
 from typing import Any, Callable, Dict
 
+import ast
+
 from tunix.rl.agentic.rewards import reward_types
 
-_REGISTRY: Dict[
+_REGISTRY:
+class UnsafeExpressionError(ValueError):
+  """Raised when an expression contains disallowed syntax."""
+
+
+def _safe_eval_math(expr: str) -> float:
+  """Safely evaluate a simple numeric arithmetic expression.
+
+  Supported:
+    - numeric literals (int/float)
+    - parentheses
+    - binary ops: +, -, *, /, //, %, **
+    - unary ops: +, -
+
+  Disallowed:
+    - names/identifiers, attribute access, calls, subscripts, comprehensions, etc.
+  """
+  if not isinstance(expr, str):
+    raise UnsafeExpressionError("Expression must be a string.")
+  expr = expr.strip()
+  if not expr or len(expr) > 200:
+    raise UnsafeExpressionError("Expression is empty or too long.")
+
+  try:
+    node = ast.parse(expr, mode="eval")
+  except SyntaxError as e:
+    raise UnsafeExpressionError("Invalid expression syntax.") from e
+
+  def _eval(n):
+    if isinstance(n, ast.Expression):
+      return _eval(n.body)
+
+    if isinstance(n, ast.Constant):
+      if isinstance(n.value, (int, float)):
+        return float(n.value)
+      raise UnsafeExpressionError("Only numeric constants are allowed.")
+
+    if isinstance(n, ast.UnaryOp) and isinstance(n.op, (ast.UAdd, ast.USub)):
+      v = _eval(n.operand)
+      return +v if isinstance(n.op, ast.UAdd) else -v
+
+    if isinstance(n, ast.BinOp) and isinstance(
+        n.op, (ast.Add, ast.Sub, ast.Mult, ast.Div, ast.FloorDiv, ast.Mod, ast.Pow)
+    ):
+      a = _eval(n.left)
+      b = _eval(n.right)
+      if isinstance(n.op, ast.Add):
+        return a + b
+      if isinstance(n.op, ast.Sub):
+        return a - b
+      if isinstance(n.op, ast.Mult):
+        return a * b
+      if isinstance(n.op, ast.Div):
+        return a / b
+      if isinstance(n.op, ast.FloorDiv):
+        return a // b
+      if isinstance(n.op, ast.Mod):
+        return a % b
+      if isinstance(n.op, ast.Pow):
+        if abs(b) > 1000:
+          raise UnsafeExpressionError("Exponent too large.")
+        return a ** b
+
+    raise UnsafeExpressionError(f"Disallowed expression node: {type(n).__name__}")
+
+  return float(_eval(node))
+ Dict[
     str, Callable[[Dict[str, Any], str], reward_types.RewardOutput]
 ] = {}
 
@@ -47,6 +115,7 @@ def register(name: str):
 
   def _wrap(fn):
     if name in _REGISTRY:
+
       raise ValueError(f"Reward {name} already registered.")
     _REGISTRY[name] = fn
     return fn
@@ -67,6 +136,7 @@ def unregister(name: str) -> bool:
       bool: True if the function was removed, False if it wasn't registered
   """
   if name in _REGISTRY:
+
     del _REGISTRY[name]
     return True
   return False
@@ -189,7 +259,7 @@ def calculate_reward(
   try:
     answer_str = action.replace("The answer is ", "").strip().rstrip(".")
     answer = float(answer_str)
-    correct_value = eval(expression)
+    correct_value = _safe_eval_math(expression)
     tolerance = 1e-6
     if abs(correct_value - answer) < tolerance:
       score = 1.0


### PR DESCRIPTION
### What changed
This PR removes Python `eval()` usage from `tunix/rl/agentic/rewards/reward.py::calculate_reward` and replaces it with a safe arithmetic evaluator based on an AST allowlist.

### Why
`calculate_reward` derives an expression from `task["question"]` and previously evaluated it with full Python semantics. If tasks/questions originate from untrusted sources (shared datasets/benchmarks/task files), this can lead to unintended code execution in the context of the running process.

### Implementation details
- Introduces `_safe_eval_math()` that supports:
  - numeric literals (int/float)
  - parentheses
  - unary ops: `+`, `-`
  - binary ops: `+`, `-`, `*`, `/`, `//`, `%`, `**` (with exponent guardrails)
- Rejects anything else (names, calls, attributes, subscripts, comprehensions, etc.) by raising `UnsafeExpressionError`
- `calculate_reward` now uses `_safe_eval_math(expression)` and safely returns score `0.0` on invalid/unsafe expressions (existing try/except behavior preserved)

### Tests
Extends `tests/rl/agentic/rewards/reward_test.py` to cover:
- correct arithmetic evaluation (`2 + 2`)
- unsafe expression rejection (`__import__('os').system(...)`)
- large exponent guard (`2 ** 5000`)
- division-by-zero continues to fail safely

Note: local test execution on my environment is blocked by missing `absl` in an externally managed Python environment; CI should validate.

### Security context
This is a defensive hardening change that eliminates an `eval()` injection/code-execution risk while preserving expected arithmetic behavior.