### PR TITLE
add support for repeating kv head tensors during weight sync.

### DIFF
--- a/tests/generate/utils_test.py
+++ b/tests/generate/utils_test.py
@@ -1138,7 +1138,7 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
 
     np.testing.assert_array_equal(
         dst_state['model']['decoder']['layers_0']['mlp']['weight'][...], # Use [...]
@@ -1166,7 +1166,7 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
 
     np.testing.assert_array_equal(
         dst_state['layers']['layers_0']['mlp']['weight'][...],
@@ -1211,7 +1211,7 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
 
     # Verify direct mapping cast
     self.assertEqual(dst_state['decoder']['layer0']['weight'].dtype, jnp.bfloat16)
@@ -1255,7 +1255,7 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
 
     # Verify casting and slicing for implicit layers
     self.assertEqual(dst_state['layers']['layers_0']['mlp']['weight'].dtype, jnp.bfloat16)
@@ -1270,6 +1270,115 @@ class UtilsTest(parameterized.TestCase):
         jnp.array(200.0, dtype=jnp.bfloat16),
         atol=1e-2
     )
+
+  def test_transfer_state_directly_repeats_kv_heads(self):
+    """Tests that direct-match weights are repeated when dst has more heads."""
+    src = jnp.array([[1., 2., 3., 4., 5., 6., 7., 8.],
+                     [3., 4., 5., 6., 7., 8., 9., 10.]], dtype=jnp.float32)
+    src_state = nnx.Dict(
+        attn=nnx.Dict(
+            kv_weight=nnx.Param(src)
+        )
+    )
+    dst_state = nnx.Dict(
+        attn=nnx.Dict(
+            kv_weight=nnx.Param(jnp.zeros((4, 8), dtype=jnp.float32))
+        )
+    )
+
+    mock_reshard = lambda source, target: source
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
+
+    expected = jnp.repeat(src, 2, axis=0)
+    np.testing.assert_array_equal(
+        dst_state['attn']['kv_weight'][...],
+        expected,
+    )
+
+  def test_transfer_state_directly_repeats_scanned_kv_heads(self):
+    """Tests that scanned weights are tiled when dst has more heads than src."""
+    # Source: scanned layers, kv_weight shape [2, 2, 8] (layers=2, heads=2, dim=8)
+    src_state = nnx.Dict(
+        layers=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(jnp.ones((2, 2, 8), dtype=jnp.float32))
+            )
+        )
+    )
+    # Destination: unrolled layers, each with kv_weight shape [4, 8]
+    dst_state = nnx.Dict(
+        layers_0=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(jnp.zeros((4, 8), dtype=jnp.float32))
+            )
+        ),
+        layers_1=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(jnp.zeros((4, 8), dtype=jnp.float32))
+            )
+        ),
+    )
+
+    mock_reshard = lambda source, target: source
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+
+    expected = jnp.repeat(jnp.ones((2, 8), dtype=jnp.float32), 2, axis=0)
+    np.testing.assert_array_equal(
+        dst_state['layers_0']['attn']['kv_weight'][...],
+        expected,
+    )
+    np.testing.assert_array_equal(
+        dst_state['layers_1']['attn']['kv_weight'][...],
+        expected,
+    )
+
+  def test_slice_scanned_param_with_repeatable_target(self):
+    """_slice_scanned_param finds scan axis even when post-slice shape needs repeat."""
+    # src: (embed=4, layers=3, kv_heads=2, head_dim=8)
+    # tgt: (embed=4, kv_heads=4, head_dim=8) — 2x repeat on kv_heads axis
+    src = jnp.arange(4 * 3 * 2 * 8, dtype=jnp.float32).reshape(4, 3, 2, 8)
+    tgt = jnp.zeros((4, 4, 8), dtype=jnp.float32)
+    result = utils._unstack_scanned_param(src, tgt, key_path='test')[1]
+    # Should return layer 1 slice: shape (4, 2, 8)
+    np.testing.assert_equal(result.shape, (4, 2, 8))
+    np.testing.assert_array_equal(result, src[:, 1, :, :])
+
+  def test_transfer_state_directly_scanned_with_repeated_kv_heads(self):
+    """Scanned src + KV-head-repeated dst transfer works end-to-end."""
+    # src: scanned, shape (2, 2, 4) = (embed, layers, kv_heads*head_dim combined)
+    # Use small shapes: embed=4, layers=2, kv_heads=2, head_dim=4
+    # scanned param shape: (4, 2, 2, 4)
+    layer0 = jnp.array([[1., 2., 3., 4.], [5., 6., 7., 8.]], dtype=jnp.float32)  # (2, 4)
+    layer1 = jnp.array([[9., 10., 11., 12.], [13., 14., 15., 16.]], dtype=jnp.float32)
+    # Stack into scanned shape (2, 2, 4): [layer0, layer1] on axis 0
+    scanned = jnp.stack([layer0, layer1], axis=0)  # (2, 2, 4)
+    src_state = nnx.Dict(
+        layers=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(scanned)
+            )
+        )
+    )
+    # dst: unrolled, each layer has (4, 4) — 2x repeat on kv_heads axis
+    dst_state = nnx.Dict(
+        layers_0=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(jnp.zeros((4, 4), dtype=jnp.float32))
+            )
+        ),
+        layers_1=nnx.Dict(
+            attn=nnx.Dict(
+                kv_weight=nnx.Param(jnp.zeros((4, 4), dtype=jnp.float32))
+            )
+        ),
+    )
+    mock_reshard = lambda source, target: source
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+
+    expected_0 = jnp.repeat(layer0, 2, axis=0)  # (4, 4)
+    expected_1 = jnp.repeat(layer1, 2, axis=0)
+    np.testing.assert_array_equal(dst_state['layers_0']['attn']['kv_weight'][...], expected_0)
+    np.testing.assert_array_equal(dst_state['layers_1']['attn']['kv_weight'][...], expected_1)
 
   def test_sglang_jax_1d_kv_bias_alignment(self):
     """Test 1-D KV bias alignment for sglang_jax rollout engine."""

