### PR TITLE
Fix env logging metrics tab

### DIFF
--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -504,10 +504,8 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     }
 
     # Extract time metrics (env_time and reward_time)
-    for time_key, prefix in [
-        ("env_time", "trajectory/env_time"),
-        ("reward_time", "trajectory/reward_time"),
-    ]:
+    for time_key in ["env_time", "reward_time"]:
+      prefix = f"trajectory/{time_key}"
       time_dicts = [item.traj.get(time_key, {}) for item in trajectories]
 
       # Safely gather all unique sub-keys (e.g., 'reset_latency') across all trajectories

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -505,8 +505,8 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
 
     # Extract time metrics (env_time and reward_time)
     for time_key, prefix in [
-        ("env_time", "generation/trajectory/env_time"),
-        ("reward_time", "generation/trajectory/reward_time"),
+        ("env_time", "trajectory/env_time"),
+        ("reward_time", "trajectory/reward_time"),
     ]:
       time_dicts = [item.traj.get(time_key, {}) for item in trajectories]
 


### PR DESCRIPTION
Moved environment metrics (`env_time` and `reward_time`) out of the `generation` tab and into a dedicated `trajectory` tab by changing their prefix in `agentic_grpo_learner.py`.

---
*PR created automatically by Jules for task [15550395902903563396](https://jules.google.com/task/15550395902903563396) started by @sizhit2*