### PR TITLE
Fixes the tfds prompt not sanitizated issue for agentic path.

### DIFF
--- a/tests/cli/utils/data_test.py
+++ b/tests/cli/utils/data_test.py
@@ -309,6 +309,40 @@ def create_dataset():
         ],
     )
 
+  def test_normalizes_bytes_prompt_key_to_sanitized_prompts(self):
+      tokenizer = _FakeTokenizer()
+      dataset = _BaseDataset([
+        {"question": b"<start_of_turn>short prompt", "answer": 1},
+        {"question": memoryview(b"another prompt"), "answer": 2},
+      ])
+
+      first, second = data_lib.post_init_dataset(
+        dataset,
+        tokenizer=tokenizer,  # pytype: disable=wrong-arg-types
+        batch_size=2,
+        num_batches=None,
+        max_prompt_length=None,
+        prompt_key="question",
+      )
+
+      self.assertIsNone(second)
+      batches = list(first)
+      self.assertEqual(
+        batches[0],
+        [
+          {
+            "question": b"<start_of_turn>short prompt",
+            "answer": 1,
+            "prompts": "short prompt",
+          },
+          {
+            "question": memoryview(b"another prompt"),
+            "answer": 2,
+            "prompts": "another prompt",
+          },
+        ],
+      )
+
   def test_num_epochs_repeats_dataset(self):
     tokenizer = _FakeTokenizer()
     dataset = _BaseDataset(

--- a/tunix/cli/utils/data.py
+++ b/tunix/cli/utils/data.py
@@ -7,6 +7,7 @@ import os
 from typing import Any, Callable, Optional, Protocol, Union
 
 from tunix.generate import tokenizer_adapter
+from tunix.utils import token_sanitization
 
 Tokenizer = tokenizer_adapter.Tokenizer
 TokenizerAdapter = tokenizer_adapter.TokenizerAdapter
@@ -199,7 +200,12 @@ def post_init_dataset(
     source_prompt_key = prompt_key
 
     def normalize_prompt_key(x):
-      return {**x, "prompts": x[source_prompt_key]}
+      return {
+          **x,
+          "prompts": token_sanitization.sanitize_control_tokens(
+              x[source_prompt_key]
+          ),
+      }
 
     dataset = dataset.map(normalize_prompt_key)
     prompt_key = "prompts"


### PR DESCRIPTION
In agentic mode, the post init filters the entries based on prompt length and therefore needs sanitize the prompt during the process. It's not a problem in the non agentic path because the chat template is applied during dataset creation and sanitization is done then.

Error:
```
Started trajectory logging thread.
[rank0]: Traceback (most recent call last):
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/mnt/disks/github/tunix/tunix/cli/grpo_main.py", line 932, in <module>
[rank0]:     app.run(main)
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/absl/app.py", line 367, in run
[rank0]:     _run_main(main, args)
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/absl/app.py", line 312, in _run_main
[rank0]:     sys.exit(main(argv))
[rank0]:              ^^^^^^^^^^
[rank0]:   File "/mnt/disks/github/tunix/tunix/cli/grpo_main.py", line 928, in main
[rank0]:     pipeline.run_grpo_trainer()
[rank0]:   File "/mnt/disks/github/tunix/tunix/cli/grpo_main.py", line 899, in run_grpo_trainer
[rank0]:     self._run(mode=mode)
[rank0]:   File "/mnt/disks/github/tunix/tunix/cli/grpo_main.py", line 890, in _run
[rank0]:     GRPOLearner(**learner_kwargs).train(dataset)
[rank0]:   File "/mnt/disks/github/tunix/tunix/rl/agentic/agentic_rl_learner.py", line 779, in train
[rank0]:     first_item = next(full_batch_iterator)
[rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 461, in result
[rank0]:     self = None
[rank0]:     ^^^^
[rank0]:   File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line 404, in __get_result
[rank0]:     self = None
[rank0]:     ^^^^
[rank0]:   File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 63, in run
[rank0]:     self = None
[rank0]:     ^^^^
[rank0]:   File "/mnt/disks/github/tunix/tunix/cli/utils/data.py", line 217, in prompt_length_filter
[rank0]:     tokens = tokenizer.encode(x[prompt_key])
[rank0]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disks/github/tunix/tunix/generate/tokenizer_adapter.py", line 62, in encode
[rank0]:     return self._tokenizer.encode(text, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2732, in encode
[rank0]:     encoded_inputs = self.encode_plus(
[rank0]:                      ^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/transformers/tokenization_utils_base.py", line 3123, in encode_plus
[rank0]:     return self._encode_plus(
[rank0]:            ^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/transformers/tokenization_utils_fast.py", line 627, in _encode_plus
[rank0]:     batched_output = self._batch_encode_plus(
[rank0]:                      ^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/venv/lib/python3.12/site-packages/transformers/tokenization_utils_fast.py", line 553, in _batch_encode_plus
[rank0]:     encodings = self._tokenizer.encode_batch(
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: TextEncodeInput must be Union[TextInputSequence, Tuple[InputSequence, InputSequence]]
[rank0]: --------------------
[rank0]: For simplicity, Grain has removed its internal frames from the traceback of the following exception. Set --grain_py_traceback_filtering=off to include these.
I0601 22:57:15.874089 139186351342336 trajectory_logger.py:225] Stopping trajectory logging thread...
I0601 22:57:15.874795 139186351342336 trajectory_logger.py:230] Stopped trajectory logging thread.
INFO 06-01 22:57:15 [dp_scheduler.py:265] Rank 1: Shutting down
INFO 06-01 22:57:15 [dp_scheduler.py:265] Rank 0: Shutting down
```

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