--- a/tests/generate/vllm_sampler_qwen_test.py
+++ b/tests/generate/vllm_sampler_qwen_test.py
@@ -30,6 +30,7 @@ from io import StringIO
 import os
 import sys
 import tempfile
+from unittest import mock
 from absl.testing import absltest
 from flax import nnx
 import jax
@@ -102,10 +103,13 @@ class VllmSamplerQwenTest(absltest.TestCase):
     sys.stderr = stderr_capture
 
     try:
-      # 4. Trigger param update to force mapping of the base model weights
-      sampler.load_checkpoint(nnx.state(base_model))
+      # Mock the RPC calls to delete and reinitialize kv cache
+      with mock.patch.object(sampler.llm, "reset_prefix_cache"), \
+           mock.patch.object(sampler.llm, "collective_rpc"):
+        # 4. Trigger param update to force mapping of the base model weights
+        sampler.load_checkpoint(nnx.state(base_model))
 
-      # 5. Check the mocked logger to see if it was called with mapping errors
+        # 5. Check the mocked logger to see if it was called with mapping errors
     finally:
       # Always restore stderr so we don't break console output for other tests
       sys.stderr = original_stderr

--- a/tests/generate/vllm_sampler_test.py
+++ b/tests/generate/vllm_sampler_test.py
@@ -176,7 +176,11 @@ class VllmSamplerTest(absltest.TestCase):
     # vLLM construct its own mesh
     self.assertNotEqual(vl_sampler.mesh, self.mesh)
     state = nnx.state(tunix_model)
-    vl_sampler.load_checkpoint(state)
+    # Mock the RPC calls to delete and reinitialize kv cache
+    mock_llm = vl_sampler._driver.llm_engine if server_mode else vl_sampler.llm
+    with mock.patch.object(mock_llm, "reset_prefix_cache"), \
+        mock.patch.object(mock_llm, "collective_rpc"):
+        vl_sampler.load_checkpoint(state)
 
     base_utils.show_hbm_usage("After loading vLLM sampler")
 
@@ -249,7 +253,10 @@ class VllmSamplerTest(absltest.TestCase):
     self.addCleanup(vl_sampler.stop)
 
     state = nnx.state(tunix_model)
-    vl_sampler.load_checkpoint(state)
+    # Mock the RPC calls to delete and reinitialize kv cache
+    with mock.patch.object(vl_sampler._driver.llm_engine, "reset_prefix_cache"), \
+        mock.patch.object(vl_sampler._driver.llm_engine, "collective_rpc"):
+        vl_sampler.load_checkpoint(state)
 
     base_prompts = [
         "Hello, my name is Tom.",
@@ -394,7 +401,10 @@ class VllmSamplerTest(absltest.TestCase):
     )
 
     state = nnx.state(tunix_model)
