### PR TITLE
Add RLOO (REINFORCE Leave-One-Out) learner for lower-variance policy …

### DIFF
--- a/examples/rl/rloo/gsm8k/run_qwen3.sh
+++ b/examples/rl/rloo/gsm8k/run_qwen3.sh
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RLOO (REINFORCE Leave-One-Out) training example on GSM8K with Qwen3.
+#
+# RLOO replaces GRPO's group-mean advantage baseline with a leave-one-out
+# baseline, providing lower variance while remaining unbiased. This is
+# especially effective with moderate group sizes (num_generations=4-16).
+#
+# Reference: Ahmadian et al., "Back to Basics: Revisiting REINFORCE-Style
+# Optimization for Learning from Human Feedback in LLMs", 2024.
+# https://arxiv.org/abs/2402.14740
+#
+# Usage:
+#   bash examples/rl/rloo/gsm8k/run_qwen3.sh
+#
+# To customize:
+#   model_name=Qwen3-4B-base num_generations=8 bash examples/rl/rloo/gsm8k/run_qwen3.sh
+
+set -x # Enable xtrace
+
+# specify at cmd line to override defaults, e.g.
+model_name=${model_name:-"Qwen3-1.7B-base"}
+batch_size=${batch_size:-8}
+num_train_epochs=${num_train_epochs:-1}
+warmup_ratio=${warmup_ratio:-0.1}
+train_fraction=${train_fraction:-0.8}
+num_generations=${num_generations:-8}
+
+echo "Using parameters:"
+echo "  Model: $model_name"
+echo "  Batch Size: $batch_size"
+echo "  Num Epochs: $num_train_epochs"
+echo "  Warmup Ratio: $warmup_ratio"
+echo "  Train Fraction: $train_fraction"
+echo "  Num Generations (RLOO group size): $num_generations"
+
+python3 -m tunix.cli.grpo_main \
+  base_config.yaml \
+  model_config.model_name=${model_name} \
+  model_config.model_id=Qwen/${model_name} \
+  model_config.model_source=huggingface \
+  model_config.use_flash_attention=true \
+  model_config.flash_attention_block_size=256 \
+  model_config.intermediate_ckpt_dir="/tmp/intermediate_ckpt/${model_name}_rloo" \
+  model_config.mesh.shape="(2,4)" \
+  model_config.mesh.axis_names="('fsdp','tp')" \
+  model_config.rng_seed=42 \
+  actor_model_config.lora_config.rank=64 \
+  actor_model_config.lora_config.alpha=64.0 \
+  actor_model_config.lora_config.module_path=".*q_einsum|.*kv_einsum|.*gate_proj|.*down_proj|.*up_proj|.*attn_vec_einsum" \
+  actor_model_config.mesh.shape="(2,4)" \
+  actor_model_config.mesh.axis_names="('fsdp','tp')" \
+  rollout_model_config.mesh.shape="(2,4)" \
+  rollout_model_config.mesh.axis_names="('fsdp','tp')" \
+  tokenizer_config.tokenizer_path=Qwen/${model_name} \
+  tokenizer_config.tokenizer_type=huggingface \
+  tokenizer_config.add_bos=false \
+  dataset_name="gsm8k" \
+  batch_size=$batch_size \
+  num_test_batches=100 \
+  num_train_epochs=$num_train_epochs \
+  rl_training_config.actor_optimizer_config.opt_type="adamw" \
+  rl_training_config.actor_optimizer_config.peak_value=3e-6 \
+  rl_training_config.actor_optimizer_config.schedule_type="warmup_cosine_decay_schedule" \
+  rl_training_config.actor_optimizer_config.init_value=0.0 \
+  rl_training_config.actor_optimizer_config.end_value=0.0 \
+  rl_training_config.actor_optimizer_config.warmup_ratio=$warmup_ratio \
+  rl_training_config.actor_optimizer_config.b1=0.9 \
+  rl_training_config.actor_optimizer_config.b2=0.99 \
+  rl_training_config.actor_optimizer_config.weight_decay=0.1 \
+  rl_training_config.actor_optimizer_config.max_grad_norm=0.1 \
+  rl_training_config.eval_every_n_steps=10 \
+  rl_training_config.metrics_logging_options.log_dir="/tmp/tensorboard/${model_name}_rloo" \
+  rl_training_config.metrics_logging_options.flush_every_n_steps=20 \
+  rl_training_config.checkpointing_options.save_interval_steps=500 \
+  rl_training_config.checkpointing_options.max_to_keep=4 \
+  rl_training_config.profiler_options={} \
+  rollout_config.total_generation_steps=768 \
+  rollout_config.max_prompt_length=256 \
+  rollout_config.temperature=0.9 \
+  rollout_config.top_p=1.0 \
+  rollout_config.top_k=50 \
+  rollout_engine="vanilla" \
+  offload_to_cpu=false \
+  grpo_config.advantage_estimator=rloo \
+  grpo_config.num_generations=$num_generations \
+  grpo_config.num_iterations=1 \
+  grpo_config.beta=0.04 \
+  grpo_config.epsilon=0.2 \
+  grpo_config.loss_agg_mode=token-mean \
+  reward_functions="['tunix/cli/reward_fn/gsm8k.py']"

