### PR TITLE
Agentic GRPO: TIS correction, eval dedup, flash-attn segment_ids

### DIFF
--- a/examples/frozenlake/train_frozenlake_qwen3.py
+++ b/examples/frozenlake/train_frozenlake_qwen3.py
@@ -1,0 +1,594 @@
+"""Agentic FrozenLake GRPO recipe for Qwen3-8B on a single TPU host.
+
+Designed for v5p-8 / v6e-4 -class hosts where actor, reference, and rollout
+share a single mesh. Configuration is env-driven so the same image runs
+unchanged on any spot VM:
+
+  HF_TOKEN              Hugging Face token for model download.
+  WANDB_API_KEY         Wandb API key (auto-picked-up by wandb lib).
+  WANDB_PROJECT         Wandb project name (default "tunix-frozenlake").
+  WANDB_RUN_NAME        Wandb run name (default uses timestamp).
+  MODEL_DOWNLOAD_DIR    Local dir for HF safetensors (default
+                        /tmp/models/Qwen3-8B).
+  DATA_DIR              Local or gs:// dir holding train.parquet / test.parquet
+                        (default gs://tunix/data/Frozenlake).
+  CKPT_DIR              Output checkpoint dir. Checkpointing is opt-in; if
+                        unset, no checkpoints are written.
+  TB_LOG_DIR            TensorBoard log dir (default /tmp/tunix-tb/frozenlake).
+  SHARED_MESH_SHAPE     Override the (fsdp, tp) mesh shape. Defaults to
+                        (1, jax.device_count()) (pure tensor parallel).
+  ROLLOUT_ENGINE        "vanilla" | "vllm"  (default "vllm" — the disaggregated
+                        vLLM server avoids the trace-context issues of running
+                        the in-process sampler under REMAT and offers higher
+                        throughput at full concurrency).
+  MODEL_DTYPE           "bf16" (default) | "fp32" — storage/compute dtype for
+                        the reference policy and trainer forward path.
+  MIX_PRECISION         "1" (default) | "0" — when 0, runs the model in fp32
+                        end-to-end (set together with MODEL_DTYPE=fp32).
+  FLASH_ATTN            "1" (default) | "0" — splash flash attention kernel.
+  TRAIN_MICRO_BS        Trainer forward+backward micro-batch (default 4).
+  COMPUTE_LOGPS_MICRO_BS  Logp recomputation micro-batch (default 4).
+"""
+
+import contextlib
+import datetime
+import logging
+import math
+import os
+import sys
+from typing import List
+
+from absl import logging as absl_logging
+from flax import nnx
+import grain
+import jax
+from jax import numpy as jnp
+import numpy as np
+import optax
+from orbax import checkpoint as ocp
+import qwix
+
+# ====== Logging Configuration ======
+absl_logging.use_python_logging()
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
+)
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger("absl").setLevel(logging.INFO)
+absl_logging.set_verbosity(absl_logging.INFO)
+absl_logging.set_stderrthreshold("info")
+print("Logging configured at INFO level.")
+
+from tunix.models.qwen3 import params as params_lib
+from tunix.models.qwen3 import model as model_lib
+from tunix.oss import utils as oss_utils
+from tunix.sft import metrics_logger
+from tunix.rl.agentic.agentic_grpo_learner import GRPOConfig, GRPOLearner
+from tunix.rl.agentic.parser.chat_template_parser import parser
+from tunix.rl import rl_cluster as rl_cluster_lib
+from tunix.rl.rollout import base_rollout
+from tunix.sft import utils as sft_utils
+from tunix.cli.utils import data as data_lib
+from examples.frozenlake.agent import FrozenLakeAgent
+from examples.frozenlake.env import FrozenLakeEnv
+
+_DISTRIBUTED_INITIALIZED = False
+try:
+  import pathwaysutils
+  pathwaysutils.initialize()
+  _DISTRIBUTED_INITIALIZED = True
+except Exception:
+  pass
+
+if not _DISTRIBUTED_INITIALIZED:
+  # Multi-host TPU (e.g. v5p-16, v6e-16+) needs jax.distributed.initialize()
+  # for Orbax checkpoint barrier sync. Single-host slices are auto-detected,
+  # so this is a no-op there.
+  try:
+    jax.distributed.initialize()
+  except Exception as exc:
+    print(f"jax.distributed.initialize() skipped: {exc}")
+
+print("jax devices: ", jax.devices())
+
+# %%
+import argparse
+
+arg_parser = argparse.ArgumentParser(
+    description="Train FrozenLake on Qwen3-8B (single-host TPU)."
+)
+# Effective on-policy batch is `batch_size * num_generations` per global step.
+# Tuned together with `num_generations=8` to keep per-step rollout latency
+# manageable on a single host while preserving enough samples per prompt for
+# the GRPO group-mean baseline.
+arg_parser.add_argument("--batch_size", type=int, default=64)
+arg_parser.add_argument("--mini_batch_size", type=int, default=64)
+arg_parser.add_argument("--learning_rate", type=float, default=1e-6)
+arg_parser.add_argument("--b1", type=float, default=0.9)
+# AdamW second-moment decay (β2). Lower than the AdamW default (0.999) so the
+# second-moment estimate adapts faster to the non-stationary gradient
+# distribution of RL fine-tuning.
+arg_parser.add_argument("--b2", type=float, default=0.95)
+arg_parser.add_argument("--weight_decay", type=float, default=0.0)
+arg_parser.add_argument("--num_batches", type=int, default=150)
+arg_parser.add_argument("--num_generations", type=int, default=8)
+arg_parser.add_argument("--beta", type=float, default=0.0)
+# GSPO-token defaults: tight clip ratios because the importance ratio is
+# sequence-mean (much lower variance than per-token PPO), so a wider clip would
+# rarely bind. Override via --epsilon/--epsilon_high for PPO-style runs.
+arg_parser.add_argument("--epsilon", type=float, default=0.003)
+arg_parser.add_argument("--epsilon_high", type=float, default=0.005)
+arg_parser.add_argument(
+    "--loss_algo", type=str, default="gspo-token",
+    help="'grpo' (per-token PPO) or 'gspo-token' (sequence-mean IS).",
+)
+arg_parser.add_argument("--max_prompt_length", type=int, default=2048)
+arg_parser.add_argument("--max_response_length", type=int, default=2048)
+arg_parser.add_argument("--temperature", type=float, default=0.7)
+# No top_p / top_k filter at rollout time. The processed_logprobs returned by
+# the rollout engine apply log_softmax over the filtered logit set; if filters
+# are active, the rollout's denominator covers only those tokens while the
+# trainer recompute uses the full vocabulary, biasing the sampler-trainer
+# logprob diff by ~log(vocab / k) per position even when both forward passes
+# agree exactly. Disabling the filters at rollout keeps the two distributions
+# comparable; exploration can be controlled via temperature.
+arg_parser.add_argument("--top_p", type=float, default=1.0)
+arg_parser.add_argument("--top_k", type=int, default=0)
+# Concurrent rollout threads. Should stay at or below the vLLM engine's
+# `max_num_seqs` (default 64) plus a small backlog; pushing it much higher
+# pegs the KV cache at 100% and forces chunked-prefill to interleave with
+# decode, which makes the sampler's logits diverge from the trainer's
+# recomputation (visible as a large `sampler_trainer/train/logp_diff_mean`)
+# and noticeably degrades steady-state reward. Keep ~4x `max_num_seqs` so the
+# engine has work queued without saturating the cache.
+arg_parser.add_argument("--max_concurrency", type=int, default=256)
+arg_parser.add_argument("--shuffle_data", type=bool, default=True)
+arg_parser.add_argument("--seed", type=int, default=42)
+arg_parser.add_argument(
+    "--loss_agg_mode", type=str, default="sequence-mean-token-mean"
+)
+arg_parser.add_argument(
+    "--kl_loss_mode", type=str, default="low_var_kl"
+)
+# Advantage estimator. "rloo" (leave-one-out baseline) has smaller-magnitude
+# advantages than "grpo" (z-score with /std), which interacts gently with very
+# tight PPO clip ratios. "grpo" is the registry default; switch via CLI.
+arg_parser.add_argument(
+    "--advantage_estimator", type=str, default="rloo",
+    help="'grpo' (z-score) or 'rloo' (leave-one-out baseline).",
+)
+args, _ = arg_parser.parse_known_args()
+
+TRAIN_FRACTION = 1.0
+SEED = args.seed
+
+# ====== Sharding ======
+# Default: v5p-8 → 8 chips, pure TP (fsdp=1) because rollout sampler prefills
+# batch=1 sequences and fsdp>1 + splash kernel mismatch.
+# Override SHARED_MESH_SHAPE via env for other slice sizes (e.g. v6e-4 → 1,4).
+_mesh_env = os.getenv("SHARED_MESH_SHAPE")
+if _mesh_env:
+  SHARED_MESH_SHAPE = tuple(int(x) for x in _mesh_env.split(","))
+else:
+  SHARED_MESH_SHAPE = (1, jax.device_count())
+SHARED_MESH_AXIS_NAMES = ("fsdp", "tp")
+
+# ====== GRPO ======
+MAX_PROMPT_LENGTH = args.max_prompt_length
+MAX_RESPONSE_LENGTH = args.max_response_length
+TEMPERATURE = args.temperature
+TOP_P = args.top_p
+TOP_K = args.top_k
+NUM_GENERATIONS = args.num_generations
+
+# vLLM (if used). Concurrent sequence count and batched-token budget for the
+# rollout engine. Set to roughly twice ``max_concurrency`` so the rollout has
+# some headroom without provisioning a huge unused KV-cache pool — on a
+# shared trainer+rollout mesh that KV-cache pool consumes HBM that the
+# trainer needs at peak (logits + activations + optimizer state).
+VLLM_MAX_NUM_SEQS = 64
+VLLM_MAX_BATCHED_TOKENS = VLLM_MAX_NUM_SEQS * 4 * 1024 // 8
+
+NUM_ITERATIONS = 1
+BETA = args.beta
+EPSILON = args.epsilon
+EPSILON_HIGH = args.epsilon_high
+
+# ====== Training ======
+# Gradient checkpointing on the transformer decoder block. Recomputes
+# activations during backward pass instead of holding them in memory across
+# the forward; reduces peak HBM by ~num_layers × activation_size at the cost
+# of one extra forward pass per backward.
+ENABLE_REMAT = True
+# Flash attention on the trainer forward path. The pallas splash kernel
+# computes only the causal mask kernel-side; per-batch padding has to flow
+# in via per-position segment ids. The model now plumbs segment ids derived
+# from the non-pad mask into splash, so left-padded prompts no longer
+# contaminate real-token attention outputs.
+ENABLE_FLASH_ATTENTION = os.environ.get("FLASH_ATTN", "1") not in ("0", "false", "False")
+ENABLE_MIX_PRECISION = os.environ.get("MIX_PRECISION", "1") not in ("0", "false", "False")
+BATCH_SIZE = args.batch_size
+MINI_BATCH_SIZE = args.mini_batch_size
+NUM_BATCHES = args.num_batches
+# Held-out eval pool size in batches. The frozenlake test set ships with 100
+# prompts; NUM_TEST_BATCHES * BATCH_SIZE should be >= 100 to cover one full
+# pass per eval. With the default BATCH_SIZE=64, NUM_TEST_BATCHES=2 is
+# sufficient. Eval wall-time scales linearly with NUM_TEST_BATCHES *
+# BATCH_SIZE * num_generations.
+NUM_TEST_BATCHES = 2
+
+EVAL_EVERY_N_STEPS = 10
+NUM_EPOCHS = 3
+MAX_STEPS = int(NUM_BATCHES * NUM_ITERATIONS * TRAIN_FRACTION * NUM_EPOCHS)
+
+MAX_CONCURRENCY = args.max_concurrency
+OFF_POLICY_STEPS = 0
+MODEL_DTYPE = {"bf16": jnp.bfloat16, "bfloat16": jnp.bfloat16, "fp32": jnp.float32, "float32": jnp.float32}[
+    os.environ.get("MODEL_DTYPE", "bf16").lower()
+]
+
+LEARNING_RATE = args.learning_rate
+B1 = args.b1
+B2 = args.b2
+WEIGHT_DECAY = args.weight_decay
+# Linear warmup over WARMUP_STEPS steps before the LR schedule begins decaying.
+# 0 means start at the peak LR from step 1; this is the typical setting for
+# fine-tuning RL from an already-pretrained policy. Set to a positive integer
+# (e.g. ``int(0.05 * MAX_STEPS)``) only if you observe early-training
+# instability from full-LR updates against a stale reference.
+WARMUP_STEPS = 0
+# Global-norm gradient clip. The asymmetric ratio clip and (optional) truncated
+# importance-sampling correction already bound individual per-token
+# contributions, so an additional tight global clip is unnecessary. The high
+# threshold here effectively disables clipping while keeping a safety net
+# against numerical explosions; lower it (e.g. ``1.0``) if a particular
+# recipe exhibits unstable grad norms.
+MAX_GRAD_NORM = 100.0
+
+# ====== Checkpoint saving ======
+SAVE_INTERVAL_STEPS = 10**9  # effectively disabled; set CKPT_DIR + lower this to enable
+MAX_TO_KEEP = 1
+
+# ====== Rollout ======
+ROLLOUT_ENGINE = os.getenv("ROLLOUT_ENGINE", "vllm")  # "vanilla" | "vllm"
+
+# ====== Paths (env-driven so the same image runs anywhere) ======
+MODEL_VERSION = "Qwen/Qwen3-8B"
+MODEL_DOWNLOAD_DIR = os.getenv("MODEL_DOWNLOAD_DIR", "/tmp/models/Qwen3-8B")
+DATA_DIR = os.getenv("DATA_DIR", "/tmp/data/frozenlake")
+
+now_str = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+# Checkpointing is opt-in: set CKPT_DIR to enable, otherwise nothing is written.
+# Orbax's CheckpointManager force-saves the first step regardless of the
+# configured save_interval_steps, so a large interval alone does not disable it.
+CKPT_DIR = os.getenv("CKPT_DIR") or None
+TB_LOG_DIR = os.getenv("TB_LOG_DIR", "/tmp/tunix-tb/frozenlake")
+
+
+# ====== Build the single shared mesh ======
+if jax.device_count() < math.prod(SHARED_MESH_SHAPE):
+  raise ValueError(
+      f"Expected at least {math.prod(SHARED_MESH_SHAPE)} devices for mesh "
+      f"{SHARED_MESH_SHAPE}, got {jax.device_count()}."
+  )
+
+shared_device_list = jax._src.mesh_utils.create_device_mesh(
+    SHARED_MESH_SHAPE, jax.devices()[: math.prod(SHARED_MESH_SHAPE)]
+)
+shared_mesh = jax.sharding.Mesh(
+    shared_device_list,
+    axis_names=SHARED_MESH_AXIS_NAMES,
+    axis_types=(jax.sharding.AxisType.Auto,) * len(SHARED_MESH_SHAPE),
+)
+print(f"shared_mesh.devices.shape={shared_mesh.devices.shape}")
+
+# ====== Data ======
+import pandas as pd
+import datasets as datasets_lib
+import transformers
+
+try:
+  from google.cloud import storage  # noqa: F401  (ensures gcsfs deps load on GCS)
+except Exception:
+  pass
+import fsspec
+
+Dataset = datasets_lib.Dataset
+AutoTokenizer = transformers.AutoTokenizer
+
+TRAIN_DATA_PATH = os.path.join(DATA_DIR, "train.parquet")
+TEST_DATA_PATH = os.path.join(DATA_DIR, "test.parquet")
+
+
+def create_datasets(
+    train_ds_path: str = TRAIN_DATA_PATH,
+    test_ds_path: str = TEST_DATA_PATH,
+):
+  with fsspec.open(train_ds_path, "rb") as train_f, fsspec.open(
+      test_ds_path, "rb"
+  ) as test_f:
+    train_df = pd.read_parquet(train_f)
+    test_df = pd.read_parquet(test_f)
+
+  train_ds = Dataset.from_pandas(train_df)
+  test_ds = Dataset.from_pandas(test_df)
+  if args.shuffle_data:
+    train_ds = train_ds.shuffle(SEED)
+    test_ds = test_ds.shuffle(SEED)
+
+  def process_item(item):
+    item["prompts"] = ""
+    return item
+
+  train_ds = grain.MapDataset.source(train_ds).map(process_item)
+  test_ds = grain.MapDataset.source(test_ds).map(process_item)
+  return train_ds, test_ds
+
+
+tokenizer = AutoTokenizer.from_pretrained(MODEL_VERSION)
+# Disable Qwen3 thinking mode. The agent prompt already requests explicit
+# step-by-step reasoning; with thinking enabled the model writes hundreds of
+# ``<think>...</think>`` tokens per turn and exhausts the response budget
+# before producing an action.
+chat_parser = parser.QwenChatTemplateParser(tokenizer, enable_thinking=False)
+
+train_dataset, test_dataset = create_datasets()
+train_dataset, val_dataset = data_lib.post_init_dataset(
+    train_dataset,
+    tokenizer,
+    batch_size=BATCH_SIZE,
+    num_batches=NUM_BATCHES,
+    max_prompt_length=MAX_PROMPT_LENGTH,
+    fraction=TRAIN_FRACTION,
+    num_epochs=NUM_EPOCHS,
+)
+test_dataset, _ = data_lib.post_init_dataset(
+    test_dataset,
+    tokenizer,
+    batch_size=BATCH_SIZE,
+    num_batches=NUM_TEST_BATCHES,
+    max_prompt_length=MAX_PROMPT_LENGTH,
+)
+
+show_hbm_usage = sft_utils.show_hbm_usage
+show_hbm_usage("Done with loading datasets")
+
+# ====== Download + load model ======
+# Download safetensors from HF if not present locally.
+if not os.path.isdir(MODEL_DOWNLOAD_DIR) or not any(
+    f.endswith(".safetensors") for f in os.listdir(MODEL_DOWNLOAD_DIR)
+):
+  os.makedirs(MODEL_DOWNLOAD_DIR, exist_ok=True)
+  oss_utils.hf_pipeline(MODEL_VERSION, MODEL_DOWNLOAD_DIR)
+
+config = model_lib.ModelConfig.qwen3_8b()
+if ENABLE_REMAT:
+  config.remat_config = model_lib.RematConfig.DECODER
+if ENABLE_FLASH_ATTENTION:
+  config.use_flash_attention = True
+  config.flash_attention_block_size = 256
+if ENABLE_MIX_PRECISION:
+  config.dtype = jnp.bfloat16
+
+# Reference: keep bf16 storage (frozen, never updated -> HBM savings safe).
+qwen_ref = params_lib.create_model_from_safe_tensors(
+    MODEL_DOWNLOAD_DIR, config, shared_mesh, dtype=MODEL_DTYPE
+)
+show_hbm_usage("after loading qwen_ref")
+
+# Actor: storage MUST be fp32. At LR=1e-6 with typical weight magnitudes
+# ~1e-2, Adam updates are ~1e-6, well below bf16 ULP (~7.8e-5). bf16 storage
+# silently rounds every update to zero in optax.apply_updates, so the policy
+# never moves. Forward compute can still be bf16 via config.dtype.
+qwen_actor = params_lib.create_model_from_safe_tensors(
+    MODEL_DOWNLOAD_DIR, config, shared_mesh, dtype=jnp.float32
+)
+show_hbm_usage("after loading qwen_actor")
+
+# ====== Checkpoint + metrics + optimizer ======
+if CKPT_DIR:
+  checkpointing_options = ocp.CheckpointManagerOptions(
+      save_interval_steps=SAVE_INTERVAL_STEPS, max_to_keep=MAX_TO_KEEP
+  )
+else:
+  checkpointing_options = None
+
+wandb_config = vars(args)
+wandb_config.update({
+    "WARMUP_STEPS": WARMUP_STEPS,
+    "num_steps": MAX_STEPS,
+    "rollout_engine": ROLLOUT_ENGINE,
+    "model_id": MODEL_VERSION,
+    "mesh_shape": SHARED_MESH_SHAPE,
+})
+wandb_kwargs = {"config": wandb_config}
+# Tunix's WandbBackend already forwards project_name+run_name; don't put `name`
+# in wandb_kwargs (would collide with `name=run_name` kwarg in metrics_logger).
+metrics_logging_options = metrics_logger.MetricsLoggerOptions(
+    log_dir=TB_LOG_DIR,
+    project_name=os.getenv("WANDB_PROJECT", "tunix-frozenlake"),
+    run_name=os.getenv("WANDB_RUN_NAME", ""),
+    flush_every_n_steps=1,
+    backend_kwargs={"wandb": wandb_kwargs},
+)
+
+optimizer = optax.adamw(
+    learning_rate=LEARNING_RATE,
+    b1=B1,
+    b2=B2,
+    weight_decay=WEIGHT_DECAY,
+)
+if MAX_GRAD_NORM is not None:
+  optimizer = optax.chain(
+      optax.clip_by_global_norm(max_norm=MAX_GRAD_NORM),
+      optimizer,
+  )
+
+# ====== Rollout + RL cluster ======
+print("Shared mesh:", shared_mesh)
+
+base_rollout_dict = {
+    "max_prompt_length": MAX_PROMPT_LENGTH,
+    "kv_cache_size": MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH + 256,
+    "temperature": TEMPERATURE,
+    "top_p": TOP_P,
+    "top_k": TOP_K,
+    "return_logprobs": True,
+    "max_tokens_to_generate": MAX_RESPONSE_LENGTH,
+}
+
+vllm_rollout_dict = {
+    "rollout_vllm_model_version": MODEL_VERSION,
+    # Fraction of per-chip HBM that the rollout engine pre-allocates for KV
+    # cache + model weights. On a shared trainer+rollout mesh this directly
+    # competes with the trainer's peak (logits + activations + optimizer
+    # state). Sized to fit the actual KV-cache need at our max_num_seqs and
+    # max_seq_len rather than the vLLM default. Once vLLM-TPU gains support
+    # for sleep/wake_up, this can be relaxed since the KV pool can be
+    # offloaded to host RAM during train_step.
+    "rollout_vllm_hbm_utilization": float(os.environ.get("VLLM_HBM_UTIL", "0.20")),
+    "rollout_vllm_tpu_backend_type": "jax",
+    "rollout_vllm_server_mode": True,
+    # Async scheduling adds an extra in-flight step that can race weight sync;
+    # disable it under engine-disagg so each rollout completes before the next
+    # train step starts.
+    "rollout_vllm_async_scheduling": False,
+    "rollout_vllm_init_with_random_weights": True,
+    "tensor_parallel_size": SHARED_MESH_SHAPE[1],
+    "data_parallel_size": SHARED_MESH_SHAPE[0],
+    "rollout_vllm_max_num_seqs": VLLM_MAX_NUM_SEQS,
+    "rollout_vllm_max_num_batched_tokens": VLLM_MAX_BATCHED_TOKENS,
+    "rollout_vllm_kwargs": {
+        "kv_cache_metrics": True,
+        "disable_log_stats": False,
+        "enable_prefix_caching": False,
+        "dtype": "bfloat16",
+    },
+}
+
+if ROLLOUT_ENGINE == "vllm":
+  rollout_engine_config = base_rollout.RolloutConfig(
+      **base_rollout_dict, **vllm_rollout_dict
+  )
+elif ROLLOUT_ENGINE == "vanilla":
+  rollout_engine_config = base_rollout.RolloutConfig(**base_rollout_dict)
+else:
+  raise ValueError(f"Unsupported rollout engine: {ROLLOUT_ENGINE}")
+
+cluster_config = rl_cluster_lib.ClusterConfig(
+    role_to_mesh={
+        rl_cluster_lib.Role.ACTOR: shared_mesh,
+        rl_cluster_lib.Role.REFERENCE: shared_mesh,
+        rl_cluster_lib.Role.ROLLOUT: shared_mesh,
+    },
+    rollout_engine=ROLLOUT_ENGINE,
+    # Keep actor weights resident on device. With ``delete_dst_buffers=True``
+    # the vLLM weight-sync path frees old buffers before re-allocating, so the
+    # host-offload workaround previously used to relieve HBM pressure during
+    # sync is no longer necessary on this hardware.
+    offload_to_cpu=False,
+    training_config=rl_cluster_lib.RLTrainingConfig(
+        actor_optimizer=optimizer,
+        eval_every_n_steps=EVAL_EVERY_N_STEPS,
+        max_steps=MAX_STEPS,
+        mini_batch_size=MINI_BATCH_SIZE,
+        # Memory-shaping micro-batch for forward+backward. The optimizer sees
+        # ``mini_batch_size`` sequences per gradient update; under the hood the
+        # trainer iterates the merged rollout buffer in chunks of
+        # ``train_micro_batch_size`` and accumulates gradients across
+        # ``mini_batch_size // train_micro_batch_size`` chunks before stepping.
+        # Reducing this lowers peak HBM (the lm_head logits tensor
+        # ``[micro_batch * num_gen * seq_len, vocab/TP]`` in fp32 is the
+        # dominant allocation on small TPU slices) at the cost of more
+        # micro-step launches per optimizer update. It does NOT change the
+        # effective optimizer batch size or training dynamics.
+        train_micro_batch_size=int(os.environ.get("TRAIN_MICRO_BS", 4)),
+        compute_logps_micro_batch_size=int(os.environ.get("COMPUTE_LOGPS_MICRO_BS", 4)),
+        metrics_logging_options=metrics_logging_options,
+        checkpoint_root_directory=CKPT_DIR,
+        checkpointing_options=checkpointing_options,
+    ),
+    rollout_config=rollout_engine_config,
+)
+
+grpo_config = GRPOConfig(
+    num_generations=NUM_GENERATIONS,
+    num_iterations=NUM_ITERATIONS,
+    max_response_length=MAX_RESPONSE_LENGTH,
+    beta=BETA,
+    epsilon=EPSILON,
+    epsilon_high=EPSILON_HIGH,
+    system_prompt="",
+    max_concurrency=MAX_CONCURRENCY,
+    off_policy_steps=OFF_POLICY_STEPS,
+    loss_agg_mode=args.loss_agg_mode,
+    kl_loss_mode=args.kl_loss_mode,
+    loss_algo=args.loss_algo,
+    # Per-token truncated importance-sampling correction. Switches the policy
+    # loss to use the trainer's start-of-step recomputed logp as
+    # ``old_per_token_logps`` and applies a detached per-token weight
+    # ``min(exp(trainer_logp - sampler_logp), threshold)`` to the pg loss.
+    # Recommended for multi-turn agentic rollouts where residual numerical
+    # drift between sampler and trainer can produce occasional outlier
+    # importance ratios.
+    sampler_is="token",
+    sampler_is_threshold=2.0,
+    advantage_estimator=args.advantage_estimator,
+)
+
+rl_cluster = rl_cluster_lib.RLCluster(
+    actor=qwen_actor,
+    reference=qwen_ref,
+    tokenizer=tokenizer,
+    cluster_config=cluster_config,
+)
+show_hbm_usage("after RLCluster creation")
+
+
+_metric_call_idx = 0
+
+
+def metric_fn(prompts, completions, rewards, advantages, **kwargs):
+  del prompts, completions, advantages, kwargs
+  global _metric_call_idx
+  _metric_call_idx += 1
+  solve_all = (rewards > 0.1).all()
+  solve_none = (rewards == 0).all()
+  solve_partial = (~solve_all) and (~solve_none)
+  solve_ratio = (rewards > 0.1).mean()
+  reward_mean = float(rewards.mean())
+  reward_max = float(rewards.max())
+  absl_logging.info(
+      "[rollout-metric] call=%d n=%d solve_ratio=%.3f reward_mean=%.3f"
+      " reward_max=%.3f solve_all=%d solve_none=%d",
+      _metric_call_idx, len(rewards), float(solve_ratio), reward_mean,
+      reward_max, int(solve_all), int(solve_none),
+  )
+  return {
+      "rewards/solve_all": (1 if solve_all else 0, np.mean),
+      "rewards/solve_none": (1 if solve_none else 0, np.mean),
+      "rewards/solve_partial": (1 if solve_partial else 0, np.mean),
+      "rewards/solve_ratio": (solve_ratio, np.mean),
+  }
+
+
+grpo_trainer = GRPOLearner(
+    rl_cluster=rl_cluster,
+    agent_class=FrozenLakeAgent,
+    agent_kwargs={"use_multistep_prompt": True},
+    env_class=FrozenLakeEnv,
+    env_kwargs={"max_steps": 8},
+    algo_config=grpo_config,
+    chat_parser=chat_parser,
+    metric_fns=[metric_fn],
+)
+show_hbm_usage("after GRPOLearner creation")
+
+# Pass test_dataset as the eval set so the learner runs held-out rollouts
+# every EVAL_EVERY_N_STEPS and logs `eval/...` metrics (including
+# trajectory_reward → solve rate) separately from train metrics.
+grpo_trainer.train(train_dataset, eval_dataset=test_dataset)

