### PR TITLE
Fix typo in reward_manager docstring

### DIFF
--- a/tunix/rl/reward_manager.py
+++ b/tunix/rl/reward_manager.py
@@ -92,7 +92,7 @@ class SequenceRewardManager(AbstractRewardManager):
       completions: List[str],
       **kwargs,
   ) -> Dict[str, Any]:
-    """Computes the rewards for completions using the provided reward function, and return the sequence-level rewards information for advantage computationand logging."""
+    """Computes the rewards for completions using the provided reward function, and return the sequence-level rewards information for advantage computation and logging."""
     return self._compute_rewards(prompts, completions, **kwargs)
 
   def _compute_rewards(


### PR DESCRIPTION
Fix missing space: `computationand` → `computation and`