-    vl_sampler.load_checkpoint(state)
+    # Mock the RPC calls to delete and reinitialize kv cache
+    with mock.patch.object(vl_sampler.llm, "reset_prefix_cache"), \
+        mock.patch.object(vl_sampler.llm, "collective_rpc"):
+        vl_sampler.load_checkpoint(state)
 
     # Mock the generate method to capture sampling_params
     original_generate = vl_sampler.llm.generate
@@ -476,7 +486,10 @@ class VllmSamplerTest(absltest.TestCase):
     )
 
     state = nnx.state(tunix_model)
-    vl_sampler.load_checkpoint(state)
+    # Mock the RPC calls to delete and reinitialize kv cache
+    with mock.patch.object(vl_sampler.llm, "reset_prefix_cache"), \
+        mock.patch.object(vl_sampler.llm, "collective_rpc"):
+        vl_sampler.load_checkpoint(state)
 
     # Mock the generate method to capture sampling_params
     original_generate = vl_sampler.llm.generate

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -860,22 +860,39 @@ def transfer_state_with_mappings(
   return dst_state.from_flat_path(tgt_flat_list)
 
 
+def _shapes_are_repeatable(
+    candidate_shape: tuple[int, ...],
+    tgt_shape: tuple[int, ...],
+) -> bool:
+  """Returns True if candidate_shape can be repeated to match tgt_shape."""
+  if len(candidate_shape) != len(tgt_shape):
+    return False
+
+  for s, t in zip(candidate_shape, tgt_shape):
+    if s > t or t % s != 0:
+      return False
+  return True
+
+
 def _unstack_scanned_param(
     src_val: jax.Array | np.ndarray | Any,
     tgt_val: jax.Array | np.ndarray | Any,
     key_path: str,
+    scan_axis: Optional[int] = None,
 ) -> Tuple[jax.Array | np.ndarray | Any]:
   """Unstacks a scanned parameter by moving the scan axis to 0.
 
-  This helper finds the dimension in src_val that needs to be removed to match
-  tgt_val's shape, transposes that axis to the 0th position, and unstacks it. It
-  is used when transferring weights from a scanned representation (e.g., MaxText)
-  to an unrolled one (e.g., vLLM).
+  This helper unstacks a scanned array at the specified scan_axis. When scan_axis
+  is provided, it transposes that axis to position 0 and unstacks it. This is used
+  when transferring weights from a scanned representation (e.g., MaxText) to an
+  unrolled one (e.g., vLLM).
 
   Args:
     src_val: The source array (scanned) to slice from.
     tgt_val: The target array whose shape we want to match.
     key_path: The dot-separated path to the parameter for debugging.
+    scan_axis: The axis containing the scanned dimension. If None, attempts to
+      auto-detect it for backward compatibility.
 
   Returns:
       A tuple of unstacked arrays, or a tuple containing just the original src_val
@@ -891,15 +908,16 @@ def _unstack_scanned_param(
     return (src_val,)
 
   if len(src_shape) == len(tgt_shape) + 1:
-    scan_axis = None
-    # Check which dimension, when removed, matches the target shape
-    for i in range(len(src_shape)):
-      if src_shape[:i] + src_shape[i + 1 :] == tgt_shape:
-        scan_axis = i
-        break
-
+    # If scan_axis not provided, try to detect it
+    if scan_axis is None:
+      for i in range(len(src_shape)):
+        candidate = src_shape[:i] + src_shape[i + 1 :]
+        if _shapes_are_repeatable(candidate, tgt_shape):
+          scan_axis = i
+          break
+    
     if scan_axis is not None:
-      # 1. Transpose the scanned axis to the 0th position
+      # Transpose the scanned axis to the 0th position
       if scan_axis != 0:
         perm = (scan_axis,) + tuple(i for i in range(len(src_shape)) if i != scan_axis)
         if hasattr(src_val, 'transpose'):
@@ -907,7 +925,7 @@ def _unstack_scanned_param(
         elif isinstance(src_val, np.ndarray):
           src_val = np.transpose(src_val, perm)
 
-      # 2. Unstack along the 0th axis
+      # Unstack along the 0th axis
       # Handling JAX version differences where unstack might be under jnp
       try:
         if hasattr(jax, 'unstack'):
@@ -923,20 +941,85 @@ def _unstack_scanned_param(
             key_path, e
         )
         return (src_val,)
-
-    logging.warning(
-        "Shape mismatch in scanned param '%s'. Src: %s, Tgt: %s. Cannot"
-        ' determine scan axis.',
-        key_path, src_shape, tgt_shape,
-    )
+    else:
+      logging.warning(
+          "Shape mismatch in scanned param '%s'. Src: %s, Tgt: %s. Cannot"
+          ' determine scan axis.',
+          key_path, src_shape, tgt_shape,
+      )
 
   return (src_val,)
+
+
+def _repeat_to_model_shape(
+    src_val: jax.Array | np.ndarray | Any,
+    tgt_val: jax.Array | np.ndarray | Any,
+    key_path: str,
+) -> jax.Array | np.ndarray | Any:
+  """Repeats src_val to match tgt_val's shape if shapes are compatible multiples.
+
+  This is used to broadcast KV heads (or other dimensions) from a model with
+  fewer heads to one with more heads, e.g., when transferring GQA weights.
+
+  Args:
+      src_val: The source array to repeat.
+      tgt_val: The target array whose shape we want to match.
+      key_path: Path string for debug logging.
+
+  Returns:
+      A repeated version of src_val matching tgt_val's shape, or src_val
+      unchanged if shapes already match or repeating is not possible.
+  """
+  if not (hasattr(src_val, 'shape') and hasattr(tgt_val, 'shape')):
+    return src_val
+
+  src_shape = src_val.shape
+  tgt_shape = tgt_val.shape
+
+  if src_shape == tgt_shape:
+    return src_val
+
+  if len(src_shape) != len(tgt_shape):
+    return src_val
+
+  for src_dim, tgt_dim in zip(src_shape, tgt_shape):
+    if src_dim > tgt_dim or tgt_dim % src_dim != 0:
+      return src_val
+
+  logging.info(
+      "Repeating '%s' from %s to %s.",
+      key_path, src_shape, tgt_shape,
+  )
+  result = src_val
+  for axis, (src_dim, tgt_dim) in enumerate(zip(src_shape, tgt_shape)):
+    if tgt_dim != src_dim:
+      result = jnp.repeat(result, tgt_dim // src_dim, axis=axis)
+
+  return result
+
+
+def _delete_pytree_buffers(pytree: Any) -> None:
+  """Deletes buffers of jax.Arrays in a pytree to save memory."""
+  logging.info('Deleting pytree buffers.')
+
+  def _delete_buffers(x):
+    if isinstance(x, nnx.Variable) and isinstance(x.value, jax.Array):
+      if not x.value.is_deleted():
+        x.value.delete()
+    elif isinstance(x, jax.Array):
+      if not x.is_deleted():
+        x.delete()
+    return x
+
+  jax.tree_util.tree_map(_delete_buffers, pytree)
 
 
 def transfer_state_directly(
     src_state: Mapping[str, Any],
     dst_state: Mapping[str, Any],
     reshard_fn: Callable[..., Mapping[str, Any]],
+    scan_axis: int = 1,
+    delete_dst_buffers: bool = False,
 ) -> None:
   """Transfers state directly by matching structure, stripping wrappers.
 
@@ -951,7 +1034,13 @@ def transfer_state_directly(
     src_state: The source state to transfer from.
     dst_state: The destination state to transfer to.
     reshard_fn: A function to shard the values.
+    scan_axis: The axis along which to unroll scanned layers, if needed.
+    delete_dst_buffers: Whether to delete buffers in the destination state after transfer to save memory.
   """
+
+  if delete_dst_buffers:
+    _delete_pytree_buffers(dst_state)
+    gc.collect()
 
   def safe_has_key(obj: Mapping[str, Any], key: str) -> bool:
     if isinstance(obj, dict):
@@ -1017,11 +1106,15 @@ def transfer_state_directly(
 
     layer_pattern = re.compile(r'^layers_(\d+)$')
 
+    # Cache to store unstacked scanned arrays to avoid repeated work
+    unstacked_cache = {}
+
     for key_tuple, tgt_val in tgt_flat.items():
       # Try Direct Match
       if key_tuple in src_flat:
         src_val = src_flat[key_tuple]
         src_val = _apply_dtype_cast(src_val, tgt_val.dtype, str(key_tuple))
+        src_val = _repeat_to_model_shape(src_val, tgt_val, str(key_tuple))
         filtered_src_flat[key_tuple] = src_val
         filtered_tgt_flat[key_tuple] = tgt_val
         continue
@@ -1060,31 +1153,35 @@ def transfer_state_directly(
             break
 
         if found_candidate:
-          # Cache unstacked params to guarantee we only transpose/unstack ONCE
+          # Apply the dtype cast and the repeating *before* unstacking
           if found_candidate not in unstacked_cache:
             src_val = src_flat[found_candidate]
+            
+            # Cast the bulk tensor once
+            src_val = _apply_dtype_cast(src_val, tgt_val.dtype, str(found_candidate))
+            
+            # Predict the stacked target shape and repeat the bulk tensor once
+            src_shape = getattr(src_val, 'shape', None)
+            tgt_shape = getattr(tgt_val, 'shape', None)
+            
+            if src_shape and tgt_shape and len(src_shape) == len(tgt_shape) + 1:
+              # Construct the 3D target shape (e.g., [layers, global_heads, dim])
+              stacked_tgt_shape = tgt_shape[:scan_axis] + (src_shape[scan_axis],) + tgt_shape[scan_axis:]
+              
+              # Mock a target array purely to pass the shape to our repeat helper
+              class _MockTarget:
+                shape = stacked_tgt_shape
+                
+              src_val = _repeat_to_model_shape(src_val, _MockTarget(), str(found_candidate))
+            
+            # Unstack the already casted and repeated tensor using the provided scan_axis
             unstacked_cache[found_candidate] = _unstack_scanned_param(
-                src_val, tgt_val, str(found_candidate)
+                src_val, tgt_val, str(found_candidate), scan_axis=scan_axis
             )
+          
+          # Extract the layer_idx-th element from the unstacked cache
+          sliced_val = unstacked_cache[found_candidate][layer_idx]
 
-          unstacked_list = unstacked_cache[found_candidate]
-
-          try:
-            # Handle fallback cases where unstacking returned original value
-            if len(unstacked_list) == 1 and layer_idx > 0:
-              sliced_val = unstacked_list[0]
-            else:
-              sliced_val = unstacked_list[layer_idx]
-          except IndexError as e:
-            logging.debug(
-                "Index error pulling layer %d for '%s'. Error: %s. Using original.",
-                layer_idx, found_candidate, e
-            )
-            sliced_val = src_flat[found_candidate]
-
-          sliced_val = _apply_dtype_cast(
-              sliced_val, tgt_val.dtype, str(key_tuple)
-          )
           filtered_src_flat[key_tuple] = sliced_val
           filtered_tgt_flat[key_tuple] = tgt_val
           continue

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -16,6 +16,7 @@
 
 import atexit
 import dataclasses
+import gc
 from itertools import count
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -175,13 +176,24 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
       )
 
   # TODO(b/434969743): Optimize weight sharing between trainer and vllm sampler.
-  # TODO(b/434975493): Consider Release KV cache on the fly
   def update_params(
       self,
       updated_weights: jaxtyping.PyTree,
       filter_types: Optional[Tuple[Any, ...]] = None,
   ):
     del filter_types
+
+    if self.llm is not None:
+      self.llm.reset_prefix_cache()
+      self.llm.collective_rpc("delete_kv_cache") # will free hbm
+    elif self._driver is not None:
+      self._driver.llm_engine.reset_prefix_cache()
+      self._driver.llm_engine.collective_rpc("delete_kv_cache")
+    
+    # Perform explicit garbage collection and synchronization to free up HBM memory before loading new weights
+    gc.collect()
+    jax.clear_caches()
+    jax.effects_barrier()
 
     if self.to_hf_key_mappings:
       # Mapped Weight Sync (e.g. Vanilla -> vLLM)
@@ -223,7 +235,13 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           src_state=updated_weights,
           dst_state=self.transformer_state,
           reshard_fn=reshard.reshard_pytree,
+          delete_dst_buffers=True,  # Ensure old weights are deleted to free up HBM memory
       )
+    
+    if self.llm is not None:
+      self.llm.collective_rpc("reinitialize_kv_cache")
+    elif self._driver is not None:
+      self._driver.llm_engine.collective_rpc("reinitialize_kv_cache")
 
   def load_checkpoint(self, path_or_weights: str | jaxtyping.PyTree):
     # TODO(b/434741253): Consider support orbax checkpoint loading


### PR DESCRIPTION
Adds support for repeating the KV projection tensors in attention over the num heads dimension. This matches the logic in `tpu-inference` and allows us to shard sampler models over the `expert` mesh axis. 

Additionally this PR introduces two additional features to reduce peak HBM utilization during resharding. First, we introduce logic to delete the outdated sampler model parameters on sampler TPUs (credit to @lc5211!). Second we introduce KV cache clearing to deallocate KV Cache memory during resharding (Thanks to @wang2yn84 for the help!).

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
