### PR TITLE
Add optional output_clamp_value to compute_kl_divergence

### DIFF
--- a/tests/rl/algorithm_config_test.py
+++ b/tests/rl/algorithm_config_test.py
@@ -142,6 +142,21 @@ class AlgorithmConfigTest(parameterized.TestCase):
     self.assertIn("advantage_estimator: gae", full_log_output)
     self.assertIn("policy_loss_fn: ppo", full_log_output)
 
+  def test_kl_clamp_value_default_is_none(self):
+    """Default `kl_clamp_value` is None (no clamp, prior behavior)."""
+    config = algorithm_config.AlgorithmConfig()
+    self.assertIsNone(config.kl_clamp_value)
+
+  @parameterized.named_parameters(
+      ("ten_thousand", 10000.0),
+      ("one", 1.0),
+      ("explicit_none", None),
+  )
+  def test_kl_clamp_value_round_trips(self, value):
+    """`kl_clamp_value` is stored as-set on the config."""
+    config = algorithm_config.AlgorithmConfig(kl_clamp_value=value)
+    self.assertEqual(config.kl_clamp_value, value)
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/rl/common_test.py
+++ b/tests/rl/common_test.py
@@ -563,6 +563,77 @@ class CommonTest(parameterized.TestCase):
     )
     np.testing.assert_allclose(kl, expected_kl, rtol=1e-3)
 