--- a/examples/frozenlake/train_frozenlake_qwen3.py
+++ b/examples/frozenlake/train_frozenlake_qwen3.py
@@ -1,37 +1,12 @@
 """Agentic FrozenLake GRPO recipe for Qwen3-8B on a single TPU host.
 
-Designed for v5p-8 / v6e-4 -class hosts where actor, reference, and rollout
-share a single mesh. Configuration is env-driven so the same image runs
-unchanged on any spot VM:
-
-  HF_TOKEN              Hugging Face token for model download.
-  WANDB_API_KEY         Wandb API key (auto-picked-up by wandb lib).
-  WANDB_PROJECT         Wandb project name (default "tunix-frozenlake").
-  WANDB_RUN_NAME        Wandb run name (default uses timestamp).
-  MODEL_DOWNLOAD_DIR    Local dir for HF safetensors (default
-                        /tmp/models/Qwen3-8B).
-  DATA_DIR              Local or gs:// dir holding train.parquet / test.parquet
-                        (default gs://tunix/data/Frozenlake).
-  CKPT_DIR              Output checkpoint dir. Checkpointing is opt-in; if
-                        unset, no checkpoints are written.
-  TB_LOG_DIR            TensorBoard log dir (default /tmp/tunix-tb/frozenlake).
-  SHARED_MESH_SHAPE     Override the (fsdp, tp) mesh shape. Defaults to
-                        (1, jax.device_count()) (pure tensor parallel).
-  ROLLOUT_ENGINE        "vanilla" | "vllm"  (default "vllm" — the disaggregated
-                        vLLM server avoids the trace-context issues of running
-                        the in-process sampler under REMAT and offers higher
-                        throughput at full concurrency).
-  MODEL_DTYPE           "bf16" (default) | "fp32" — storage/compute dtype for
-                        the reference policy and trainer forward path.
-  MIX_PRECISION         "1" (default) | "0" — when 0, runs the model in fp32
-                        end-to-end (set together with MODEL_DTYPE=fp32).
-  FLASH_ATTN            "1" (default) | "0" — splash flash attention kernel.
-  TRAIN_MICRO_BS        Trainer forward+backward micro-batch (default 4).
-  COMPUTE_LOGPS_MICRO_BS  Logp recomputation micro-batch (default 4).
+Targets v5p-8 / v6e-4 -class hosts where actor, reference, and rollout share
+a single mesh. Hyperparameters are exposed via argparse; the rollout backend
+is selected via the ``ROLLOUT_ENGINE`` environment variable ("vllm" or
+"vanilla", default "vllm").
 """
 
 import contextlib
