### PR TITLE
fix: use jnp.exp(log_probs) instead of softmax(log_probs) in compute_entropy_from_logits

### DIFF
--- a/tunix/rl/ppo/ppo_helpers.py
+++ b/tunix/rl/ppo/ppo_helpers.py
@@ -161,5 +161,5 @@ def compute_entropy_from_logits(logits: jax.Array) -> jax.Array:
     A JAX array of shape `[batch_size, seq_len]`, containing the entropy values.
   """
   log_probs = jax.nn.log_softmax(logits, axis=-1)
-  probs = jax.nn.softmax(log_probs)
+  probs = jnp.exp(log_probs)
   return -jnp.sum(probs * log_probs, axis=-1)


### PR DESCRIPTION
## Summary

Fixes a bug in `compute_entropy_from_logits` in `tunix/rl/ppo/ppo_helpers.py`.

Closes #1386

## Problem

Line 164 applies `jax.nn.softmax(log_probs)` to convert log-probabilities to probabilities. This is **mathematically incorrect**:

- `softmax(log_softmax(x))` ≠ `softmax(x)`
- Only `exp(log_softmax(x))` = `softmax(x)` (i.e., the true probability distribution)

Applying `softmax` to already log-normalized values produces a *different* distribution, leading to silently incorrect entropy values during PPO training.

## Fix

Replace `jax.nn.softmax(log_probs)` with `jnp.exp(log_probs)` on line 164:

```python
# Before (wrong):
probs = jax.nn.softmax(log_probs)

# After (correct):
probs = jnp.exp(log_probs)
```

## Impact

The `compute_entropy_from_logits` function is called in `ppo_learner.py` to compute `token_entropy`. The bug causes incorrect entropy values, which can silently affect PPO training metrics and dynamics.