--- a/tests/rl/grpo/rloo_learner_test.py
+++ b/tests/rl/grpo/rloo_learner_test.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for RLOO (REINFORCE Leave-One-Out) learner."""
+
+import os
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from tunix.rl.grpo import rloo_learner as rloo_lib
+from tunix.tests import grpo_test_base
+from tunix.tests import test_common as tc
+
+os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=2'
+
+
+class RLOOConfigTest(parameterized.TestCase):
+  """Tests for RLOOConfig defaults and validation."""
+
+  def test_defaults(self):
+    config = rloo_lib.RLOOConfig(num_generations=4)
+    self.assertEqual(config.algo_variant, 'rloo')
+    self.assertEqual(config.advantage_estimator, 'rloo')
+    self.assertEqual(config.loss_agg_mode, 'token-mean')
+    self.assertEqual(config.policy_loss_fn, 'grpo')
+
+  def test_custom_params_preserve_fixed_fields(self):
+    config = rloo_lib.RLOOConfig(
+        num_generations=8,
+        num_iterations=2,
+        beta=0.1,
+        epsilon=0.3,
+        loss_agg_mode='sequence-mean-token-mean',
+    )
+    self.assertEqual(config.num_generations, 8)
+    self.assertEqual(config.num_iterations, 2)
+    self.assertEqual(config.beta, 0.1)
+    self.assertEqual(config.epsilon, 0.3)
+    self.assertEqual(config.loss_agg_mode, 'sequence-mean-token-mean')
+    # init=False fields cannot be overridden by callers.
+    self.assertEqual(config.algo_variant, 'rloo')
+    self.assertEqual(config.advantage_estimator, 'rloo')
+
+  def test_rejects_single_generation(self):
+    with self.assertRaisesRegex(ValueError, 'num_generations'):
+      rloo_lib.RLOOConfig(num_generations=1)
+
+
+class RLOOAdvantageTest(parameterized.TestCase):
+  """Tests for the RLOO advantage estimator function."""
+
+  def test_basic(self):
+    rewards = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    # Group 1: [1, 2, 3]; LOO baselines: [2.5, 2.0, 1.5].
+    # Group 2: [4, 5, 6]; LOO baselines: [5.5, 5.0, 4.5].
+    advantages = rloo_lib.compute_rloo_advantages(rewards, num_generations=3)
+    expected = np.array([-1.5, 0.0, 1.5, -1.5, 0.0, 1.5])
+    np.testing.assert_allclose(advantages, expected)
+
+  def test_single_generation_returns_zeros(self):
+    rewards = np.array([1.0, 2.0])
+    advantages = rloo_lib.compute_rloo_advantages(rewards, num_generations=1)
+    np.testing.assert_allclose(advantages, np.zeros_like(rewards))
+
+  def test_two_generations(self):
+    # With G=2 the LOO baseline for each sample is just the other one.
+    rewards = np.array([3.0, 7.0, 1.0, 5.0])
+    advantages = rloo_lib.compute_rloo_advantages(rewards, num_generations=2)
+    expected = np.array([-4.0, 4.0, -4.0, 4.0])
+    np.testing.assert_allclose(advantages, expected)
+
+  def test_equal_rewards_yield_zero_advantages(self):
+    rewards = np.array([5.0, 5.0, 5.0, 5.0])
+    advantages = rloo_lib.compute_rloo_advantages(rewards, num_generations=2)
+    np.testing.assert_allclose(advantages, np.zeros(4))
+
+  def test_advantages_sum_to_zero_per_group(self):
+    rng = np.random.default_rng(42)
+    num_generations = 4
+    num_groups = 3
+    rewards = rng.standard_normal(num_groups * num_generations)
+    advantages = rloo_lib.compute_rloo_advantages(
+        rewards, num_generations=num_generations
+    )
+    reshaped = advantages.reshape(-1, num_generations)
+    np.testing.assert_allclose(
+        reshaped.sum(axis=-1), np.zeros(num_groups), atol=1e-6
+    )
+
+  def test_registered_in_advantage_registry(self):
+    """RLOOLearner relies on advantage_estimator='rloo' being registered."""
+    from tunix.rl import function_registry
+    fn = function_registry.get_advantage_estimator('rloo')
+    self.assertIs(fn, rloo_lib.compute_rloo_advantages)
+
+
+class RLOOLearnerTest(parameterized.TestCase):
+  """End-to-end tests for the RLOO learner training loop."""
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    num_cpus = int(os.environ.get('DEVICE_COUNTS', 2))
+    chex.set_n_cpu_devices(num_cpus)
+
+  @parameterized.named_parameters(
+      dict(
+          testcase_name='single_reward_fn',
+          reward_fns=grpo_test_base.reward_1,
+      ),
+      dict(
+          testcase_name='multiple_reward_fns',
+          reward_fns=[grpo_test_base.reward_1, grpo_test_base.reward_2],
+      ),
+  )
+  def test_trains_and_updates_params(self, reward_fns):
+    rl_cluster, model, original_variables = grpo_test_base.setup(
+        {'eval_every_n_steps': 2}
+    )
+    rl_cluster.with_external_metrics_logger(print)
+    learner = rloo_lib.RLOOLearner(
+        rl_cluster=rl_cluster,
+        reward_fns=reward_fns,
+        algo_config=rloo_lib.RLOOConfig(num_generations=2, num_iterations=1),
+        metric_fns=[lambda **kwargs: {'test_metric': (1.0, np.mean)}],
+    )
+    self.assertFalse(learner.should_sync_weights)
+    self.assertFalse(learner.can_enable_async_rollout)
+
+    train_ds = grpo_test_base.dummy_dataset(
+        grpo_test_base.MySource(repeat=10), batch_size=2
+    )
+    eval_ds = grpo_test_base.dummy_dataset(batch_size=1)
+    learner.train(train_ds, eval_ds)
+
+    variables = nnx.state(model, nnx.Param)
+    jax.tree.map_with_path(tc.assert_not_equal, original_variables, variables)
+    self.assertEqual(learner._iter_steps, 10)
+
+  def test_trains_with_kl_disabled(self):
+    """beta=0.0 should skip reference inference and still update params."""
+    rl_cluster, model, original_variables = grpo_test_base.setup(
+        {'eval_every_n_steps': 2}
+    )
+    learner = rloo_lib.RLOOLearner(
+        rl_cluster=rl_cluster,
+        reward_fns=grpo_test_base.reward_1,
+        algo_config=rloo_lib.RLOOConfig(
+            num_generations=2, num_iterations=1, beta=0.0
+        ),
+    )
+    train_ds = grpo_test_base.dummy_dataset(
+        grpo_test_base.MySource(repeat=10), batch_size=2
+    )
+    learner.train(train_ds)
+
+    variables = nnx.state(model, nnx.Param)
+    jax.tree.map_with_path(tc.assert_not_equal, original_variables, variables)
+
+  def test_trains_with_multiple_iterations(self):
+    rl_cluster, model, original_variables = grpo_test_base.setup(
+        {'eval_every_n_steps': 5}
+    )
+    learner = rloo_lib.RLOOLearner(
+        rl_cluster=rl_cluster,
+        reward_fns=grpo_test_base.reward_1,
+        algo_config=rloo_lib.RLOOConfig(num_generations=2, num_iterations=2),
+    )
+    train_ds = grpo_test_base.dummy_dataset(
+        grpo_test_base.MySource(repeat=10), batch_size=2
+    )
+    learner.train(train_ds)
+
+    variables = nnx.state(model, nnx.Param)
+    jax.tree.map_with_path(tc.assert_not_equal, original_variables, variables)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tunix/cli/base_config.yaml
+++ b/tunix/cli/base_config.yaml
@@ -211,6 +211,17 @@ grpo_config:
   # stable updates.
   epsilon: 0.2
 
+  # The advantage estimator to use. Supported values: "grpo", "rloo", "drgrpo".
+  # - "grpo": Group-mean baseline (default).
+  # - "rloo": Leave-one-out baseline for lower variance.
+  # - "drgrpo": Dr.GRPO advantage without centering/normalization.
+  # advantage_estimator: grpo
+
+  # The loss aggregation mode. Supported values:
+  # "sequence-mean-token-mean" (default), "token-mean",
+  # "sequence-mean-token-scale", "sequence-mean-token-sum-norm".
+  # loss_agg_mode: sequence-mean-token-mean
+
 
 ############################### Rollout Config ###############################
 rollout_config:

--- a/tunix/cli/grpo_main.py
+++ b/tunix/cli/grpo_main.py
@@ -54,7 +54,6 @@ from tunix.perf.experimental import export as perf_export_v2
 from tunix.rl import rl_cluster as rl_cluster_lib
 from tunix.rl.rollout import base_rollout
 
-
 _PATHWAYS_BNS = flags.DEFINE_string(
     "pathways_bns", None, "BNS address of the Pathways server."
 )
@@ -744,13 +743,7 @@ class GrpoPipeline(config.HyperParameters):
     rl_cluster = self.create_rl_cluster(tokenizer)
 
     if mode == "grpo":
-      from tunix.rl.grpo import grpo_learner
-
-      grpo_trainer = grpo_learner.GrpoLearner(
-          rl_cluster=rl_cluster,
-          reward_fns=self.obtain_reward_fn(),
-          algo_config=grpo_learner.GrpoConfig(**self.config["grpo_config"]),
-      )
+      grpo_trainer = self._create_grpo_learner(rl_cluster)
       grpo_trainer.train(dataset)
       return
 
@@ -788,6 +781,62 @@ class GrpoPipeline(config.HyperParameters):
 
     logging.info("Starting agentic GRPO training...")
     GRPOLearner(**learner_kwargs).train(dataset)
+
+  # ------------------------------------------------------------------
+  # Standard GRPO learner factory
+  # ------------------------------------------------------------------
+
+  # Maps advantage_estimator -> (module path, config class name, learner class
+  # name). Each entry resolves to a learner that shares the standard GRPO
+  # training loop but plugs in a different advantage estimator.
+  _STANDARD_GRPO_LEARNERS: dict[str, tuple[str, str, str]] = {
+      "grpo": ("tunix.rl.grpo.grpo_learner", "GrpoConfig", "GrpoLearner"),
+      "rloo": ("tunix.rl.grpo.rloo_learner", "RLOOConfig", "RLOOLearner"),
+      "drgrpo": (
+          "tunix.rl.grpo.drgrpo_learner",
+          "DrGRPOConfig",
+          "DrGRPOLearner",
+      ),
+  }
+
+  def _create_grpo_learner(self, rl_cluster: rl_cluster_lib.RLCluster):
+    """Build a standard GRPO learner based on ``grpo_config``.
+
+    The learner is selected by ``grpo_config.advantage_estimator``:
+
+    * ``"grpo"`` (default) — group-mean baseline.
+    * ``"rloo"`` — REINFORCE leave-one-out baseline (lower variance).
+    * ``"drgrpo"`` — Dr.GRPO (no centering/normalization).
+
+    Raises:
+      ValueError: if ``advantage_estimator`` is unknown.
+    """
+    grpo_config = dict(self.config["grpo_config"])
+    advantage_estimator = grpo_config.get("advantage_estimator", "grpo")
+
+    entry = self._STANDARD_GRPO_LEARNERS.get(advantage_estimator)
+    if entry is None:
+      supported = sorted(self._STANDARD_GRPO_LEARNERS)
+      raise ValueError(
+          f"Unsupported advantage_estimator {advantage_estimator!r} for"
+          f" training_mode='grpo'. Supported values: {supported}."
+      )
+    module_path, config_cls_name, learner_cls_name = entry
+    module = importlib.import_module(module_path)
+    config_cls = getattr(module, config_cls_name)
+    learner_cls = getattr(module, learner_cls_name)
+
+    # Subclass configs (RLOOConfig, DrGRPOConfig) declare ``algo_variant`` and
+    # ``advantage_estimator`` as init=False fields, so they cannot be passed via
+    # kwargs from YAML. Strip them before constructing the config.
+    init_fields = {f.name for f in dataclasses.fields(config_cls) if f.init}
+    config_kwargs = {k: v for k, v in grpo_config.items() if k in init_fields}
+
+    return learner_cls(
+        rl_cluster=rl_cluster,
+        reward_fns=self.obtain_reward_fn(),
+        algo_config=config_cls(**config_kwargs),
+    )
 
   # ------------------------------------------------------------------
   # Dispatcher

--- a/tunix/rl/algorithm_config.py
+++ b/tunix/rl/algorithm_config.py
@@ -36,8 +36,10 @@ class AlgorithmConfig:
         "gspo-token",
         "ppo",
         "dapo",
+        "drgrpo",
+        "rloo",
     ]
-    valid_advantage_estimators = ["grpo", "gae"]
+    valid_advantage_estimators = ["grpo", "gae", "drgrpo", "rloo"]
     valid_policy_loss_fns = ["grpo", "ppo"]
     if self.algo_variant not in valid_algo_variants:
       raise ValueError(

--- a/tunix/rl/grpo/rloo_learner.py
+++ b/tunix/rl/grpo/rloo_learner.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RLOO (REINFORCE Leave-One-Out) learner.
+
+RLOO is a variance-reduced policy gradient method that uses leave-one-out
+baselines. For each completion in a group, the baseline is the mean reward
+of all *other* completions to the same prompt. This yields an unbiased
+advantage estimator with lower variance than the group-mean baseline used
+in standard GRPO, without requiring a separate critic network.
+
+Reference:
+  - Ahmadian et al., "Back to Basics: Revisiting REINFORCE-Style Optimization
+    for Learning from Human Feedback in LLMs", 2024.
+    https://arxiv.org/abs/2402.14740
+"""
+
+import dataclasses
+from typing import List, Sequence
+
+import jax
+import jax.numpy as jnp
+from tunix.rl import function_registry
+from tunix.rl import rl_cluster as rl_cluster_lib
+from tunix.rl import rl_learner
+from tunix.rl.grpo import grpo_learner as grpo_learner_lib
+
+TrainingInputT = rl_learner.TrainingInputT
+RewardFn = rl_learner.RewardFn
+MetricFn = rl_learner.MetricFn
+
+
+@function_registry.register_advantage_estimator("rloo")
+def compute_rloo_advantages(
+    rewards: jax.Array, num_generations: int
+) -> jax.Array:
+  """Compute RLOO (REINFORCE Leave-One-Out) advantages.
+
+  For each completion, the baseline is the mean reward of all *other*
+  completions in the same generation group. The advantage is the completion's
+  reward minus this leave-one-out baseline:
+
+      baseline_i = (sum(rewards in group) - reward_i) / (G - 1)
+      advantage_i = reward_i - baseline_i
+
+  This produces unbiased advantage estimates with lower variance than the
+  group-mean baseline used in standard GRPO.
+
+  Args:
+    rewards: Flat reward array of shape ``[B * G]`` where ``B`` is the number
+      of unique prompts and ``G`` is ``num_generations``. Rewards for the same
+      prompt must be contiguous.
+    num_generations: Number of generations per prompt (``G``). Must be >= 2;
+      otherwise zeros are returned (no baseline can be computed).
+
+  Returns:
+    Flat advantage array of the same shape as ``rewards``. Within each group,
+    the advantages sum to zero.
+  """
+  if num_generations < 2:
+    # RLOO requires at least 2 samples to calculate a baseline.
+    return jnp.zeros_like(rewards)
+
+  reshaped_rewards = rewards.reshape(-1, num_generations)
+  loo_mean = (
+      reshaped_rewards.sum(axis=-1, keepdims=True) - reshaped_rewards
+  ) / (num_generations - 1)
+  rloo_advantages = reshaped_rewards - loo_mean
+
+  return rloo_advantages.flatten()
+
+
+@dataclasses.dataclass(slots=True, kw_only=True)
+class RLOOConfig(grpo_learner_lib.GRPOConfig):
+  """Configuration for RLOO (REINFORCE Leave-One-Out).
+
+  RLOO replaces GRPO's group-mean advantage estimator with a leave-one-out
+  baseline, which provides lower variance while remaining unbiased. The
+  advantage for each completion is computed as its reward minus the mean
+  reward of all other completions to the same prompt.
+
+  This is particularly effective when ``num_generations`` is moderate (4-16),
+  as the leave-one-out baseline becomes more accurate with more samples.
+
+  Attributes:
+    algo_variant: The algorithm variant identifier. Always ``rloo``.
+    advantage_estimator: The advantage estimator to use. Always ``rloo``.
+    loss_agg_mode: The aggregation mode for the loss function. Defaults to
+      ``token-mean`` following the RLOO paper's recommendation for
+      token-level normalization.
+
+  References:
+    - RLOO: https://arxiv.org/abs/2402.14740
+  """
+
+  algo_variant: str = dataclasses.field(default="rloo", init=False)
+  advantage_estimator: str = dataclasses.field(default="rloo", init=False)
+  loss_agg_mode: str = "token-mean"
+
+
+class RLOOLearner(grpo_learner_lib.GrpoLearner[RLOOConfig]):
+  """RLOO (REINFORCE Leave-One-Out) learner.
+
+  RLOO is a reinforcement learning algorithm that improves upon GRPO by using
+  leave-one-out baselines for advantage estimation. For each completion in a
+  group, the baseline is the average reward of all *other* completions to
+  the same prompt, rather than the group mean (which includes the completion
+  itself).
+
+  This approach:
+    - Produces unbiased advantage estimates (like GRPO).
+    - Achieves lower variance than the standard group-mean baseline.
+    - Requires no additional model parameters (unlike PPO's critic).
+    - Is most effective with moderate group sizes (4-16 generations).
+
+  The learner inherits the full GRPO training loop, including clipped
+  importance sampling, optional KL penalty, and multi-iteration support.
+  Only the advantage computation differs.
+
+  Example usage::
+
+      rloo_config = RLOOConfig(
+          num_generations=8,
+          beta=0.04,
+          epsilon=0.2,
+      )
+      learner = RLOOLearner(
+          rl_cluster=rl_cluster,
+          algo_config=rloo_config,
+          reward_fns=reward_fn,
+      )
+      learner.train(train_ds)
+  """
+
+  def __init__(
+      self,
+      rl_cluster: rl_cluster_lib.RLCluster,
+      algo_config: RLOOConfig,
+      reward_fns: RewardFn | List[RewardFn],
+      metric_fns: Sequence[MetricFn] | None = None,
+      data_shuffle_seed: int | None = None,
+  ):
+    """Initializes the ``RLOOLearner``.
+
+    Args:
+      rl_cluster: RL cluster containing actor, reference and reward models.
+      algo_config: An instance of ``RLOOConfig`` containing all
+        training-specific configuration options.
+      reward_fns: A single callable or a list of callables that compute a
+        scalar reward for given prompts and completions. Each function should
+        accept ``prompts``, ``completions`` and optional keyword arguments,
+        and return a list of float rewards.
+      metric_fns: A sequence of callables that compute metrics for the
+        completions.
+      data_shuffle_seed: The seed used to shuffle the training data.
+    """
+    super().__init__(
+        rl_cluster=rl_cluster,
+        algo_config=algo_config,
+        reward_fns=reward_fns,
+        metric_fns=metric_fns,
+        data_shuffle_seed=data_shuffle_seed,
+    )

