### PR TITLE
Batch submission in vllm server mode

### DIFF
--- a/docs/rollout.md
+++ b/docs/rollout.md
@@ -122,6 +122,26 @@ settings are specific to vLLM:
         for higher-throughput request scheduling leveraging the vLLM continuous
         batching capabilities.
 
+-   `rollout_vllm_server_mode_submission_threshold`
+
+    -   Only applies when `rollout_vllm_server_mode=True`.
+    -   `0`: drain the submission queue immediately when requests arrive.
+    -   `N > 0`: hold queued requests in the in-process driver until at least
+        `N` requests have accumulated, then release them to the vLLM engine in
+        one drain cycle.
+
+-   `rollout_vllm_server_mode_submission_timeout_s`
+
+    -   Only applies when `rollout_vllm_server_mode=True` and used together with
+        `rollout_vllm_server_mode_submission_threshold > 0`.
+    -   Flush timeout (seconds) that bounds how long queued requests wait when
+        **fewer** than `submission_threshold` accumulate. The clock starts when
+        the **first** request of the current window arrives; once it elapses the
+        partial batch is drained even though the threshold was not reached. The
+        clock resets after each drain.
+    -   `0` (default): no timeout — below-threshold requests wait until the
+        threshold is met (previous behavior).
+
 -   `rollout_vllm_async_scheduling`
 
     -   Enables vLLM async scheduling.