+  @parameterized.named_parameters(
+      ("kl", "kl"),
+      ("mse_kl", "mse_kl"),
+      ("low_var_kl", "low_var_kl"),
+  )
+  def test_compute_kl_divergence_output_clamp_default_is_no_op(self, method):
+    rng = jax.random.PRNGKey(0)
+    k1, k2 = jax.random.split(rng)
+    per_token_logps = jax.random.uniform(k1, shape=(2, 2, 4))
+    ref_per_token_logps = jax.random.uniform(k2, shape=(2, 2, 4))
+    baseline = common.compute_kl_divergence(
+        per_token_logps, ref_per_token_logps, method=method
+    )
+    with_explicit_none = common.compute_kl_divergence(
+        per_token_logps,
+        ref_per_token_logps,
+        method=method,
+        clamp_value=None,
+    )
+    np.testing.assert_array_equal(baseline, with_explicit_none)
+
+  @parameterized.named_parameters(
+      ("kl", "kl"),
+      ("mse_kl", "mse_kl"),
+      ("low_var_kl", "low_var_kl"),
+  )
+  def test_compute_kl_divergence_output_clamp_caps_outliers(self, method):
+    per_token_logps = jnp.array([-50.0, 0.0, 50.0], dtype=jnp.float32)
+    ref_per_token_logps = jnp.array([50.0, 0.0, -50.0], dtype=jnp.float32)
+    clamp = 10.0
+    kl = common.compute_kl_divergence(
+        per_token_logps,
+        ref_per_token_logps,
+        method=method,
+        clamp_value=clamp,
+    )
+    self.assertTrue(bool(jnp.all(kl >= -clamp)))
+    self.assertTrue(bool(jnp.all(kl <= clamp)))
+
+  def test_compute_kl_divergence_output_clamp_passes_through_in_range(self):
+    per_token_logps = jnp.array([0.1, 0.2, 0.3], dtype=jnp.float32)
+    ref_per_token_logps = jnp.array([0.4, 0.5, 0.6], dtype=jnp.float32)
+    unclamped = common.compute_kl_divergence(
+        per_token_logps, ref_per_token_logps, method="kl"
+    )
+    clamped = common.compute_kl_divergence(
+        per_token_logps,
+        ref_per_token_logps,
+        method="kl",
+        clamp_value=10000.0,
+    )
+    np.testing.assert_array_equal(clamped, unclamped)
+
+  def test_compute_kl_divergence_output_clamp_symmetric(self):
+    per_token_logps = jnp.array([100.0], dtype=jnp.float32)
+    ref_per_token_logps = jnp.array([-100.0], dtype=jnp.float32)
+    pos = common.compute_kl_divergence(
+        per_token_logps,
+        ref_per_token_logps,
+        method="kl",
+        clamp_value=5.0,
+    )
+    neg = common.compute_kl_divergence(
+        ref_per_token_logps,
+        per_token_logps,
+        method="kl",
+        clamp_value=5.0,
+    )
+    np.testing.assert_array_equal(pos, jnp.array([5.0]))
+    np.testing.assert_array_equal(neg, jnp.array([-5.0]))
+
   def test_aggregate_loss_bf16(self):
     per_token_loss = jnp.array([1.0, 2.0, 3.0], dtype=jnp.bfloat16)
     completion_mask = jnp.array([1, 1, 0], dtype=jnp.int32)

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -256,7 +256,10 @@ def ppo_policy_loss_fn(
   kl_coef = getattr(algo_config, "kl_coef", 0.0)
   if kl_coef > 0.0 and train_example.ref_per_token_logps is not None:
     kl = common.compute_kl_divergence(
-        per_token_logps, train_example.ref_per_token_logps, "kl"
+        per_token_logps,
+        train_example.ref_per_token_logps,
+        "kl",
+        clamp_value=getattr(algo_config, "kl_clamp_value", None),
     )
     kl_loss = masked_mean(kl, completion_mask)
     loss = loss + kl_coef * kl_loss
@@ -521,6 +524,7 @@ def grpo_loss_fn(
         per_token_logps,
         train_example.ref_per_token_logps,
         algo_config.kl_loss_mode,
+        clamp_value=algo_config.kl_clamp_value,
     )
     # Log mean KL.
     aux["kl"] = jnp.astype(

--- a/tunix/rl/algorithm_config.py
+++ b/tunix/rl/algorithm_config.py
@@ -29,6 +29,14 @@ class AlgorithmConfig:
   advantage_estimator: str = "grpo"
   policy_loss_fn: str = "grpo"
   reward_manager: str = "sequence-level"
+  # Optional symmetric clamp applied to per-token KL inside
+  # `common.compute_kl_divergence`. `None` (default) disables the clamp and
+  # preserves prior behavior bit-for-bit. Set to a positive float (e.g.
+  # `10000.0`) to bound rare outliers — useful when the trained policy
+  # briefly drifts far from the reference and the `low_var_kl` estimator's
+  # `exp(diff)` term saturates bf16 / overflows fp32 and poisons the loss
+  # for the rest of the step.
+  kl_clamp_value: float | None = None
 
   def __post_init__(self):
     valid_algo_variants = [

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -117,6 +117,7 @@ def compute_kl_divergence(
     per_token_logps: jax.Array,
     ref_per_token_logps: jax.Array,
     method: str = "low_var_kl",
+    clamp_value: float | None = None,
 ) -> jax.Array:
   """Compute per token KL divergence between trained and reference policy.
 
@@ -132,6 +133,13 @@ def compute_kl_divergence(
     per_token_logps: Per token log probabilities from the trained policy.
     ref_per_token_logps: Per token log probabilities from the reference policy.
     method: KL penalty method. Defaults to "low_var_kl".
+    clamp_value: Optional symmetric clamp applied to the returned KL,
+      i.e. `clip(kl, -clamp_value, +clamp_value)`. `None`
+      (default) disables the clamp and preserves prior behavior. Set to a
+      positive float (e.g. `10000.0`) to bound rare outliers — useful when
+      the trained policy briefly drifts far from the reference and the
+      `low_var_kl` estimator's `exp(diff)` term can overflow fp32 / saturate
+      bf16.
 
   Returns:
     KL divergence.
@@ -141,17 +149,21 @@ def compute_kl_divergence(
     ref_per_token_logps = ref_per_token_logps.astype(jnp.float32)
 
   if method == "kl":
-    return per_token_logps - ref_per_token_logps
+    kl = per_token_logps - ref_per_token_logps
   elif method == "mse_kl":
-    return 0.5 * jnp.square(per_token_logps - ref_per_token_logps)
+    kl = 0.5 * jnp.square(per_token_logps - ref_per_token_logps)
   elif method == "low_var_kl":
-    kl = ref_per_token_logps - per_token_logps
-    return jnp.exp(kl) - (kl) - 1
+    diff = ref_per_token_logps - per_token_logps
+    kl = jnp.exp(diff) - diff - 1
   else:
     raise ValueError(
         "`method` must be one of 'kl', 'mse_kl', 'low_var_kl'. Received:"
         f" {method}"
     )
+
+  if clamp_value is not None:
+    kl = jnp.clip(kl, -clamp_value, clamp_value)
+  return kl
 
 
 def selective_log_softmax(logits: jax.Array, input_ids: jax.Array) -> jax.Array:

--- a/tunix/rl/ppo/ppo_learner.py
+++ b/tunix/rl/ppo/ppo_learner.py
@@ -361,6 +361,7 @@ class PPOLearner(rl_learner.RLLearner[PPOConfig]):
           old_per_token_logps,
           ref_per_token_logps,
           method=self.algo_config.kl_method,
+          clamp_value=self.algo_config.kl_clamp_value,
       )
       kl = kl * jax_completion_mask
       rewards = rewards - self.algo_config.beta * kl


### PR DESCRIPTION
## Summary

`compute_kl_divergence` currently has no upper bound on its output. The three estimators are unbiased on the math, but rare outliers happen in practice — e.g. when the trained policy briefly drifts far from the reference and the `low_var_kl` estimator's `exp(ref_logp - logp)` term saturates bf16 (or, less commonly, overflows fp32 even with the internal cast). When that happens the per-token KL becomes `Inf`/`NaN`, gets aggregated into `kl_loss`, multiplied by `β`, added to the policy-gradient loss, and poisons the gradient for the rest of the step.

This PR:

1. **Adds an optional `clamp_value: float | None = None` kwarg** to `compute_kl_divergence`. When set to a positive float, the returned KL is symmetrically clamped: `clip(kl, -clamp_value, +clamp_value)`. Default `None` is a strict no-op and preserves existing behavior bit-for-bit.

2. **Adds a `kl_clamp_value: float | None = None` field** to `AlgorithmConfig` (the base class inherited by `GRPOConfig`, `PPOConfig`, and `AgenticRLConfig`) so users can set the clamp from a recipe.

3. **Wires the field through to the three existing call sites**:
   - `tunix/rl/algo_core.py` — `ppo_policy_loss_fn` (uses defensive `getattr(algo_config, "kl_clamp_value", None)` since that path reads `kl_coef` via `getattr` too)
   - `tunix/rl/algo_core.py` — `grpo_loss_fn` (reads `algo_config.kl_clamp_value` directly, matching the existing `algo_config.kl_loss_mode` access next to it)
   - `tunix/rl/ppo/ppo_learner.py` (reads `self.algo_config.kl_clamp_value`)

Default `None` everywhere means no behavior change for existing recipes. Users opt in by setting e.g. `kl_clamp_value=10000.0` in their algo config.

## Why opt-in (not a behavior change)

Default `None` keeps existing recipes bit-identical. Reviewers who want to flip the default to a numeric value (e.g. `10000.0`) in a follow-up — happy to do so; that's a one-line change.

## Tests

**`tests/rl/common_test.py`** — 4 new methods on `CommonTest` targeting `compute_kl_divergence`:

| Test | What it checks |
|---|---|
| `test_compute_kl_divergence_clamp_default_is_no_op` (parameterized over `kl` / `mse_kl` / `low_var_kl`) | Calling with `clamp_value=None` returns byte-identical output vs not passing the kwarg at all |
| `test_compute_kl_divergence_clamp_caps_outliers` (parameterized over the three methods) | With `clamp_value=10.0` and ±50 log-prob deltas, every element of the result is in `[-10, +10]` |
| `test_compute_kl_divergence_clamp_passes_through_in_range` | A large clamp (`10000.0`) on small in-range inputs returns identical values to the unclamped path |
| `test_compute_kl_divergence_clamp_symmetric` | A `+100` input clamps to `+5.0`, the matching `-100` input clamps to `-5.0` |

**`tests/rl/algorithm_config_test.py`** — 2 new methods on `AlgorithmConfigTest`:

| Test | What it checks |
|---|---|
| `test_kl_clamp_value_default_is_none` | `AlgorithmConfig().kl_clamp_value is None` |
| `test_kl_clamp_value_round_trips` (parameterized over `10000.0` / `1.0` / `None`) | Value set on the config is what the field returns |

## Files

| File | Δ |
|---|---|
| `tunix/rl/common.py` | +20 / -4 — new kwarg + docstring |
| `tunix/rl/algorithm_config.py` | +8 — new config field |
| `tunix/rl/algo_core.py` | +6 / -1 — wire at both KL call sites |
| `tunix/rl/ppo/ppo_learner.py` | +1 — wire `self.algo_config.kl_clamp_value` |
| `tests/rl/common_test.py` | +71 — 4 new test methods |
| `tests/rl/algorithm_config_test.py` | +15 — 2 new test methods |

## Checklist
- [x] Default (`None`) is bit-identical to prior behavior at every call site
- [x] Configurable from a recipe via `AlgorithmConfig.kl_clamp_value`
- [x] Wired at all three existing `compute_kl_divergence` call sites (PPO loss, GRPO loss, PPO learner)
- [x] Tests cover the kwarg semantics + the config field
- [x] No new dependencies