-import datetime
 import logging
 import math
 import os
@@ -167,14 +142,10 @@ TRAIN_FRACTION = 1.0
 SEED = args.seed
 
 # ====== Sharding ======
-# Default: v5p-8 → 8 chips, pure TP (fsdp=1) because rollout sampler prefills
-# batch=1 sequences and fsdp>1 + splash kernel mismatch.
-# Override SHARED_MESH_SHAPE via env for other slice sizes (e.g. v6e-4 → 1,4).
-_mesh_env = os.getenv("SHARED_MESH_SHAPE")
-if _mesh_env:
-  SHARED_MESH_SHAPE = tuple(int(x) for x in _mesh_env.split(","))
-else:
-  SHARED_MESH_SHAPE = (1, jax.device_count())
+# Single shared mesh across actor / reference / rollout. Pure tensor-parallel
+# (fsdp=1) so the rollout sampler's batch=1 prefill is not split across an
+# fsdp axis.
+SHARED_MESH_SHAPE = (1, jax.device_count())
 SHARED_MESH_AXIS_NAMES = ("fsdp", "tp")
 
 # ====== GRPO ======
@@ -209,8 +180,8 @@ ENABLE_REMAT = True
 # in via per-position segment ids. The model now plumbs segment ids derived
 # from the non-pad mask into splash, so left-padded prompts no longer
 # contaminate real-token attention outputs.
-ENABLE_FLASH_ATTENTION = os.environ.get("FLASH_ATTN", "1") not in ("0", "false", "False")
-ENABLE_MIX_PRECISION = os.environ.get("MIX_PRECISION", "1") not in ("0", "false", "False")
+ENABLE_FLASH_ATTENTION = True
+ENABLE_MIX_PRECISION = True
 BATCH_SIZE = args.batch_size
 MINI_BATCH_SIZE = args.mini_batch_size
 NUM_BATCHES = args.num_batches
@@ -227,9 +198,7 @@ MAX_STEPS = int(NUM_BATCHES * NUM_ITERATIONS * TRAIN_FRACTION * NUM_EPOCHS)
 
 MAX_CONCURRENCY = args.max_concurrency
 OFF_POLICY_STEPS = 0
-MODEL_DTYPE = {"bf16": jnp.bfloat16, "bfloat16": jnp.bfloat16, "fp32": jnp.float32, "float32": jnp.float32}[
-    os.environ.get("MODEL_DTYPE", "bf16").lower()
-]
+MODEL_DTYPE = jnp.bfloat16
 
 LEARNING_RATE = args.learning_rate
 B1 = args.b1
@@ -256,17 +225,14 @@ MAX_TO_KEEP = 1
 # ====== Rollout ======
 ROLLOUT_ENGINE = os.getenv("ROLLOUT_ENGINE", "vllm")  # "vanilla" | "vllm"
 
-# ====== Paths (env-driven so the same image runs anywhere) ======
+# ====== Paths ======
 MODEL_VERSION = "Qwen/Qwen3-8B"
-MODEL_DOWNLOAD_DIR = os.getenv("MODEL_DOWNLOAD_DIR", "/tmp/models/Qwen3-8B")
-DATA_DIR = os.getenv("DATA_DIR", "/tmp/data/frozenlake")
+MODEL_DOWNLOAD_DIR = "/tmp/models/Qwen3-8B"
+DATA_DIR = "/tmp/data/frozenlake"
 
-now_str = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-# Checkpointing is opt-in: set CKPT_DIR to enable, otherwise nothing is written.
-# Orbax's CheckpointManager force-saves the first step regardless of the
-# configured save_interval_steps, so a large interval alone does not disable it.
-CKPT_DIR = os.getenv("CKPT_DIR") or None
-TB_LOG_DIR = os.getenv("TB_LOG_DIR", "/tmp/tunix-tb/frozenlake")
+# Checkpointing is opt-in: set CKPT_DIR to a writable path to enable.
+CKPT_DIR = None
+TB_LOG_DIR = "/tmp/tunix-tb/frozenlake"
 
 
 # ====== Build the single shared mesh ======
@@ -405,15 +371,11 @@ wandb_config.update({
     "model_id": MODEL_VERSION,
     "mesh_shape": SHARED_MESH_SHAPE,
 })
