### PR TITLE
Fix Qwen2 KV-cache dtype mismatch in cached decoding

### DIFF
--- a/tests/models/qwen2_kv_cache_dtype_test.py
+++ b/tests/models/qwen2_kv_cache_dtype_test.py
@@ -1,0 +1,47 @@
+from absl.testing import absltest
+from flax import nnx
+import jax.numpy as jnp
+from tunix.models.qwen2 import model as qwen2_model
+
+
+class Qwen2KvCacheDtypeTest(absltest.TestCase):
+
+  def test_attention_cache_update_casts_to_cache_dtype(self):
+    cfg = qwen2_model.ModelConfig(
+        num_layers=1,
+        vocab_size=32,
+        embed_dim=8,
+        hidden_dim=16,
+        num_heads=2,
+        head_dim=4,
+        num_kv_heads=1,
+        rope_theta=10000,
+        norm_eps=1e-6,
+        shd_config=qwen2_model.ShardingConfig.get_default_sharding(),
+        dtype=jnp.float32,
+        param_dtype=jnp.float32,
+        use_flash_attention=False,
+    )
+
+    attn = qwen2_model.Attention(cfg, rngs=nnx.Rngs(0))
+    x = jnp.zeros((1, 1, cfg.embed_dim), dtype=jnp.float32)
+    sin = jnp.zeros((1, 1, cfg.head_dim // 2), dtype=jnp.float32)
+    cos = jnp.ones((1, 1, cfg.head_dim // 2), dtype=jnp.float32)
+    cache = {
+        'end_index': jnp.array([0], dtype=jnp.int32),
+        'v': jnp.zeros((1, 4, cfg.num_kv_heads, cfg.head_dim), dtype=jnp.bfloat16),
+        'k': jnp.zeros((1, 4, cfg.num_kv_heads, cfg.head_dim), dtype=jnp.bfloat16),
+    }
+
+    new_cache, _ = attn.block(x, cache, None, sin, cos)
+
+    self.assertIsNotNone(new_cache)
+    self.assertEqual(new_cache['v'].dtype, cache['v'].dtype)
+    self.assertEqual(new_cache['k'].dtype, cache['k'].dtype)
+    self.assertEqual(new_cache['v'].shape, cache['v'].shape)
+    self.assertEqual(new_cache['k'].shape, cache['k'].shape)
+    self.assertEqual(int(new_cache['end_index'][0]), 1)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tunix/models/qwen2/model.py
+++ b/tunix/models/qwen2/model.py
@@ -471,11 +471,13 @@ class Attention(nnx.Module):
     if cache is not None:
       end_index = cache['end_index'][0]
       slice_indices = (0, end_index % cache['v'].shape[1], 0, 0)
+      value_proj = value_proj.astype(cache['v'].dtype)
       value_proj = jax.lax.dynamic_update_slice(
           cache['v'],
           value_proj,
           slice_indices,
       )
+      key_proj = key_proj.astype(cache['k'].dtype)
       key_proj = jax.lax.dynamic_update_slice(
           cache['k'], key_proj, slice_indices
       )


### PR DESCRIPTION
Resolves #1321 

This PR fixes a dtype mismatch in the Qwen2 cached decoding path.

In `tunix/models/qwen2/model.py`, `value_proj` and `key_proj` are written into
`cache['v']` / `cache['k']` via `jax.lax.dynamic_update_slice(...)` without
first matching the cache dtype:

```python
value_proj = jax.lax.dynamic_update_slice(
    cache['v'],
    value_proj,
    slice_indices,
)
key_proj = jax.lax.dynamic_update_slice(
    cache['k'], key_proj, slice_indices
)
```

When the projection dtype differs from the cache dtype,
`jax.lax.dynamic_update_slice(...)` raises a dtype mismatch error.
This PR adds explicit casts to `cache['v'].dtype` / `cache['k'].dtype`
immediately before the cache update.

The change is intentionally minimal and only affects the Qwen2 cache update
path in `tunix/models/qwen2/model.py`.

**Reference**

- GitHub issue: #1321 
- Affected file: `tunix/models/qwen2/model.py`
- Reproduction steps and observed traceback are included in the linked issue.
- Regression test: `tests/models/qwen2_kv_cache_dtype_test.py`

**Colab Notebook**

- N/A; this PR adds a regression unit test instead.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [X] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
