### PR TITLE
Disable sglang_jax with LoRA test in nightly regression

### DIFF
--- a/.github/workflows/tpu-nightly-regression.yml
+++ b/.github/workflows/tpu-nightly-regression.yml
@@ -136,8 +136,8 @@ jobs:
         echo "📦 Executing: scripts/grpo_demo_llama3_qwen2.py with sglang_jax in 3 way disaggregated mode ..."
         python scripts/grpo_demo_llama3_qwen2.py --root-dir=/tmp/grpo_test --num-batches=20 --rollout-engine=sglang_jax --cluster-setup=disaggregated-3-way || FAILED=1
 
-        echo "📦 Executing: scripts/grpo_demo_llama3_qwen2.py with sglang_jax with LoRA ..."
-        python scripts/grpo_demo_llama3_qwen2.py --root-dir=/tmp/grpo_test --num-batches=20 --rollout-engine sglang_jax --enable-lora --lora-target-modules all || FAILED=1
+        # echo "📦 Executing: scripts/grpo_demo_llama3_qwen2.py with sglang_jax with LoRA ..."
+        # python scripts/grpo_demo_llama3_qwen2.py --root-dir=/tmp/grpo_test --num-batches=20 --rollout-engine sglang_jax --enable-lora --lora-target-modules all || FAILED=1
 
     
         if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
Disable sglang_jax with LoRA test in nightly regression

Disable the `scripts/grpo_demo_llama3_qwen2.py` test that runs with `sglang_jax` and LoRA enabled in `.github/workflows/tpu-nightly-regression.yml`. This test has been consistently failing and is hard to fix.

---
*PR created automatically by Jules for task [14781762604319494015](https://jules.google.com/task/14781762604319494015) started by @sizhit2*