@@ -180,6 +200,8 @@ rollout_config = base_rollout.RolloutConfig(
     rollout_vllm_hbm_utilization=0.2,
     rollout_vllm_tpu_backend_type="jax",
     rollout_vllm_server_mode=False,
+    rollout_vllm_server_mode_submission_threshold=0,
+    rollout_vllm_server_mode_submission_timeout_s=0.0,
 )
 
 cluster_config = rl_cluster_lib.ClusterConfig(

--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -180,6 +180,27 @@ parser.add_argument(
     help="Rollout engine asynchronous scheduling.",
 )
 parser.add_argument(
+  "--rollout-server-mode-submission-threshold",
+  type=int,
+  default=0,
+  required=False,
+  help=(
+    "Only drain the vLLM server-mode submission queue after at least this "
+    "many requests have accumulated. 0 disables the threshold."
+  ),
+)
+parser.add_argument(
+  "--rollout-server-mode-submission-timeout-s",
+  type=float,
+  default=0.0,
+  required=False,
+  help=(
+    "Flush the vLLM server-mode submission queue after this many seconds "
+    "since the first request of the current window arrived, even if the "
+    "submission threshold has not been reached. 0 disables the timeout."
+  ),
+)
+parser.add_argument(
     "--rollout-dp",
     type=int,
     default=-1,
@@ -1140,6 +1161,12 @@ def get_rollout_config(engine: str) -> base_rollout.RolloutConfig:
       rollout_vllm_hbm_utilization=0.2,
       rollout_vllm_tpu_backend_type="jax",
       rollout_vllm_server_mode=args.rollout_server_mode,
+        rollout_vllm_server_mode_submission_threshold=(
+          args.rollout_server_mode_submission_threshold
+        ),
+        rollout_vllm_server_mode_submission_timeout_s=(
+          args.rollout_server_mode_submission_timeout_s
+        ),
       rollout_vllm_async_scheduling=args.async_scheduling,
   )
 

--- a/tests/cli/grpo_main_test.py
+++ b/tests/cli/grpo_main_test.py
@@ -572,6 +572,24 @@ verl_compatible: false
     cfg = p.create_rollout_config()
     self.assertEqual(cfg.kv_cache_size, 256 + 512 + 256)
 
+  def test_vllm_submission_threshold_passed_through(self):
+    extra = """
+vllm_config:
+  hbm_utilization: 0.4
+  server_mode: true
+  server_mode_submission_threshold: 3840
+  server_mode_submission_timeout_s: 1.5
+"""
+    p = _make_pipeline_with_cli_args(extra, ["rollout_engine=vllm"])
+    role_to_mesh = {
+        rl_cluster_lib.Role.ROLLOUT: mock.Mock(
+            devices=mock.Mock(shape=(1, 1))
+        )
+    }
+    cfg = p.create_rollout_config(role_to_mesh=role_to_mesh)
+    self.assertEqual(cfg.rollout_vllm_server_mode_submission_threshold, 3840)
+    self.assertEqual(cfg.rollout_vllm_server_mode_submission_timeout_s, 1.5)
+
 
 # ---------------------------------------------------------------------------
 # GRPOConfig construction

--- a/tests/generate/vllm_driver_test.py
+++ b/tests/generate/vllm_driver_test.py
@@ -102,6 +102,60 @@ class _FakeLLMEngine:
 
 class VllmDriverAsyncTest(absltest.TestCase):
 
+  def test_requests_are_staged_until_loop_starts(self):
+    engine = _FakeLLMEngine(["req-0", "req-1"])
+    driver = VLLMInProcessDriver(llm_engine=engine, auto_start=False)
+    self.addCleanup(driver.shutdown)
+
+    future_0 = driver.submit_request(
+        request_id="req-0",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+    future_1 = driver.submit_request(
+        request_id="req-1",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    self.assertEmpty(engine._pending)
+    self.assertFalse(future_0.done())
+    self.assertFalse(future_1.done())
+
+    driver.start()
+
+    self.assertEqual(future_0.result(timeout=5.0).request_id, "req-0")
+    self.assertEqual(future_1.result(timeout=5.0).request_id, "req-1")
+
+  def test_submission_threshold_delays_queue_drain(self):
+    engine = _FakeLLMEngine(["req-0", "req-1"])
+    driver = VLLMInProcessDriver(
+        llm_engine=engine,
+        submission_threshold=2,
+        poll_interval_s=0.001,
+        auto_start=True,
+    )
+    self.addCleanup(driver.shutdown)
+
+    future_0 = driver.submit_request(
+        request_id="req-0",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    time.sleep(0.01)
+    self.assertEmpty(engine._pending)
+    self.assertFalse(future_0.done())
+
+    future_1 = driver.submit_request(
+        request_id="req-1",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    self.assertEqual(future_0.result(timeout=5.0).request_id, "req-0")
+    self.assertEqual(future_1.result(timeout=5.0).request_id, "req-1")
+
   def test_out_of_order_completions_preserved(self):
     request_ids = [f"req-{i}" for i in range(10)]
     completion_order = [
@@ -155,6 +209,101 @@ class VllmDriverAsyncTest(absltest.TestCase):
 
     # Wait for the log thread to call into the engine's do_log_stats.
     self.assertTrue(engine.log_called.wait(timeout=1.0))
+
+  def test_submission_timeout_flushes_partial_batch(self):
+    # Threshold of 2 but only 1 request arrives: the flush timeout must still
+    # submit it instead of letting it hang in the queue forever.
+    engine = _FakeLLMEngine(["req-0"])
+    timeout_s = 0.05
+    driver = VLLMInProcessDriver(
+        llm_engine=engine,
+        submission_threshold=2,
+        submission_timeout_s=timeout_s,
+        poll_interval_s=0.001,
+        auto_start=True,
+    )
+    self.addCleanup(driver.shutdown)
+
+    start = time.perf_counter()
+    future_0 = driver.submit_request(
+        request_id="req-0",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    result = future_0.result(timeout=5.0)
+    elapsed = time.perf_counter() - start
+    self.assertEqual(result.request_id, "req-0")
+    # It flushed because of the timeout (threshold of 2 was never reached), so
+    # the request could not have completed before the timeout elapsed.
+    self.assertGreaterEqual(elapsed, timeout_s * 0.8)
+
+  def test_submission_timeout_disabled_holds_partial_batch(self):
+    # timeout == 0 disables the flush: below-threshold requests stay queued
+    # (identical to the pre-existing behavior).
+    engine = _FakeLLMEngine(["req-0"])
+    driver = VLLMInProcessDriver(
+        llm_engine=engine,
+        submission_threshold=2,
+        submission_timeout_s=0.0,
+        poll_interval_s=0.001,
+        auto_start=True,
+    )
+    self.addCleanup(driver.shutdown)
+
+    future_0 = driver.submit_request(
+        request_id="req-0",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    time.sleep(0.05)
+    self.assertEmpty(engine._pending)
+    self.assertFalse(future_0.done())
+
+  def test_submission_timeout_counts_from_first_request(self):
+    # The clock starts at the FIRST request of the window. With threshold=3
+    # never reached, the partial batch must flush ~timeout after req-0, even
+    # though req-1 arrives later (well after req-0 but before the deadline).
+    engine = _FakeLLMEngine(["req-0", "req-1"])
+    timeout_s = 0.1
+    driver = VLLMInProcessDriver(
+        llm_engine=engine,
+        submission_threshold=3,
+        submission_timeout_s=timeout_s,
+        poll_interval_s=0.001,
+        auto_start=True,
+    )
+    self.addCleanup(driver.shutdown)
+
+    start = time.perf_counter()
+    future_0 = driver.submit_request(
+        request_id="req-0",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+    time.sleep(timeout_s * 0.6)
+    future_1 = driver.submit_request(
+        request_id="req-1",
+        prompt={"prompt_token_ids": [1]},
+        params=object(),
+    )
+
+    self.assertEqual(future_0.result(timeout=5.0).request_id, "req-0")
+    self.assertEqual(future_1.result(timeout=5.0).request_id, "req-1")
+    elapsed = time.perf_counter() - start
+    # If the clock had (incorrectly) restarted at req-1, the flush would land at
+    # ~0.6*timeout + timeout; assert it fired well before that.
+    self.assertLess(elapsed, timeout_s * 1.5)
+
+  def test_negative_submission_timeout_raises(self):
+    engine = _FakeLLMEngine([])
+    with self.assertRaises(ValueError):
+      VLLMInProcessDriver(
+          llm_engine=engine,
+          submission_timeout_s=-1.0,
+          auto_start=False,
+      )
 
 
 if __name__ == "__main__":

--- a/tunix/cli/grpo_main.py
+++ b/tunix/cli/grpo_main.py
@@ -378,12 +378,22 @@ class GrpoPipeline(config.HyperParameters):
               (max_num_seqs * kv_cache_size) // 4,
           ),
       )
+      submission_threshold = rollout_cfg.get(
+          "rollout_vllm_server_mode_submission_threshold",
+          vllm.get("server_mode_submission_threshold", 0),
+      )
+      submission_timeout_s = rollout_cfg.get(
+          "rollout_vllm_server_mode_submission_timeout_s",
+          vllm.get("server_mode_submission_timeout_s", 0.0),
+      )
       os.environ["VLLM_ALLOW_LONG_MAX_MODEL_LEN"] = "1"
       return dict(
           rollout_vllm_model_version=vllm.get("model_version", model_id),
           rollout_vllm_hbm_utilization=vllm.get("hbm_utilization", 0.4),
           rollout_vllm_tpu_backend_type=vllm.get("tpu_backend_type", "jax"),
           rollout_vllm_server_mode=vllm.get("server_mode", True),
+          rollout_vllm_server_mode_submission_threshold=submission_threshold,
+          rollout_vllm_server_mode_submission_timeout_s=submission_timeout_s,
           rollout_vllm_async_scheduling=vllm.get("async_scheduling", True),
           tensor_parallel_size=(
               rollout_shape[1] if len(rollout_shape) > 1 else 1

--- a/tunix/generate/vllm_async_driver.py
+++ b/tunix/generate/vllm_async_driver.py
@@ -25,7 +25,7 @@ from concurrent.futures import Future
 import os
 import threading
 import time
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 from absl import logging
 from vllm import envs
@@ -47,6 +47,7 @@ envs.VLLM_ENABLE_V1_MULTIPROCESSING = False
 
 StreamCallback = Callable[[Union[RequestOutput, PoolingRequestOutput]], None]
 RequestFuture = Future[Union[RequestOutput, PoolingRequestOutput]]
+QueuedRequest = dict[str, Any]
 
 
 class VLLMInProcessDriver:
@@ -56,14 +57,23 @@ class VLLMInProcessDriver:
       self,
       llm_engine: LLMEngine,
       *,
-      poll_interval_s: float = 0.005,
+      poll_interval_s: float = 0.004,
+      submission_threshold: int = 0,
+      submission_timeout_s: float = 0.0,
       log_stats_interval_s: float = 10.0,
       stream_callback: Optional[StreamCallback] = None,
       auto_start: bool = True,
   ) -> None:
     self._llm_engine = llm_engine
     self._poll_interval_s = poll_interval_s
+    self._submission_threshold = submission_threshold
+    self._submission_timeout_s = submission_timeout_s
     self._stream_callback = stream_callback
+
+    if self._submission_threshold < 0:
+      raise ValueError("submission_threshold must be >= 0.")
+    if self._submission_timeout_s < 0:
+      raise ValueError("submission_timeout_s must be >= 0.")
 
     self._engine_lock = threading.Lock()
     self._work_event = threading.Event()
@@ -73,6 +83,11 @@ class VLLMInProcessDriver:
     self._log_stats_interval_s: float = log_stats_interval_s
 
     self._pending: Dict[str, RequestFuture] = {}
+    self._submission_queue: list[QueuedRequest] = []
+    # Monotonic (``time.perf_counter``) timestamp of the first request in the
+    # current submission window; used to flush a partial batch once
+    # ``submission_timeout_s`` elapses. Reset to ``None`` on each drain.
+    self._submission_window_start: Optional[float] = None
     self._last_error: Optional[Exception] = None
 
     if auto_start:
@@ -85,6 +100,8 @@ class VLLMInProcessDriver:
       *,
       usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
       poll_interval_s: float = 0.005,
+      submission_threshold: int = 0,
+      submission_timeout_s: float = 0.0,
       log_stats_interval_s: float = 1.0,
       stream_callback: Optional[StreamCallback] = None,
       auto_start: bool = True,
@@ -101,9 +118,30 @@ class VLLMInProcessDriver:
     return cls(
         llm_engine,
         poll_interval_s=poll_interval_s,
+        submission_threshold=submission_threshold,
+        submission_timeout_s=submission_timeout_s,
         stream_callback=stream_callback,
         auto_start=auto_start,
     )
+
+  def _submission_queue_ready_locked(self) -> bool:
+    if not self._submission_queue:
+      return False
+    if self._submission_threshold == 0:
+      return True
+    if len(self._submission_queue) >= self._submission_threshold:
+      return True
+    # Flush a partial batch if the submission timeout has elapsed since the
+    # first request of the current window arrived. Without this, fewer than
+    # ``submission_threshold`` requests would stall in the queue indefinitely.
+    if (
+        self._submission_timeout_s > 0
+        and self._submission_window_start is not None
+        and time.perf_counter() - self._submission_window_start
+        >= self._submission_timeout_s
+    ):
+      return True
+    return False
 
   def submit_request(
       self,
@@ -117,16 +155,8 @@ class VLLMInProcessDriver:
       trace_headers: Optional[dict[str, str]] = None,
       priority: int = 0,
   ) -> RequestFuture:
-    future: RequestFuture = Future()
     with self._engine_lock:
-      if request_id in self._pending:
-        raise ValueError(f"Request {request_id} already pending.")
-      self._pending[request_id] = future
-      logging.debug(
-          f"VLLMInProcessDriver submitting request {request_id} with prompt"
-          f" {prompt} and sampling params {params} to vLLM engine."
-      )
-      self._llm_engine.add_request(
+      future = self._queue_request_locked(
           request_id=request_id,
           prompt=prompt,
           params=params,
@@ -138,6 +168,92 @@ class VLLMInProcessDriver:
       )
       self._work_event.set()
     return future
+
+  def submit_requests(
+      self,
+      requests: Sequence[QueuedRequest],
+  ) -> list[RequestFuture]:
+    futures: list[RequestFuture] = []
+    with self._engine_lock:
+      for request in requests:
+        futures.append(
+            self._queue_request_locked(
+                request_id=request["request_id"],
+                prompt=request["prompt"],
+                params=request["params"],
+                arrival_time=request.get("arrival_time"),
+                lora_request=request.get("lora_request"),
+                tokenization_kwargs=request.get("tokenization_kwargs"),
+                trace_headers=request.get("trace_headers"),
+                priority=request.get("priority", 0),
+            )
+        )
+
+      if futures:
+        self._work_event.set()
+    return futures
+
+  def _queue_request_locked(
+      self,
+      *,
+      request_id: str,
+      prompt: Union[EngineCoreRequest, PromptType],
+      params: Union[SamplingParams, PoolingParams],
+      arrival_time: Optional[float] = None,
+      lora_request: Optional[LoRARequest] = None,
+      tokenization_kwargs: Optional[dict[str, Any]] = None,
+      trace_headers: Optional[dict[str, str]] = None,
+      priority: int = 0,
+  ) -> RequestFuture:
+    if request_id in self._pending:
+      raise ValueError(f"Request {request_id} already pending.")
+
+    future: RequestFuture = Future()
+    self._pending[request_id] = future
+    if self._submission_window_start is None:
+      # Start the flush-timeout clock from the first request of this window.
+      self._submission_window_start = time.perf_counter()
+    self._submission_queue.append({
+        "request_id": request_id,
+        "prompt": prompt,
+        "params": params,
+        "arrival_time": arrival_time,
+        "lora_request": lora_request,
+        "tokenization_kwargs": tokenization_kwargs,
+        "trace_headers": trace_headers,
+        "priority": priority,
+    })
+    logging.debug(
+        "VLLMInProcessDriver queued request %s for loop-side submission.",
+        request_id,
+    )
+    return future
+
+  def _drain_submission_queue_locked(self) -> None:
+    if not self._submission_queue_ready_locked():
+      return
+
+    queued_requests = self._submission_queue
+    self._submission_queue = []
+    self._submission_window_start = None
+    for request in queued_requests:
+      future = self._pending.get(request["request_id"])
+      if future is None or future.cancelled():
+        continue
+      logging.debug(
+          "VLLMInProcessDriver submitting queued request %s to vLLM engine.",
+          request["request_id"],
+      )
+      self._llm_engine.add_request(
+          request_id=request["request_id"],
+          prompt=request["prompt"],
+          params=request["params"],
+          arrival_time=request.get("arrival_time"),
+          lora_request=request.get("lora_request"),
+          tokenization_kwargs=request.get("tokenization_kwargs"),
+          trace_headers=request.get("trace_headers"),
+          priority=request.get("priority", 0),
+      )
 
   def start(self) -> None:
     if self._loop_thread and self._loop_thread.is_alive():
@@ -218,14 +334,17 @@ class VLLMInProcessDriver:
       self._record_error(exc)
 
   def _wait_for_work(self) -> bool:
-    with self._engine_lock:
-      has_work = self._llm_engine.has_unfinished_requests()
-      if has_work:
-        return True
-      self._work_event.clear()
+    while not self._stop_event.is_set():
+      with self._engine_lock:
+        has_work = self._submission_queue_ready_locked()
+        if not has_work:
+          has_work = self._llm_engine.has_unfinished_requests()
+        if has_work:
+          return True
+        self._work_event.clear()
 
-    self._work_event.wait(timeout=self._poll_interval_s)
-    return not self._stop_event.is_set()
+      self._work_event.wait(timeout=self._poll_interval_s)
+    return False
 
   def _step_engine(
       self,
@@ -236,6 +355,7 @@ class VLLMInProcessDriver:
         100,
     )
     with self._engine_lock:
+      self._drain_submission_queue_locked()
       logging.log_every_n(
           logging.DEBUG,
           "VLLMInProcessDriver has"

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -49,6 +49,8 @@ class VllmConfig:
 
   # Sampler related
   server_mode: bool = False
+  server_mode_submission_threshold: int = 0
+  server_mode_submission_timeout_s: float = 0.0
   mapping_config: MappingConfig = dataclasses.field(
       default_factory=MappingConfig
   )
@@ -312,6 +314,8 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     engine_args = self._build_engine_args()
     return VLLMInProcessDriver.from_engine_args(
         engine_args,
+        submission_threshold=self.config.server_mode_submission_threshold,
+        submission_timeout_s=self.config.server_mode_submission_timeout_s,
     )
 
   def stop(self):
@@ -392,18 +396,19 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     if self._driver is None:
       raise RuntimeError("vLLM in-process driver is not initialized.")
 
-    futures = []
+    requests = []
     for idx, prompt in enumerate(prompts):
       request_id = str(next(self._request_counter))
       params = sampling_params
       if idx > 0 and hasattr(sampling_params, "clone"):
         params = sampling_params.clone()
-      future = self._driver.submit_request(
-          request_id=request_id,
-          prompt=prompt,
-          params=params,
-      )
-      futures.append(future)
+      requests.append({
+          "request_id": request_id,
+          "prompt": prompt,
+          "params": params,
+      })
+
+    futures = self._driver.submit_requests(requests)
 
     outputs: List[RequestOutput] = []
     for future in futures:
@@ -444,7 +449,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           f"{self.args['max_model_len']}."
       )
     if beam_size is not None:
-      self.sampling_params = BeamSearchParams(
+      sampling_params = BeamSearchParams(
           beam_width=beam_size,
           max_tokens=max_generation_steps,
           ignore_eos=False,
@@ -514,16 +519,14 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
               f" {sampling_kwargs}. Error: {e}",
           )
 
-      self.sampling_params = sampling_params
-
     prompt_ids = [self.tokenize(x) for x in input_strings]
     prompt_objects = [TokensPrompt(prompt_token_ids=ids) for ids in prompt_ids]
     if self._driver is not None:
-      outputs = self._generate_server_mode(prompt_objects, self.sampling_params)
+      outputs = self._generate_server_mode(prompt_objects, sampling_params)
     else:
       outputs = self.llm.generate(
           prompts=prompt_objects,
-          sampling_params=self.sampling_params,
+          sampling_params=sampling_params,
           use_tqdm=True,
       )
     decoded_outputs, out_logprobs, out_tokens = self.detokenize(

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -121,6 +121,16 @@ class RolloutConfig:
   # Whether to run rollout in vLLM server mode or batch inference mode.
   rollout_vllm_server_mode: bool = False
 
+  # Only drain the vLLM server-mode submission queue once at least this many
+  # requests have accumulated. 0 disables the threshold.
+  rollout_vllm_server_mode_submission_threshold: int = 0
+
+  # Flush the vLLM server-mode submission queue after this many seconds have
+  # elapsed since the first request of the current window arrived, even if the
+  # submission threshold has not been reached. This bounds latency when fewer
+  # than the threshold accumulate. 0 disables the timeout.
+  rollout_vllm_server_mode_submission_timeout_s: float = 0.0
+
   # Model version for vLLM rollout engine.
   rollout_vllm_model_version: str = ""
 

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -44,6 +44,12 @@ class VllmRollout(base_rollout.BaseRollout):
         tokenizer=tokenizer,
         config=vllm_sampler.VllmConfig(
             server_mode=rollout_config.rollout_vllm_server_mode,
+            server_mode_submission_threshold=(
+              rollout_config.rollout_vllm_server_mode_submission_threshold
+            ),
+            server_mode_submission_timeout_s=(
+              rollout_config.rollout_vllm_server_mode_submission_timeout_s
+            ),
             mapping_config=mapping_config,
             return_logprobs=rollout_config.return_logprobs,
             init_with_random_weights=rollout_config.rollout_vllm_init_with_random_weights,


### PR DESCRIPTION
In agentic mode, the rollout requests are send out one at a time, separately. The current vLLM integration sends these requests one by one, which are not very efficient. This PR batches these request based on rollout_vllm_server_mode_submission_threshold, then submit these requests in one shot. This optimization makes sure vLLM sees these requests together and schedules in the most optimized way. rollout_vllm_server_mode_submission_timeout_s is also added just to make sure the vllm drive will not stuck if the accumulated requests doesn't reach the submission threshold, e.g. in off policy mode.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
