### PR TITLE
Fix broken base_config for RL training.

### DIFF
--- a/tunix/cli/base_config.yaml
+++ b/tunix/cli/base_config.yaml
@@ -93,7 +93,7 @@ tokenizer_config:
 ################################## DATASET ##################################
 # Translation_dataset  "Helsinki-NLP/opus-100" or "mtnt/en-fr" for SFT
 # Math_dataset "gsm8k" for grpo
-data_source: ""
+data_source: "tfds"
 data_directory: ""
 data_module: ""
 dataset_name: "Helsinki-NLP/opus-100"


### PR DESCRIPTION
Broken by https://github.com/google/tunix/pull/1375 which now requires a dataset to be specified.

Resolves #\<issue_number_goes_here\>

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