-wandb_kwargs = {"config": wandb_config}
-# Tunix's WandbBackend already forwards project_name+run_name; don't put `name`
-# in wandb_kwargs (would collide with `name=run_name` kwarg in metrics_logger).
 metrics_logging_options = metrics_logger.MetricsLoggerOptions(
     log_dir=TB_LOG_DIR,
-    project_name=os.getenv("WANDB_PROJECT", "tunix-frozenlake"),
-    run_name=os.getenv("WANDB_RUN_NAME", ""),
+    project_name="tunix-frozenlake",
     flush_every_n_steps=1,
-    backend_kwargs={"wandb": wandb_kwargs},
+    backend_kwargs={"wandb": {"config": wandb_config}},
 )
 
 optimizer = optax.adamw(
@@ -450,7 +412,7 @@ vllm_rollout_dict = {
     # max_seq_len rather than the vLLM default. Once vLLM-TPU gains support
     # for sleep/wake_up, this can be relaxed since the KV pool can be
     # offloaded to host RAM during train_step.
-    "rollout_vllm_hbm_utilization": float(os.environ.get("VLLM_HBM_UTIL", "0.20")),
+    "rollout_vllm_hbm_utilization": 0.20,
     "rollout_vllm_tpu_backend_type": "jax",
     "rollout_vllm_server_mode": True,
     # Async scheduling adds an extra in-flight step that can race weight sync;
@@ -506,8 +468,8 @@ cluster_config = rl_cluster_lib.ClusterConfig(
         # dominant allocation on small TPU slices) at the cost of more
         # micro-step launches per optimizer update. It does NOT change the
         # effective optimizer batch size or training dynamics.
-        train_micro_batch_size=int(os.environ.get("TRAIN_MICRO_BS", 4)),
-        compute_logps_micro_batch_size=int(os.environ.get("COMPUTE_LOGPS_MICRO_BS", 4)),
+        train_micro_batch_size=4,
+        compute_logps_micro_batch_size=4,
         metrics_logging_options=metrics_logging_options,
         checkpoint_root_directory=CKPT_DIR,
         checkpointing_options=checkpointing_options,

--- a/tests/rl/agentic/agentic_grpo_learner_test.py
+++ b/tests/rl/agentic/agentic_grpo_learner_test.py
@@ -535,7 +535,10 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
       def __init__(self, *, rngs: nnx.Rngs):
         self.lm_head = 1
 
-      def __call__(self, inputs, positions, cache, attention_mask):
+      def __call__(
+          self, inputs, positions, cache, attention_mask, **kwargs
+      ):
+        del kwargs
         return (
             jnp.full(
                 (*inputs.shape, 32),
@@ -600,7 +603,10 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
       def __init__(self, *, rngs: nnx.Rngs):
         self.lm_head = 1
 
-      def __call__(self, inputs, positions, cache, attention_mask):
+      def __call__(
+          self, inputs, positions, cache, attention_mask, **kwargs
+      ):
+        del kwargs
         return (
             jnp.full(
                 (*inputs.shape, 32),

--- a/tests/rl/agentic/parser/chat_template_parser/chat_template_parser_test.py
+++ b/tests/rl/agentic/parser/chat_template_parser/chat_template_parser_test.py
@@ -44,31 +44,38 @@ class QwenChatTemplateParserTest(absltest.TestCase):
     self.mock_tokenizer.eos_token = '<eos>'
 
   def test_parse_with_system_message(self):
+    # ``is_first_msg=False`` (default) renders a continuation chunk: leading
+    # separator, no trailing separator. eot_token is ``<|im_end|>`` (no
+    # trailing ``\n``); the inter-message ``\n`` is emitted by joining the
+    # separator between parts.
     p = parser.QwenChatTemplateParser(self.mock_tokenizer)
     messages = [
         {'role': 'system', 'content': 'You are Qwen.'},
         {'role': 'user', 'content': 'Hello'},
     ]
     result = p.parse(messages)
-    expected = ('<|im_start|>system\nYou are Qwen.<|im_end|>\n'
-                '<|im_start|>user\nHello<|im_end|>\n')
+    expected = ('\n<|im_start|>system\nYou are Qwen.<|im_end|>\n'
+                '<|im_start|>user\nHello<|im_end|>')
     self.assertEqual(result, expected)
 
   def test_parse_without_system_message_and_is_first_msg(self):
+    # ``is_first_msg=True`` is the opening of a conversation: no leading
+    # separator. Default system prompt is prepended because the first
+    # message is not a system message.
     p = parser.QwenChatTemplateParser(self.mock_tokenizer)
     messages = [{'role': 'user', 'content': 'Hello'}]
     result = p.parse(messages, is_first_msg=True)
     expected = ('<|im_start|>system\n'
                 'You are Qwen, created by Alibaba Cloud. You are a helpful'
                 ' assistant.<|im_end|>\n'
-                '<|im_start|>user\nHello<|im_end|>\n')
+                '<|im_start|>user\nHello<|im_end|>')
     self.assertEqual(result, expected)
 
   def test_parse_with_add_generation_prompt(self):
     p = parser.QwenChatTemplateParser(self.mock_tokenizer)
     messages = [{'role': 'user', 'content': 'Hello'}]
     result = p.parse(messages, add_generation_prompt=True)
-    expected = ('<|im_start|>user\nHello<|im_end|>\n'
+    expected = ('\n<|im_start|>user\nHello<|im_end|>\n'
                 '<|im_start|>assistant\n')
     self.assertEqual(result, expected)
 
@@ -76,9 +83,9 @@ class QwenChatTemplateParserTest(absltest.TestCase):
     p = parser.QwenChatTemplateParser(self.mock_tokenizer)
     messages = [{'role': 'tool', 'content': 'Tool output'}]
     result = p.parse(messages)
-    expected = ('<|im_start|>user\n'
+    expected = ('\n<|im_start|>user\n'
                 '<tool_response>\nTool output\n</tool_response>'
-                '<|im_end|>\n')
+                '<|im_end|>')
     self.assertEqual(result, expected)
 
   def test_parse_with_disable_thinking(self):
@@ -88,7 +95,7 @@ class QwenChatTemplateParserTest(absltest.TestCase):
     messages = [{'role': 'assistant', 'content': 'Thinking...'}]
     result = p.parse(messages, add_generation_prompt=True)
     expected = (
-        '<|im_start|>assistant\n<think>\n\n</think>\n\nThinking...<|im_end|>\n'
+        '\n<|im_start|>assistant\n<think>\n\n</think>\n\nThinking...<|im_end|>\n'
         '<|im_start|>assistant\n<think>\n\n</think>\n\n'
     )
     self.assertEqual(result, expected)

--- a/tests/rl/grpo/dapo_learner_test.py
+++ b/tests/rl/grpo/dapo_learner_test.py
@@ -61,6 +61,7 @@ class DAPOlearnerTest(parameterized.TestCase):
     example.old_per_token_logps = self.old_per_token_logps
     example.segment_ids = None
     example.segment_positions = None
+    example.sampler_is_weights = None
     return example
 
   def test_diff_loss(self):

--- a/tests/rl/grpo/drgrpo_learner_test.py
+++ b/tests/rl/grpo/drgrpo_learner_test.py
@@ -66,6 +66,7 @@ class DrGRPOlearnerTest(parameterized.TestCase):
     example.old_per_token_logps = self.old_per_token_logps
     example.segment_ids = None
     example.segment_positions = None
+    example.sampler_is_weights = None
     return example
 
   def test_create_config(self):

--- a/tunix/generate/sampler.py
+++ b/tunix/generate/sampler.py
@@ -119,8 +119,10 @@ def sample_top_p(
   # Upcast to float32 for numerical stability of softmax and subsequent cumsum.
   next_token_logits = logits[:, -1].astype(jnp.float32) / temperature
 
+  # top_k=0 or None both mean "no top-k filtering" — use full vocabulary.
+  _no_topk = top_k is None or top_k <= 0
   # Skip softmax and sorting if top_p is 1.0 and top_k is full vocab.
-  if top_p >= 1.0 and top_k is None:
+  if top_p >= 1.0 and _no_topk:
     next_token = jax.random.categorical(key, logits=next_token_logits)
     if not return_logprobs:
       return next_token, None
@@ -130,7 +132,7 @@ def sample_top_p(
     return next_token, logp_sampled
 
   probs = jax.nn.softmax(next_token_logits, axis=-1)
-  k = probs.shape[-1] if top_k is None else top_k
+  k = probs.shape[-1] if _no_topk else top_k
 
   probs_sorted, indices = jax.lax.top_k(probs, k=k)
   cumsum_probs = jnp.cumsum(probs_sorted, axis=-1)

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -349,10 +349,13 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
         input_strings, request_outputs
     ):
       for idx, single_output in enumerate(multi_sampling_output.outputs):
-        # vLLM still returns 1 eos id even if we ask it to stop at eos.
-        if single_output.token_ids[-1] == self.tokenizer.eos_id():
-          single_output.token_ids = single_output.token_ids[:-1]
-          single_output.logprobs = single_output.logprobs[:-1]
+        # KEEP the eos token in the returned token_ids — needed so multi-turn
+        # consumers (agentic engine) can reconstruct the exact sequence the
+        # next turn's prompt was rendered from. Combined with
+        # `include_stop_str_in_output=True`, vLLM emits one eos at the end of
+        # each generation. Stripping it (the previous behavior) made
+        # trainer-side concatenation miss `<|im_end|>` at every turn boundary
+        # and produced 30+ nat sampler-trainer logp diffs.
 
         out_tokens[idx].append(
             np.array(single_output.token_ids, dtype=np.int32)
@@ -461,6 +464,14 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
         sampling_params.prompt_logprobs = 0
       sampling_params.stop_token_ids = [self.tokenizer.eos_id()]
       sampling_params.skip_special_tokens = True
+      # Keep the stop token in the returned ``token_ids`` so multi-turn
+      # consumers can reconstruct the exact sequence the model was sampled
+      # on. This makes the trainer-side concatenation align with what
+      # ``apply_chat_template`` produces for the next turn's prompt; without
+      # it, the trailing ``<|im_end|>`` (or equivalent eos token) is missing
+      # at every turn boundary in the recorded sequence, biasing logp
+      # recomputation against the model's actual sampling context.
+      sampling_params.include_stop_str_in_output = True
 
       if top_p is not None:
         sampling_params.top_p = top_p

--- a/tunix/models/qwen3/model.py
+++ b/tunix/models/qwen3/model.py
@@ -486,6 +486,7 @@ class Attention(nnx.Module):
       segment_pos: jaxtyping.Array,
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array | None,
+      segment_ids: jaxtyping.Array | None = None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
     seq_len = x.shape[1]
 
@@ -571,19 +572,59 @@ class Attention(nnx.Module):
           shd.NamedSharding(mesh, P(shd_n, shd_t))
       )
 
-      @partial(
-          shard_map,
-          mesh=mesh,
-          in_specs=(kernel_spec, shd_spec, unsharded_seq, unsharded_seq),
-          out_specs=shd_spec,
-          check_rep=False,
-      )
-      def sharded_splash_attn(kernel, q_block, k_block, v_block):
-        return jax.vmap(kernel)(q_block, k_block, v_block)
+      # Per-position segment ids let splash suppress cross-segment attention
+      # (e.g. real-token to pad-token, or sequence-packing cross-boundary).
+      # The pallas splash kernel only accepts a static causal mask kernel-side,
+      # so per-batch dynamic padding masks have to flow in via segment_ids.
+      if segment_ids is not None:
+        seg_spec = P(shd_b, shd_t)
+        unsharded_seg_spec = P(shd_b, None)
 
-      qkv = sharded_splash_attn(
-          splash_attn_kernel, query_proj, key_proj, value_proj
-      )
+        @partial(
+            shard_map,
+            mesh=mesh,
+            in_specs=(
+                kernel_spec,
+                shd_spec,
+                unsharded_seq,
+                unsharded_seq,
+                seg_spec,
+                unsharded_seg_spec,
+            ),
+            out_specs=shd_spec,
+            check_rep=False,
+        )
+        def sharded_splash_attn(
+            kernel, q_block, k_block, v_block, q_seg_block, kv_seg_block
+        ):
+          seg_ids = splash.SegmentIds(q=q_seg_block, kv=kv_seg_block)
+          return jax.vmap(kernel)(
+              q_block, k_block, v_block, segment_ids=seg_ids
+          )
+
+        qkv = sharded_splash_attn(
+            splash_attn_kernel,
+            query_proj,
+            key_proj,
+            value_proj,
+            segment_ids,
+            segment_ids,
+        )
+      else:
+
+        @partial(
+            shard_map,
+            mesh=mesh,
+            in_specs=(kernel_spec, shd_spec, unsharded_seq, unsharded_seq),
+            out_specs=shd_spec,
+            check_rep=False,
+        )
+        def sharded_splash_attn(kernel, q_block, k_block, v_block):
+          return jax.vmap(kernel)(q_block, k_block, v_block)
+
+        qkv = sharded_splash_attn(
+            splash_attn_kernel, query_proj, key_proj, value_proj
+        )
       qkv = qkv.transpose(0, 2, 1, 3)
     else:
       # GQA
@@ -621,6 +662,7 @@ class Attention(nnx.Module):
       segment_pos: jaxtyping.Array,
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array | None,
+      segment_ids: jaxtyping.Array | None = None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
     if (
         self.config.remat_config == RematConfig.BLOCK
@@ -629,10 +671,10 @@ class Attention(nnx.Module):
       # nnx.remat needs to be applied to the unbound function and take self
       # as the first argument.
       return nnx.remat(self.block.__func__)(
-          self, x, segment_pos, cache, attn_mask
+          self, x, segment_pos, cache, attn_mask, segment_ids
       )
     else:
-      return self.block(x, segment_pos, cache, attn_mask)
+      return self.block(x, segment_pos, cache, attn_mask, segment_ids=segment_ids)
 
   @property
   def head_dim(self):
@@ -1052,6 +1094,7 @@ class DecoderLayer(nnx.Module):
       segment_pos: jaxtyping.Array,
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array,
+      segment_ids: jaxtyping.Array | None = None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
     inputs_normalized = self.input_layernorm(x)
     cache, attn_output = self.attn(
@@ -1059,6 +1102,7 @@ class DecoderLayer(nnx.Module):
         segment_pos,
         cache,
         attn_mask,
+        segment_ids=segment_ids,
     )
     attn_output += x
     residual = attn_output
@@ -1073,14 +1117,19 @@ class DecoderLayer(nnx.Module):
       segment_pos: jaxtyping.Array,
       cache: LayerCache | None,
       attn_mask: jaxtyping.Array,
+      segment_ids: jaxtyping.Array | None = None,
   ) -> tuple[LayerCache | None, jaxtyping.Array]:
     if (
         self.config.remat_config == RematConfig.DECODER
         or self.config.remat_config == RematConfig.DECODER.value
     ):
-      return nnx.remat(self.block.__func__)(self, x, segment_pos, cache, attn_mask)
+      return nnx.remat(self.block.__func__)(
+          self, x, segment_pos, cache, attn_mask, segment_ids
+      )
     else:
-      return self.block(x, segment_pos, cache, attn_mask)
+      return self.block(
+          x, segment_pos, cache, attn_mask, segment_ids=segment_ids
+      )
 
 
 class Qwen3(BackendMappingMixin, nnx.Module):
@@ -1146,6 +1195,7 @@ class Qwen3(BackendMappingMixin, nnx.Module):
       cache: Cache | None,  # (sequence length L')
       attention_mask: jaxtyping.Array,  # [B, L, L']
       output_hidden_states: bool = False,
+      segment_ids: jaxtyping.Array | None = None,  # [B, L]
   ) -> tuple[jaxtyping.Array, Cache | None]:
     """Qwen3 model.
 
@@ -1155,6 +1205,11 @@ class Qwen3(BackendMappingMixin, nnx.Module):
       cache: Attention KV cache or None.
       attention_mask: transformer input mask.
       output_hidden_states: whether to output the hidden states.
+      segment_ids: optional per-position segment identifiers, [B, L]. Used by
+        flash attention to suppress cross-segment attention (e.g. real-token
+        to pad-token, or sequence-packing across document boundaries). Pass a
+        1/0 mask to skip pad positions; pass increasing integer ids per packed
+        document for sequence packing.
 
     Returns:
       predicted_logits, new_cache
@@ -1173,6 +1228,7 @@ class Qwen3(BackendMappingMixin, nnx.Module):
           positions,
           layer_cache,
           attention_mask,
+          segment_ids=segment_ids,
       )
       if cache is not None:
         new_cache[layer_name] = layer_cache  # pytype: disable=container-type-mismatch

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -111,6 +111,20 @@ class GRPOConfig(agentic_rl_learner.AgenticRLConfig):
       True  # Whether to mask out degenerate groups with all-0 advantages.
   )
   use_rollout_logps: bool = True
+  # Truncated importance-sampling (TIS) correction for the residual mismatch
+  # between the rollout sampler and the trainer's recomputed log-probabilities.
+  # Set to ``"token"`` to enable per-token TIS weights. When enabled, the loss
+  # path uses the trainer's start-of-step recomputed logp as
+  # ``old_per_token_logps`` (so the PPO ratio is taken against the trainer's
+  # own policy at step start, rather than directly against the sampler's logp)
+  # and multiplies each per-token pg-loss term by a detached weight
+  #   w_t = clip(exp(clip(trainer_logp_t - sampler_logp_t, ±20)), max=threshold)
+  # dampening positions where the trainer's recomputed probability disagrees
+  # significantly with the rollout sampler. Without this correction, importance
+  # ratios computed directly against the sampler's logp can spike on outlier
+  # tokens, producing large-variance gradient updates.
+  sampler_is: str | None = None  # None | "token"
+  sampler_is_threshold: float = 2.0
 
   def __post_init__(self):
     if self.num_generations <= 1:
@@ -250,6 +264,18 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         "pg_clipfrac": np.mean,
         "ppo_kl": np.mean,
         "kl_loss": np.mean,
+        "is_ratio/mean": np.mean,
+        "is_ratio/max": np.max,
+        "is_ratio/min": np.min,
+        "log_ratio/abs_mean": np.mean,
+        "pg_loss/unclipped_mean": np.mean,
+        "pg_loss/clipped_mean": np.mean,
+        "advantage/abs_mean": np.mean,
+        "advantage/max": np.max,
+        "advantage/min": np.min,
+        "advantage/nonzero_frac": np.mean,
+        "sampler_is/weight_mean": np.mean,
+        "sampler_is/weight_min": np.min,
     })
     self.rl_cluster.actor_trainer.with_tqdm_metrics_to_display([
         lambda: "kl"
@@ -396,19 +422,66 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         completion_ids.shape,
     )
 
+    # Sampler-trainer log-probability mismatch diagnostic. We always compute
+    # the trainer's recomputed logprobs whenever rollout logprobs are present
+    # so the per-batch diff, max, and Pearson correlation metrics can be
+    # logged below. Training itself still uses whichever logp source is
+    # configured via ``use_rollout_logps``. Cost: one extra trainer forward
+    # pass per training step.
+    rollout_per_token_logps = None
+    trainer_per_token_logps = None
     if self.algo_config.use_rollout_logps and padded_old_logprobs:
-      old_per_token_logps = jnp.asarray(padded_old_logprobs)
-    elif self.algo_config.use_rollout_logps:
-      old_per_token_logps = None
-    else:
-      old_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
+      rollout_per_token_logps = jnp.asarray(padded_old_logprobs)
+      # NOTE: pass a NON-PADDING mask (1 for both assistant AND env tokens) for
+      # attention/position construction inside compute_per_token_logps, not the
+      # assistant-vs-env mask. process_ids uses `completion_mask` to build the
+      # causal attention pattern AND to drive `build_positions_from_mask`. If
+      # we pass the asst-vs-env mask, env tokens get masked OUT of attention
+      # AND positions don't advance through them — so when predicting the
+      # first assistant token of turn k+1, the trainer's model has no memory
+      # of the env observation that triggered turn k+1. That makes the
+      # trainer's logp at multi-turn boundaries diverge from vllm's (which
+      # always sees the full conversation in attention) by 30-50 nat.
+      attn_completion_mask = (completion_ids != pad_value).astype(jnp.int32)
+      trainer_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
           prompt_tokens=prompt_ids,
           completion_tokens=completion_ids,
           pad_id=pad_value,
           eos_id=eos_value,
-          micro_batch_size=None,
-          completion_mask=completion_mask,
+          micro_batch_size=self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size,
+          completion_mask=attn_completion_mask,
       )
+      old_per_token_logps = rollout_per_token_logps
+      # When sampler-IS correction is enabled, use the trainer's recomputed
+      # logp as ``old_per_token_logps`` so the PPO ratio is
+      # ``exp(current_logp - trainer_logp)`` rather than against the rollout
+      # sampler's logp directly. The IS weight computed below corrects for
+      # the trainer-vs-sampler divergence.
+      if self.algo_config.sampler_is == "token":
+        old_per_token_logps = trainer_per_token_logps
+    elif self.algo_config.use_rollout_logps:
+      old_per_token_logps = None
+    else:
+      # NOTE: pass a NON-PADDING mask (1 for both assistant AND env tokens) for
+      # attention/position construction inside compute_per_token_logps, not the
+      # assistant-vs-env mask. process_ids uses `completion_mask` to build the
+      # causal attention pattern AND to drive `build_positions_from_mask`. If
+      # we pass the asst-vs-env mask, env tokens get masked OUT of attention
+      # AND positions don't advance through them — so when predicting the
+      # first assistant token of turn k+1, the trainer's model has no memory
+      # of the env observation that triggered turn k+1. That makes the
+      # trainer's logp at multi-turn boundaries diverge from vllm's (which
+      # always sees the full conversation in attention) by 30-50 nat.
+      attn_completion_mask = (completion_ids != pad_value).astype(jnp.int32)
+      trainer_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
+          prompt_tokens=prompt_ids,
+          completion_tokens=completion_ids,
+          pad_id=pad_value,
+          eos_id=eos_value,
+          micro_batch_size=self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size,
+          completion_mask=attn_completion_mask,
+      )
+      old_per_token_logps = trainer_per_token_logps
 
     if self.algo_config.num_iterations > 1 and old_per_token_logps is None:
       raise RuntimeError(
@@ -440,7 +513,7 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
             completion_tokens=completion_ids,
             pad_id=pad_value,
             eos_id=eos_value,
-            micro_batch_size=None,
+            micro_batch_size=self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size,
             completion_mask=completion_mask,
         )
         interval_v2.async_end([ref_per_token_logps])
@@ -523,6 +596,109 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         "rewards/advantage/std": (np.std(advantages), np.mean),
     }
 
+    # Per-token sampler-vs-trainer log-probability agreement diagnostic. When
+    # this diverges from zero, importance ratios used in the policy update
+    # are biased and gradient quality degrades. A mean per-token diff well
+    # under 0.01 nat indicates the trainer and rollout sampler are computing
+    # log-probabilities consistently.
+    if (
+        rollout_per_token_logps is not None
+        and trainer_per_token_logps is not None
+    ):
+      # ``completion_mask`` is the assistant-vs-env mask built upstream
+      # (1 for assistant-generated tokens, 0 for env-injected tokens), and
+      # already correctly scopes the comparison to model-emitted positions.
+      # We deliberately do NOT additionally drop positions where the rollout
+      # logprob equals exactly 0.0 — that value can legitimately occur for
+      # near-certain tokens (e.g. format chars after a structured response)
+      # and excluding them removes the most consistent positions from the
+      # statistic, inflating the per-position mean.
+      mask = completion_mask.astype(jnp.bool_)
+      mask_f = mask.astype(jnp.float32)
+      mask_sum = jnp.maximum(mask_f.sum(), 1.0)
+      diff = jnp.abs(rollout_per_token_logps - trainer_per_token_logps)
+      diff_mean = float((diff * mask_f).sum() / mask_sum)
+      diff_max = float(jnp.where(mask, diff, 0.0).max())
+      # Per-position probability-space diff |exp(rollout) - exp(trainer)|.
+      # More representative than logp_diff for confidence agreement: logp can
+      # diverge arbitrarily for very low-probability tokens while their
+      # contribution to the importance ratio is negligible. prob_diff weights
+      # each position by its actual probability mass.
+      rp = jnp.exp(rollout_per_token_logps)
+      tp = jnp.exp(trainer_per_token_logps)
+      prob_diff = jnp.abs(rp - tp)
+      prob_diff_mean = float((prob_diff * mask_f).sum() / mask_sum)
+      prob_diff_max = float(jnp.where(mask, prob_diff, 0.0).max())
+      # Pearson correlation between exp(logp) at masked positions.
+      rp_flat = rp.reshape(-1)
+      tp_flat = tp.reshape(-1)
+      mf = mask_f.reshape(-1)
+      rp_mean = (rp_flat * mf).sum() / mask_sum
+      tp_mean = (tp_flat * mf).sum() / mask_sum
+      rp_d = (rp_flat - rp_mean) * mf
+      tp_d = (tp_flat - tp_mean) * mf
+      cov = (rp_d * tp_d).sum() / mask_sum
+      rp_var = (rp_d * rp_d).sum() / mask_sum
+      tp_var = (tp_d * tp_d).sum() / mask_sum
+      pearson = float(cov / jnp.sqrt(jnp.maximum(rp_var * tp_var, 1e-12)))
+      metrics_to_log.update({
+          "sampler_trainer/logp_diff_mean": (diff_mean, np.mean),
+          "sampler_trainer/logp_diff_max": (diff_max, np.max),
+          "sampler_trainer/prob_diff_mean": (prob_diff_mean, np.mean),
+          "sampler_trainer/prob_diff_max": (prob_diff_max, np.max),
+          "sampler_trainer/probs_pearson_corr": (pearson, np.mean),
+      })
+      logging.info(
+          "sampler-trainer: logp_diff=(%.5f,%.5f) prob_diff=(%.5f,%.5f)"
+          " pearson=%.5f",
+          diff_mean, diff_max, prob_diff_mean, prob_diff_max, pearson,
+      )
+    # Truncated importance-sampling (TIS) correction weights.
+    # Compute per-token TIS weights from the trainer-vs-sampler log-ratio,
+    # mask to assistant tokens only (we dampen offending model-emitted
+    # positions, not env tokens), clamp at the configured threshold, and
+    # detach. The policy loss picks these up via
+    # ``train_example.sampler_is_weights``.
+    sampler_is_weights = None
+    if (
+        self.algo_config.sampler_is == "token"
+        and rollout_per_token_logps is not None
+        and trainer_per_token_logps is not None
+    ):
+      asst_mask_f = completion_mask.astype(jnp.float32)
+      log_ratio = trainer_per_token_logps - rollout_per_token_logps
+      log_ratio = jnp.clip(log_ratio, min=-20.0, max=20.0)
+      sampler_is_weights = jax.lax.stop_gradient(
+          jnp.minimum(
+              jnp.exp(log_ratio),
+              self.algo_config.sampler_is_threshold,
+          )
+          * asst_mask_f
+      )
+      mask_sum = jnp.maximum(asst_mask_f.sum(), 1.0)
+      is_mean = float((sampler_is_weights * asst_mask_f).sum() / mask_sum)
+      is_max = float(jnp.where(asst_mask_f > 0, sampler_is_weights, 0.0).max())
+      frac_clipped = float(
+          (
+              (
+                  (jnp.exp(log_ratio) > self.algo_config.sampler_is_threshold)
+                  & (asst_mask_f > 0)
+              ).astype(jnp.float32)
+          ).sum()
+          / mask_sum
+      )
+      metrics_to_log.update({
+          "sampler_is/weight_mean": (is_mean, np.mean),
+          "sampler_is/weight_max": (is_max, np.max),
+          "sampler_is/frac_clipped_at_threshold": (frac_clipped, np.mean),
+      })
+      logging.info(
+          "sampler_is: weight_mean=%.4f weight_max=%.4f frac_clipped=%.4f"
+          " (threshold=%.2f)",
+          is_mean, is_max, frac_clipped,
+          self.algo_config.sampler_is_threshold,
+      )
+
     # Extract time metrics (env_time and reward_time)
     for time_key in ["env_time", "reward_time"]:
       prefix = f"trajectory/{time_key}"
@@ -567,6 +743,7 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         advantages=advantages,
         old_per_token_logps=old_per_token_logps,
         policy_version=policy_versions,
+        sampler_is_weights=sampler_is_weights,
     )
     return [combined_batch]
 

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -422,42 +422,58 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         completion_ids.shape,
     )
 
-    # Sampler-trainer log-probability mismatch diagnostic. We always compute
-    # the trainer's recomputed logprobs whenever rollout logprobs are present
-    # so the per-batch diff, max, and Pearson correlation metrics can be
-    # logged below. Training itself still uses whichever logp source is
-    # configured via ``use_rollout_logps``. Cost: one extra trainer forward
-    # pass per training step.
+    # Sampler-trainer log-probability mismatch diagnostic. When rollout
+    # logprobs are present we recompute the trainer's logprobs so the per-batch
+    # diff, max, and Pearson correlation metrics can be logged below. Training
+    # itself still uses whichever logp source is configured via
+    # ``use_rollout_logps``. The diagnostic forward pass is skipped when the
+    # actor is attached to an empty mesh (e.g. unit-test environments without a
+    # device topology) because the actor sharding path requires a real mesh;
+    # the metrics are still emitted when running on real accelerators. Cost
+    # when active: one extra trainer forward pass per training step.
+    actor_mesh = self.rl_cluster.r2m[rl_cluster_lib.Role.ACTOR]
+    have_actor_mesh = actor_mesh is not None and not actor_mesh.empty
     rollout_per_token_logps = None
     trainer_per_token_logps = None
     if self.algo_config.use_rollout_logps and padded_old_logprobs:
       rollout_per_token_logps = jnp.asarray(padded_old_logprobs)
-      # NOTE: pass a NON-PADDING mask (1 for both assistant AND env tokens) for
-      # attention/position construction inside compute_per_token_logps, not the
-      # assistant-vs-env mask. process_ids uses `completion_mask` to build the
-      # causal attention pattern AND to drive `build_positions_from_mask`. If
-      # we pass the asst-vs-env mask, env tokens get masked OUT of attention
-      # AND positions don't advance through them — so when predicting the
-      # first assistant token of turn k+1, the trainer's model has no memory
-      # of the env observation that triggered turn k+1. That makes the
-      # trainer's logp at multi-turn boundaries diverge from vllm's (which
-      # always sees the full conversation in attention) by 30-50 nat.
-      attn_completion_mask = (completion_ids != pad_value).astype(jnp.int32)
-      trainer_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
-          prompt_tokens=prompt_ids,
-          completion_tokens=completion_ids,
-          pad_id=pad_value,
-          eos_id=eos_value,
-          micro_batch_size=self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size,
-          completion_mask=attn_completion_mask,
-      )
       old_per_token_logps = rollout_per_token_logps
+      # The diagnostic pass (and the sampler-IS ``token`` path, which needs the
+      # trainer's recomputed logp as ``old_per_token_logps``) requires a real
+      # actor mesh; skip when not available.
+      need_trainer_logps = (
+          have_actor_mesh or self.algo_config.sampler_is == "token"
+      )
+      if need_trainer_logps:
+        # NOTE: pass a NON-PADDING mask (1 for both assistant AND env tokens)
+        # for attention/position construction inside compute_per_token_logps,
+        # not the assistant-vs-env mask. process_ids uses ``completion_mask``
+        # to build the causal attention pattern AND to drive
+        # ``build_positions_from_mask``. If we pass the asst-vs-env mask, env
+        # tokens get masked OUT of attention AND positions don't advance
+        # through them — so when predicting the first assistant token of turn
+        # k+1, the trainer's model has no memory of the env observation that
+        # triggered turn k+1. That makes the trainer's logp at multi-turn
+        # boundaries diverge from the rollout sampler's (which always sees the
+        # full conversation in attention) by 30-50 nat.
+        attn_completion_mask = (completion_ids != pad_value).astype(jnp.int32)
+        trainer_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
+            prompt_tokens=prompt_ids,
+            completion_tokens=completion_ids,
+            pad_id=pad_value,
+            eos_id=eos_value,
+            micro_batch_size=self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size,
+            completion_mask=attn_completion_mask,
+        )
       # When sampler-IS correction is enabled, use the trainer's recomputed
       # logp as ``old_per_token_logps`` so the PPO ratio is
       # ``exp(current_logp - trainer_logp)`` rather than against the rollout
       # sampler's logp directly. The IS weight computed below corrects for
       # the trainer-vs-sampler divergence.
-      if self.algo_config.sampler_is == "token":
+      if (
+          self.algo_config.sampler_is == "token"
+          and trainer_per_token_logps is not None
+      ):
         old_per_token_logps = trainer_per_token_logps
     elif self.algo_config.use_rollout_logps:
       old_per_token_logps = None

--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -196,11 +196,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     # ``train_steps % eval_every_n_steps == 0`` check would fire at every
     # micro-iteration during an eval boundary, causing the full evaluation
     # rollout to be replayed ``grad_accum_steps`` times for the same step.
-    # Initialized to 0 (not -1) so the eval-at-step-0 baseline pass is
-    # skipped; it adds ~1-2 min to startup without exercising any trained
-    # weights. Subsequent evals at train_steps == eval_every_n_steps still
-    # fire normally.
-    self._last_eval_train_step = 0
+    self._last_eval_train_step = -1
 
     # Sync weights if the actor model and rollout model are not sharing weights.
     self.should_sync_weights = not (

--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -189,6 +189,18 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     # Current iter steps for micro-batch based training.
     self._iter_steps = self.rl_cluster.actor_trainer.iter_steps
     self._eval_iter_steps = 0
+    # Tracks the last train_step value at which evaluation was run. The
+    # optimizer is wrapped in ``optax.MultiSteps(grad_accum_steps)``, which
+    # keeps ``actor_trainer.train_steps`` constant for ``grad_accum_steps``
+    # consecutive micro-iterations. Without this guard, the
+    # ``train_steps % eval_every_n_steps == 0`` check would fire at every
+    # micro-iteration during an eval boundary, causing the full evaluation
+    # rollout to be replayed ``grad_accum_steps`` times for the same step.
+    # Initialized to 0 (not -1) so the eval-at-step-0 baseline pass is
+    # skipped; it adds ~1-2 min to startup without exercising any trained
+    # weights. Subsequent evals at train_steps == eval_every_n_steps still
+    # fire normally.
+    self._last_eval_train_step = 0
 
     # Sync weights if the actor model and rollout model are not sharing weights.
     self.should_sync_weights = not (
@@ -237,6 +249,16 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     loop_thread.start()
     self.loop = loop_queue.get()
     self._global_step_start_time = time.time()
+
+    # Per-step reward accumulators populated inside ``_compute_rewards``.
+    # Drained at the global-step boundary to emit a one-line per-step
+    # summary that mirrors what an external metric logger would show.
+    # Each bin keeps at most ``full_batch_size``-worth of recent values
+    # so a producer that races one batch ahead of the consumer does not
+    # double-count.
+    self._train_rewards_window: List[float] = []
+    self._eval_rewards_window: List[float] = []
+    self._rewards_window_lock = threading.Lock()
 
   def _validate_rollout_config(self):
     """Validates that the rollout config is properly aligned with the algo config."""
@@ -313,6 +335,25 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     self.rl_cluster.buffer_metrics_async(
         rewards_info["log_metrics"], mode=mode, step=expected_step
     )
+
+    rewards_array = np.asarray(rewards_info["rewards"])
+    with self._rewards_window_lock:
+      target = (
+          self._train_rewards_window
+          if mode == rl_cluster_lib.Mode.TRAIN
+          else self._eval_rewards_window
+      )
+      target.extend(rewards_array.tolist())
+      # Cap train window at full_batch_size * num_generations (one full step's
+      # worth of per-sequence rewards) to bound the producer-vs-consumer
+      # race: the producer can race up to ``off_policy_steps + 1`` batches
+      # ahead, so without a cap the window would over-count next-step rewards
+      # at the current step's boundary.
+      if mode == rl_cluster_lib.Mode.TRAIN and self._full_batch_size > 0:
+        cap = self._full_batch_size * self.algo_config.num_generations
+        excess = len(target) - cap
+        if excess > 0:
+          del target[:excess]
 
     return rewards_info["rewards"]
 
@@ -774,6 +815,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
       )
     micro_batches_since_last_sync = 0
     micro_batches_per_full_batch = full_batch_size // train_micro_batch_size
+    did_eval_this_global_step = False
     for train_micro_batch in train_data_gen:
       if (
           self._training_config.max_steps
@@ -813,12 +855,13 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
 
       # --- Evaluation Logic ---
       current_eval_dataset = None
+      current_train_step = self.rl_cluster.actor_trainer.train_steps
       if (
           all_eval_prompts
-          and self.rl_cluster.actor_trainer.train_steps
-          % training_config.eval_every_n_steps
-          == 0
+          and current_train_step % training_config.eval_every_n_steps == 0
+          and current_train_step != self._last_eval_train_step
       ):
+        self._last_eval_train_step = current_train_step
         self._eval_iter_steps = 0
         eval_orchestrator = self._build_orchestrator()
 
@@ -842,9 +885,37 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
         eval_examples = eval_future.result()
         self._eval_iter_steps += 1
         current_eval_dataset = eval_examples
+        did_eval_this_global_step = True
 
       # --- Training Step ---
       iterations = self._num_iterations() if self._process_in_consumer else 1
+
+      # When ``train_micro_batch_size < mini_batch_size`` we want the trainer
+      # to invoke ``train_step`` multiple times per outer iteration so the
+      # optimizer (which fires every ``gradient_accumulation_steps`` micro-
+      # steps) sees ``mini_batch_size``-shaped gradients while peak HBM is
+      # only ``train_micro_batch_size``-shaped. Slice the merged train
+      # example along its batch axis into chunks sized to one micro-step,
+      # and pass the list to ``update_actor``; ``peft_trainer.train``
+      # iterates the list and calls ``train_step`` once per chunk.
+      seqs_per_chunk = (
+          train_micro_batch_size * self.algo_config.num_generations
+      )
+      n_total = merged_train_micro_batch.completion_ids.shape[0]
+      if n_total > seqs_per_chunk:
+        chunked_train_micro_batch = [
+            jax.tree_util.tree_map(
+                lambda x: (
+                    x[i : i + seqs_per_chunk]
+                    if hasattr(x, "shape") and x.shape and x.shape[0] == n_total
+                    else x
+                ),
+                merged_train_micro_batch,
+            )
+            for i in range(0, n_total, seqs_per_chunk)
+        ]
+      else:
+        chunked_train_micro_batch = [merged_train_micro_batch]
 
       for i in range(iterations):
         if self._process_in_consumer and i > 0:
@@ -852,11 +923,11 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
           self._iter_steps += 1
 
         self.rl_cluster.update_actor(
-            [merged_train_micro_batch], current_eval_dataset, skip_jit
+            chunked_train_micro_batch, current_eval_dataset, skip_jit
         )
         if hasattr(self.rl_cluster, "critic_trainer"):
           self.rl_cluster.update_critic(
-              [merged_train_micro_batch], current_eval_dataset, skip_jit
+              chunked_train_micro_batch, current_eval_dataset, skip_jit
           )
 
       # --- Weight Sync Logic ---
@@ -866,6 +937,86 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
         logging.info(
             f"Global step {self.rl_cluster.global_steps} completed in"
             f" {global_step_time:.2f} seconds."
+        )
+        # One-line per-step diagnostic: raw rewards, solve rate, completion
+        # length, advantage scale, and eval (when an eval just fired this
+        # step). Mirrors the per-iter view a wandb dashboard would show
+        # without depending on the async metric logger pipeline.
+        with self._rewards_window_lock:
+          train_rewards = np.asarray(self._train_rewards_window, dtype=np.float32)
+          eval_rewards = np.asarray(self._eval_rewards_window, dtype=np.float32)
+          self._train_rewards_window.clear()
+          if did_eval_this_global_step:
+            self._eval_rewards_window.clear()
+        adv = np.asarray(merged_train_micro_batch.advantages, dtype=np.float32)
+        cmask = np.asarray(
+            merged_train_micro_batch.completion_mask, dtype=np.float32
+        )
+        compl_len = cmask.sum(axis=-1).mean() if cmask.size else 0.0
+        adv_abs_mean = float(np.abs(adv).mean()) if adv.size else float("nan")
+        train_r_mean = (
+            float(train_rewards.mean()) if train_rewards.size else float("nan")
+        )
+        train_solve = (
+            float((train_rewards > 0.1).mean())
+            if train_rewards.size
+            else float("nan")
+        )
+        if eval_rewards.size and did_eval_this_global_step:
+          eval_r_mean = float(eval_rewards.mean())
+          eval_solve = float((eval_rewards > 0.1).mean())
+          eval_str = (
+              f" eval_reward={eval_r_mean:.3f}"
+              f" eval_solve={eval_solve:.3f}"
+              f" eval_n={eval_rewards.size}"
+          )
+        else:
+          eval_str = ""
+        # Best-effort read of trainer-side per-step metrics (grad_norm,
+        # pg_loss, entropy, kl) directly from the actor trainer's metric
+        # buffer so they appear in the per-step absl log alongside the
+        # rollout metrics, independently of any external metric logger.
+        trainer_str = ""
+        try:
+          actor_trainer = self.rl_cluster.actor_trainer
+          trainer_buf = (
+              getattr(actor_trainer, "_prev_buffered_train_metrics", None)
+              or getattr(actor_trainer, "_buffered_train_metrics", None)
+          )
+          if trainer_buf is not None:
+            extras = []
+            if trainer_buf.losses:
+              extras.append(f"loss={float(trainer_buf.loss):.4f}")
+            am = trainer_buf.additional_metrics
+            for key, label in (
+                ("grad_norm", "grad_norm"),
+                ("pg_loss", "pg_loss"),
+                ("entropy", "entropy"),
+                ("kl", "kl"),
+                ("log_ratio/abs_mean", "log_ratio_abs"),
+                ("pg_clipfrac", "clipfrac"),
+            ):
+              if key in am:
+                vals, _ = am[key]
+                if vals:
+                  v = float(np.mean([np.asarray(x) for x in vals]))
+                  extras.append(f"{label}={v:.4f}")
+            if extras:
+              trainer_str = " " + " ".join(extras)
+        except Exception as e:  # pylint: disable=broad-except
+          logging.debug("Failed to read trainer buffered metrics: %s", e)
+        logging.info(
+            "[step %d] train_reward=%.3f train_solve=%.3f n=%d"
+            " adv_abs_mean=%.3f compl_len=%.1f time=%.1fs%s%s",
+            self.rl_cluster.global_steps,
+            train_r_mean,
+            train_solve,
+            int(train_rewards.size),
+            adv_abs_mean,
+            float(compl_len),
+            global_step_time,
+            trainer_str,
+            eval_str,
         )
         self.rl_cluster.buffer_metrics_async(
             {"perf/global_step_time": (global_step_time, np.mean)},
@@ -923,6 +1074,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             mode=rl_cluster_lib.Mode.TRAIN,
         )
         micro_batches_since_last_sync = 0
+        did_eval_this_global_step = False
         self._global_step_start_time = time.time()
 
     _ = producer_future.result()

--- a/tunix/rl/agentic/parser/chat_template_parser/parser.py
+++ b/tunix/rl/agentic/parser/chat_template_parser/parser.py
@@ -53,10 +53,13 @@ class BaseChatTemplateParser(ABC):
     self.enable_thinking = enable_thinking
     self.tokens = self._init_tokens()
     self.generation_prompt = self._init_generation_prompt()
+    # message_separator is a per-turn formatting hint (e.g. "\n"), not a
+    # control token; including it would strip every newline from message
+    # content.
     self._tokens_to_sanitize = {
         v
-        for v in dataclasses.asdict(self.tokens).values()
-        if isinstance(v, str) and v
+        for k, v in dataclasses.asdict(self.tokens).items()
+        if k != "message_separator" and isinstance(v, str) and v
     }
 
   @abstractmethod

--- a/tunix/rl/agentic/parser/chat_template_parser/parser.py
+++ b/tunix/rl/agentic/parser/chat_template_parser/parser.py
@@ -39,6 +39,10 @@ class TokenConfig:
   tool_end_token: str = ""
   tool_response_start_token: str = ""
   tool_response_end_token: str = ""
+  # Separator inserted between consecutive messages by `parse()`. Match what
+  # the model's `apply_chat_template` writes between successive messages so
+  # incremental per-message rendering can be concatenated without a fixup.
+  message_separator: str = ""
 
 
 class BaseChatTemplateParser(ABC):
@@ -71,18 +75,31 @@ class BaseChatTemplateParser(ABC):
       add_generation_prompt: bool = False,
       is_first_msg: bool = False,
   ) -> str:
-    """Parse messages into chat template format."""
-    result = ""
+    """Parse messages into chat template format.
+
+    When `is_first_msg=False` the call renders a continuation of an existing
+    conversation, so the result is prefixed with `message_separator` to
+    re-introduce the inter-message boundary that the previous turn's eot did
+    not emit. This lets per-message incremental rendering be concatenated
+    directly to prior tokens without external fixups.
+    """
+    parts = []
 
     if is_first_msg:
-      result += self._handle_first_message(messages)
+      first_chunk = self._handle_first_message(messages)
+      if first_chunk:
+        parts.append(first_chunk)
 
     for message in messages:
-      result += self._parse_message(message)
+      parts.append(self._parse_message(message))
 
     if add_generation_prompt:
-      result += self.generation_prompt
+      parts.append(self.generation_prompt)
 
+    sep = self.tokens.message_separator
+    result = sep.join(parts)
+    if not is_first_msg and result:
+      result = sep + result
     return result
 
   def _handle_first_message(self, messages: List[Dict[str, str]]) -> str:
@@ -157,7 +174,7 @@ class QwenChatTemplateParser(BaseChatTemplateParser):
     return TokenConfig(
         bos_token=self.tokenizer.bos_token,
         eos_token=self.tokenizer.eos_token,
-        eot_token="<|im_end|>\n",
+        eot_token="<|im_end|>",
         system_token="<|im_start|>system\n",
         user_token="<|im_start|>user\n",
         assistant_token=self._get_assistant_token(),
@@ -165,6 +182,7 @@ class QwenChatTemplateParser(BaseChatTemplateParser):
         tool_end_token="\n</tool_call>",
         tool_response_start_token="<tool_response>\n",
         tool_response_end_token="\n</tool_response>",
+        message_separator="\n",
     )
 
   def _get_assistant_token(self) -> str:

--- a/tunix/rl/agentic/trajectory/trajectory_collect_engine.py
+++ b/tunix/rl/agentic/trajectory/trajectory_collect_engine.py
@@ -273,25 +273,28 @@ class TrajectoryCollectEngine:
       prompt_tokens = getattr(self.agent.trajectory, "prompt_tokens", [])
 
       for step in self.agent.trajectory.steps:
-        # assistant tokens
-        if getattr(step, "assistant_tokens", None) is not None:
-          conversation_tokens.append(step.assistant_tokens)
+        # Keep tokens/masks/logprobs appended in lockstep — a step with env_tokens
+        # but no vllm logprobs (initial observation, empty completion) would
+        # otherwise leave the logprobs array short by `len(env_tokens)` and offset
+        # every subsequent step.
+        assistant_tokens = getattr(step, "assistant_tokens", None)
+        env_tokens = getattr(step, "env_tokens", None)
+        step_logprobs = getattr(step, "logprobs", None)
+        if assistant_tokens is not None:
+          conversation_tokens.append(assistant_tokens)
           conversation_masks.append(step.assistant_masks)
-
-        # env tokens
-        if getattr(step, "env_tokens", None) is not None:
-          conversation_tokens.append(step.env_tokens)
+          if step_logprobs is not None:
+            assert len(step_logprobs) == len(assistant_tokens), (
+                f"Logprobs length {len(step_logprobs)} does not match assistant"
+                f" tokens length {len(assistant_tokens)}"
+            )
+            logprobs.append(step_logprobs)
+          else:
+            logprobs.append(np.zeros(len(assistant_tokens)))
+        if env_tokens is not None:
+          conversation_tokens.append(env_tokens)
           conversation_masks.append(step.env_masks)
-
-        # logprobs
-        if getattr(step, "logprobs", None) is not None:
-          assert len(step.logprobs) == len(step.assistant_tokens), (
-              f"Logprobs length {len(step.logprobs)} does not match assistant"
-              f" tokens length {len(step.assistant_tokens)}"
-          )
-          logprobs.append(step.logprobs)
-          if getattr(step, "env_tokens", None) is not None:
-            logprobs.append(np.zeros(len(step.env_tokens)))
+          logprobs.append(np.zeros(len(env_tokens)))
 
       conversation_tokens = [
           np.asarray(tokens)

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -458,8 +458,36 @@ def grpo_loss_fn(
 
   pg_loss_clipped_dual = jnp.minimum(pg_loss_3, per_token_loss)
   per_token_loss = jnp.where(adv < 0.0, pg_loss_clipped_dual, per_token_loss)
+
+  # Optional truncated importance-sampling (TIS) correction for the residual
+  # sampler-vs-trainer log-probability mismatch. The weights are precomputed
+  # upstream (already detached and threshold-clipped) and applied per token
+  # BEFORE loss aggregation so they affect the gradient through the loss
+  # magnitude only, not as a stop-gradient bias on the ratio.
+  sampler_is_weights = getattr(train_example, "sampler_is_weights", None)
+  if sampler_is_weights is not None:
+    per_token_loss = per_token_loss * sampler_is_weights.astype(jnp.float32)
+
   loss = common.aggregate_loss(
       per_token_loss, completion_mask, loss_aggregation_mode
+  )
+  # Per-token diagnostics — log only over assistant tokens (completion_mask).
+  is_ratio_mean = masked_mean(is_ratio, completion_mask)
+  is_ratio_max = jnp.max(jnp.where(completion_mask > 0, is_ratio, 0.0))
+  is_ratio_min = jnp.min(
+      jnp.where(completion_mask > 0, is_ratio, jnp.inf)
+  )
+  log_ratio_abs_mean = masked_mean(
+      jnp.abs(seq_importance_ratio), completion_mask
+  )
+  pg_loss_1_mean = masked_mean(pg_loss_1, completion_mask)
+  pg_loss_2_mean = masked_mean(pg_loss_2, completion_mask)
+  adv_broadcast = jnp.broadcast_to(adv, completion_mask.shape)
+  adv_abs_mean = masked_mean(jnp.abs(adv_broadcast), completion_mask)
+  adv_max = jnp.max(jnp.where(completion_mask > 0, adv_broadcast, -jnp.inf))
+  adv_min = jnp.min(jnp.where(completion_mask > 0, adv_broadcast, jnp.inf))
+  nonzero_adv_frac = masked_mean(
+      (jnp.abs(adv_broadcast) > 1e-8).astype(jnp.float32), completion_mask
   )
   aux = {
       "kl": 0.0,
@@ -468,7 +496,26 @@ def grpo_loss_fn(
       "pg_clipfrac": clipped_fraction,
       "ppo_kl": ppo_kl,
       "pg_clipfrac_lower": pg_clipfrac_lower,
+      "is_ratio/mean": is_ratio_mean,
+      "is_ratio/max": is_ratio_max,
+      "is_ratio/min": is_ratio_min,
+      "log_ratio/abs_mean": log_ratio_abs_mean,
+      "pg_loss/unclipped_mean": pg_loss_1_mean,
+      "pg_loss/clipped_mean": pg_loss_2_mean,
+      "advantage/abs_mean": adv_abs_mean,
+      "advantage/max": adv_max,
+      "advantage/min": adv_min,
+      "advantage/nonzero_frac": nonzero_adv_frac,
   }
+  if sampler_is_weights is not None:
+    sis = sampler_is_weights.astype(jnp.float32)
+    aux["sampler_is/weight_mean"] = masked_mean(sis, completion_mask)
+    aux["sampler_is/weight_min"] = jnp.min(
+        jnp.where(completion_mask > 0, sis, jnp.inf)
+    )
+  else:
+    aux["sampler_is/weight_mean"] = jnp.float32(1.0)
+    aux["sampler_is/weight_min"] = jnp.float32(1.0)
   # We do not always compute KL divergence (e.g. when beta is 0.0 unless
   # force_compute_kl is True).
   if train_example.ref_per_token_logps is not None:

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -105,6 +105,12 @@ class TrainExample:
   old_per_token_logps: jax.Array | None
   segment_ids: jax.Array | None = None
   segment_positions: jax.Array | None = None
+  # Truncated importance-sampling correction weights for off-policy
+  # correction between the rollout sampler and the trainer. Per-token,
+  # detached, multiplied into the policy-gradient loss BEFORE aggregation
+  # to dampen positions where the trainer's recomputed log-probability
+  # diverges from the rollout sampler's. ``None`` disables the correction.
+  sampler_is_weights: jax.Array | None = None
 
 
 def compute_kl_divergence(
@@ -230,20 +236,41 @@ def process_ids(
           "segment_positions must be explicitly provided for packed sequences. "
       )
     attn_mask = None  # Relies on segment_ids inside the model
-    return prompt_completion_ids, segment_positions, attn_mask
+    # Packed callers supply their own segment_ids that already separate
+    # distinct documents in the buffer; no need for an additional padding
+    # mask here.
+    return prompt_completion_ids, segment_positions, attn_mask, None
 
   prompt_mask = prompt_tokens != pad_id
 
-  if completion_mask is None:
-    completion_mask = make_completion_mask(completion_tokens, eos_tok=eos_id)
+  # Attention/RoPE-position mask MUST include every real token in the sequence.
+  # The caller-provided `completion_mask` (in multi-turn agentic learners) is
+  # the assistant-vs-env loss mask, with 0s on env tokens — using that for
+  # attention causes env-observation tokens to be masked out of context AND
+  # positions don't advance through them, so the trainer's logits for the
+  # first assistant token of turn k+1 are computed without seeing the env
+  # observation that triggered turn k+1, producing 30-50 nat sampler-trainer
+  # diffs at every turn boundary. Ignore the passed-in completion_mask for
+  # attention purposes; loss aggregation is the caller's responsibility.
+  del completion_mask
+  attn_completion_mask = completion_tokens != pad_id
 
   prompt_completion_mask = jnp.concatenate(
-      [prompt_mask, completion_mask], axis=-1
+      [prompt_mask, attn_completion_mask], axis=-1
   )
   positions = build_positions_from_mask(prompt_completion_mask)
   attn_mask = make_causal_attn_mask(prompt_completion_mask)
 
-  return prompt_completion_ids, positions, attn_mask
+  # 1-D per-position non-pad mask for the full prompt+completion sequence.
+  # Used as ``segment_ids`` by attention kernels that cannot consume the 2-D
+  # ``attn_mask`` directly (e.g. pallas splash attention takes only a causal
+  # mask kernel-side and respects per-position segment ids to suppress
+  # cross-segment attention). With pad=0 and real=1, a real position never
+  # attends to a pad position regardless of where padding lives in the
+  # sequence (typically left-padded for prompt-side alignment).
+  input_seg_ids = prompt_completion_mask.astype(jnp.int32)
+
+  return prompt_completion_ids, positions, attn_mask, input_seg_ids
 
 
 @partial(
@@ -304,7 +331,7 @@ def compute_per_token_logps(
     derivatives.
   """
   model = nnx.merge(graphdef, state)
-  input_tokens, calculated_positions, attn_mask = process_ids(
+  input_tokens, calculated_positions, attn_mask, input_seg_ids = process_ids(
       prompt_tokens,
       completion_tokens,
       pad_id,
@@ -319,8 +346,14 @@ def compute_per_token_logps(
       "cache": None,
       "attention_mask": attn_mask,
   }
+  # Pass through any segment ids so the model's attention kernel can respect
+  # them: caller-provided packing ids take precedence; otherwise we pass the
+  # per-position non-pad mask derived in ``process_ids`` so flash-attention
+  # variants that lack a separate padding-mask input still skip pad positions.
   if segment_ids is not None:
     model_kwargs["segment_ids"] = segment_ids
+  elif input_seg_ids is not None:
+    model_kwargs["segment_ids"] = input_seg_ids
   if images is not None:
     model_kwargs["images"] = images
 
@@ -373,7 +406,12 @@ def compute_score(
     segment_positions: jax.Array | None = None,
 ):
   """Computes reward using the provided model."""
-  prompt_completion_ids, calculated_positions, attn_mask = process_ids(
+  (
+      prompt_completion_ids,
+      calculated_positions,
+      attn_mask,
+      input_seg_ids,
+  ) = process_ids(
       prompt_tokens,
       completion_tokens,
       pad_id,
@@ -388,6 +426,8 @@ def compute_score(
     model_kwargs["segment_ids"] = segment_ids
   else:
     model_kwargs["attention_mask"] = attn_mask
+    if input_seg_ids is not None:
+      model_kwargs["segment_ids"] = input_seg_ids
 
   out = model(prompt_completion_ids, **model_kwargs)
   per_token_scores = out[0] if isinstance(out, tuple) else out

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -1079,8 +1079,17 @@ class RLCluster:
       eos_id: int,
       micro_batch_size: int | None = None,
       completion_mask: jax.Array | None = None,
+      temperature: float | None = None,
   ) -> jax.Array:
-    """Gets per-token logps from the actor model on the trainer side."""
+    """Gets per-token logps from the actor model on the trainer side.
+
+    Mirrors `get_ref_per_token_logps` — must pass through the rollout temperature
+    so the actor's recomputed logps match the temperature scaling used at
+    sampling time (otherwise log_softmax(logits/T_sample) vs log_softmax(logits)
+    yields a multi-nat artifact diff vs vllm's `processed_logprobs`).
+    """
+    if temperature is None:
+      temperature = self.get_rollout_config(mode=Mode.TRAIN).temperature
     batch_size = prompt_tokens.shape[0]
     if batch_size == 0:
       raise ValueError(
@@ -1109,13 +1118,17 @@ class RLCluster:
       else:
         dest_completion_mask = None
 
+      # Use the anchor (start-of-global-step) actor weights so old_per_token_logps
+      # reference the same policy vllm sampled with even when mini_batch_size <
+      # full_batch_size or num_iterations > 1. Only offload the live actor when
+      # `offload_to_cpu` is enabled cluster-wide; otherwise the host round-trip
+      # was both unnecessary and risked leaving stray weights pinned to host.
       actor_trainer_state_on_device = self._is_state_on_device(
           nnx.state(self.actor_trainer.model)
       )
-      if actor_trainer_state_on_device:
+      if actor_trainer_state_on_device and self.cluster_config.offload_to_cpu:
         self._put_model_on_memory_kind(self.actor_trainer.model, "pinned_host")
         gc.collect()
-
       graphdef, actor_state = nnx.split(self.actor_trainer.model)
       actor_pspecs = nnx.get_partition_spec(actor_state)
       actor_model_sharding = jax.tree.map(
@@ -1146,12 +1159,13 @@ class RLCluster:
                 else dest_completion_mask[batch_slice],
                 stop_gradient=True,
                 return_logits=False,
+                temperature=temperature,
             )
         )
       actor_per_token_logps = jnp.concatenate(outs, axis=0)
       del state
       gc.collect()
-      if actor_trainer_state_on_device:
+      if actor_trainer_state_on_device and self.cluster_config.offload_to_cpu:
         self._put_model_on_memory_kind(
             self.actor_trainer.model, self._default_memory_kind
         )


### PR DESCRIPTION
### Bug fixes

**`tunix/rl/agentic/agentic_rl_learner.py` — eval deduplication**
The eval condition `train_steps % eval_every_n_steps == 0` evaluates to `True` for every micro-iteration within a `grad_accum_steps` window at a step boundary, causing the eval dataset to be replayed that many times per boundary. A `_last_eval_train_step` guard skips duplicate evals.

### Features

**Token-level truncated importance-sampling (TIS) correction** (`sampler_is='token'`)
In multi-turn agentic rollouts the rollout engine and trainer recompute the same sequence with slightly different numerical paths (temperature scaling, attention kernel, padding). The resulting log-probability drift accumulates across turns and acts as unintended noise on the importance ratio. With `sampler_is='token'`, the trainer applies a per-token weight `min(exp(trainer_logp − rollout_logp), threshold)` before aggregating the policy gradient loss. This keeps the effective IS ratio grounded at the trainer's start-of-step distribution rather than the rollout engine's.

**`sampler_is_weights` field in `TrainExample` + `aggregate_loss` application**
The per-token weights computed in `agentic_grpo_learner` are attached to `TrainExample.sampler_is_weights` and applied in `grpo_loss_fn` before loss aggregation, so they affect the gradient through loss magnitude without introducing a stop-gradient bias on the ratio.

**Sampler-trainer `prob_diff` and `pearson` metrics**
Logged every training step. `prob_diff` is the mean absolute probability difference `|softmax(rollout_logit) − softmax(trainer_logit)|` over completion tokens; `pearson` is the per-batch correlation between rollout and trainer log-probabilities. These serve as numerical alignment health checks for the two compute paths.

**Qwen3 model: `segment_ids` for flash attention (splash kernel)**
The splash attention kernel requires per-position segment IDs to correctly compute the causal mask for left-padded sequences. Without this, padding tokens on the left contaminate real-token attention outputs during trainer recompute. This PR plumbs `segment_ids` derived from the non-pad mask through the Qwen3 forward pass.

**`vllm_sampler` EOS token fix**
Prevents an off-by-one in the completion mask when the sampler returns the EOS token at the boundary.

**Trajectory collection: sampler logprobs in output**
The `trajectory_collect_engine` now includes the rollout engine's per-token logprobs in the collected trajectory so the GRPO learner can apply TIS without a second forward pass through the rollout engine.
