### PR TITLE
Guard duplicate-key check and write in safetensors loader with a lock

### DIFF
--- a/tests/models/safetensors_loader_test.py
+++ b/tests/models/safetensors_loader_test.py
@@ -168,6 +168,45 @@ class SafetensorsLoaderTest(parameterized.TestCase):
         loaded_state,
     )
 
+  def test_load_and_create_model_raises_on_duplicate_key(self):
+    # Two distinct source keys that both map to the same jax key. In the
+    # 'original' loader these are processed on separate threads, so without a
+    # lock around the duplicate-key check and write the second write can
+    # silently overwrite the first (issue #1259). With the lock the duplicate
+    # is always detected.
+    try:
+      st_dir = self.create_tempdir().full_path
+    except Exception:  # pylint: disable=broad-except
+      st_dir = tempfile.TemporaryDirectory().name
+      os.makedirs(st_dir, exist_ok=True)
+
+    tensors = {
+        'lm_head.kernel': np.zeros((2, 2), dtype=np.float32),
+        'lm_head.weight': np.zeros((2, 2), dtype=np.float32),
+    }
+    filename = os.path.join(st_dir, 'model.safetensors')
+    stnp.save_file(tensors, filename)
+
+    def duplicate_key_mapping(config):
+      del config
+      return {
+          r'^lm_head\.kernel$': ('lm_head.kernel', None),
+          r'^lm_head\.weight$': ('lm_head.kernel', None),
+      }
+
+    # The duplicate ValueError is re-raised wrapped as RuntimeError by the
+    # loader, so match on RuntimeError. mode='original' is required because the
+    # default optimized path is single-threaded and does not run this check.
+    with self.assertRaisesRegex(RuntimeError, 'Duplicate key'):
+      safetensors_loader.load_and_create_model(
+          st_dir,
+          test_common.ToyTransformer,
+          self.model.config,
+          duplicate_key_mapping,
+          dtype=jnp.float32,
+          mode='original',
+      )
+
 
 if __name__ == '__main__':
   absltest.main()

--- a/tunix/models/safetensors_loader.py
+++ b/tunix/models/safetensors_loader.py
@@ -194,6 +194,7 @@ def load_and_create_model_orig(
   key_map = key_mapping(config)
 
   file_lock = threading.Lock()
+  dict_lock = threading.Lock()  # guards the duplicate-key check and write
 
   # Load tensors from all files
   skipped_keys = []
@@ -225,11 +226,12 @@ def load_and_create_model_orig(
           if dtype and current_arr.dtype != dtype:
             current_arr = current_arr.astype(dtype)
 
-          if jax_key_mapped in file_loaded_tensors:
-            raise ValueError(
-                f'Duplicate key {jax_key_mapped} found within file {f.name}.'
-            )
-          file_loaded_tensors[jax_key_mapped] = current_arr
+          with dict_lock:
+            if jax_key_mapped in file_loaded_tensors:
+              raise ValueError(
+                  f'Duplicate key {jax_key_mapped} found within file {f.name}.'
+              )
+            file_loaded_tensors[jax_key_mapped] = current_arr
 
         except Exception as e:
           raise RuntimeError(


### PR DESCRIPTION
Resolves #1259

This fixes a TOCTOU race in `load_and_create_model_orig`
(`tunix/models/safetensors_loader.py`). `process_key` runs across a
`ThreadPoolExecutor(max_workers=os.cpu_count())`, but the duplicate-key check
`if jax_key_mapped in file_loaded_tensors` and the following write were not
protected by a lock. Two threads whose source keys map to the same jax key can
both pass the check before either writes, so the second silently overwrites the
first and the intended `ValueError` never fires. The model then loads with
incorrect weights and no error.

The fix adds a `dict_lock` and wraps only the check and write in it. The tensor
read, transform, and dtype cast stay outside the lock, so loading remains
parallel with no meaningful speed impact.

**Reference**
- Issue: #1259

**Colab Notebook**
N/A. This is a bug fix to existing loading code and adds no new API.

**Checklist**
- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).