--- a/tunix/tests/grpo_test_base.py
+++ b/tunix/tests/grpo_test_base.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared test helpers for GRPO-family learner tests.
+
+Centralizes the toy-model RLCluster setup, dummy datasets, and reward
+functions used by GRPOLearner, RLOOLearner, DrGRPOLearner, etc. Tests should
+import from here rather than duplicating these helpers.
+"""
+
+from typing import Any, Dict, Optional
+
+from flax import nnx
+from grain import python as grain
+import jax
+from jax.interpreters import pxla
+import jax.numpy as jnp
+import optax
+from tunix.rl import rl_cluster as rl_cluster_lib
+from tunix.rl.rollout import base_rollout
+from tunix.tests import test_common as tc
+
+# Token strings defined in MockVocab in test_common.py.
+DUMMY_DATA = [
+    'input string',
+    'hello world',
+    'My name',
+    'hello there',
+]
+
+
+def reward_1(completions, **kargs):  # pylint: disable=unused-argument
+  """Reward function returning a per-completion rank."""
+  return jnp.arange(len(completions))
+
+
+def reward_2(prompts, answer, **kargs):  # pylint: disable=unused-argument
+  """Reward function that depends on the optional ``answer`` field."""
+  return jnp.arange(len(answer))
+
+
+class MySource(grain.RandomAccessDataSource):
+  """A simple grain data source backed by an in-memory list."""
+
+  def __init__(self, data=None, repeat=1):
+    if data is None:
+      data = DUMMY_DATA
+    self._data = data * repeat
+
+  def __getitem__(self, idx):
+    return self._data[idx]
+
+  def __len__(self):
+    return len(self._data)
+
+
+def dummy_dataset(source: Optional[grain.RandomAccessDataSource] = None,
+                  batch_size: int = 1):
+  """Builds a batched grain dataset yielding ``{'prompts', 'answer'}`` dicts."""
+  if source is None:
+    source = MySource()
+  return (
+      grain.MapDataset.source(source)
+      .batch(batch_size)
+      .map(lambda x: {'prompts': x, 'answer': x})
+  )
+
+
+def setup(kwargs: Optional[Dict[str, Any]] = None):
+  """Builds a toy RLCluster with matching actor/reference models.
+
+  Returns:
+    A tuple ``(rl_cluster, model, original_variables)`` where
+    ``original_variables`` is a snapshot of the actor parameters before any
+    training, useful for asserting that training updates the parameters.
+  """
+  if kwargs is None:
+    kwargs = {}
+  vocab = tc.MockVocab()
+  model = tc.ToyTransformer(
+      config=tc.ModelConfig(vocab_size=vocab.GetPieceSize()),
+      rngs=nnx.Rngs(0),
+  )
+  original_variables = jax.tree.map(jnp.copy, nnx.state(model, nnx.Param))
+  ref_model = tc.ToyTransformer(
+      config=tc.ModelConfig(vocab_size=vocab.GetPieceSize()), rngs=nnx.Rngs(0)
+  )
+
+  mesh = pxla.thread_resources.env.physical_mesh
+  cluster_config = rl_cluster_lib.ClusterConfig(
+      role_to_mesh={
+          rl_cluster_lib.Role.ACTOR: mesh,
+          rl_cluster_lib.Role.REFERENCE: mesh,
+          rl_cluster_lib.Role.ROLLOUT: mesh,
+      },
+      rollout_engine='vanilla',
+      offload_to_cpu=False,
+      training_config=rl_cluster_lib.RLTrainingConfig(
+          actor_optimizer=optax.sgd(1e-3),
+          eval_every_n_steps=kwargs.get('eval_every_n_steps', 2),
+          max_steps=10,
+          gradient_accumulation_steps=kwargs.get(
+              'gradient_accumulation_steps', None
+          ),
+          max_seq_token_per_tpu=kwargs.get('max_seq_token_per_tpu', None),
+      ),
+      rollout_config=base_rollout.RolloutConfig(
+          max_tokens_to_generate=10,
+          max_prompt_length=256,
+          kv_cache_size=1024,
+      ),
+  )
+  rl_cluster = rl_cluster_lib.RLCluster(
+      actor=model,
+      reference=ref_model,
+      tokenizer=vocab,
+      cluster_config=cluster_config,
+  )
+  return rl_cluster, model, original_variables


### PR DESCRIPTION
## Summary

Implements the RLOO (REINFORCE Leave One Out) advantage estimator as a first class learner in Tunix, addressing #953.

RLOO replaces GRPO's group mean advantage baseline with a leave one out baseline: for each completion, the baseline is the mean reward of all *other* completions to the same prompt. This yields **unbiased advantage estimates with lower variance** than standard GRPO, without requiring a separate critic network (unlike PPO).

## Changes

- **`tunix/rl/grpo/rloo_learner.py`** — `RLOOConfig` and `RLOOLearner` following the same pattern as `DrGRPOConfig`/`DrGRPOLearner`
- **`tunix/rl/algorithm_config.py`** — Register `"rloo"` and `"drgrpo"` as valid algo variants and advantage estimators
- **`tunix/cli/grpo_main.py`** — Route to `RLOOLearner` when `advantage_estimator=rloo` is set in `grpo_config`
- **`tunix/cli/base_config.yaml`** — Document `advantage_estimator` and `loss_agg_mode` config options
- **`tests/rl/grpo/rloo_learner_test.py`** — Comprehensive tests (config, advantage math, e2e training)
- **`examples/rl/rloo/gsm8k/run_qwen3.sh`** — Example training script for GSM8K with Qwen3

### Usage

Switch from GRPO to RLOO with a single config change:

```bash
grpo_config.advantage_estimator=rloo
```

Or via Python API:

```python
from tunix.rl.grpo.rloo_learner import RLOOConfig, RLOOLearner

config = RLOOConfig(num_generations=8, beta=0.04, epsilon=0.2)
learner = RLOOLearner(rl_cluster=cluster, algo_config=config, reward_fns=reward_fn)
learner.train(dataset)
```

Resolves #953

**Reference**

Ahmadian et al., ["Back to Basics: Revisiting REINFORCE-Style Optimization for Learning from Human Feedback in LLMs"](https://arxiv.org/abs/2402.14740), 2024.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).