### PR TITLE
Fix example max_steps calculations

### DIFF
--- a/examples/rl/grpo/gsm8k/run_gemma2_2b.sh
+++ b/examples/rl/grpo/gsm8k/run_gemma2_2b.sh
@@ -34,7 +34,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 
@@ -67,4 +67,3 @@ python3 -m tunix.cli.grpo_main \
   rollout_config.total_generation_steps=$total_generation_steps \
   rollout_config.max_prompt_length=$max_prompt_length \
   "$@"
-

--- a/examples/rl/grpo/gsm8k/run_gemma3_12b.sh
+++ b/examples/rl/grpo/gsm8k/run_gemma3_12b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 

--- a/examples/rl/grpo/gsm8k/run_gemma3_1b.sh
+++ b/examples/rl/grpo/gsm8k/run_gemma3_1b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 
@@ -55,4 +55,3 @@ python3 -m tunix.cli.grpo_main \
   rl_training_config.max_steps=$max_steps \
   rl_training_config.metrics_logging_options.log_dir="/tmp/tensorboard/grpo_gemma3_1b" \
   "$@"
-

--- a/examples/rl/grpo/gsm8k/run_gemma3_4b.sh
+++ b/examples/rl/grpo/gsm8k/run_gemma3_4b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 
@@ -55,4 +55,3 @@ python3 -m tunix.cli.grpo_main \
   rl_training_config.max_steps=$max_steps \
   rl_training_config.metrics_logging_options.log_dir="/tmp/tensorboard/grpo_gemma3_4b" \
   "$@"
-

--- a/examples/rl/grpo/gsm8k/run_llama3.2_1b.sh
+++ b/examples/rl/grpo/gsm8k/run_llama3.2_1b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 

--- a/examples/rl/grpo/gsm8k/run_qwen3_simplereward.sh
+++ b/examples/rl/grpo/gsm8k/run_qwen3_simplereward.sh
@@ -30,7 +30,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 max_steps=$(printf "%.0f" "$max_steps_float")
 warmup_steps=$(awk "BEGIN {printf \"%.0f\", $warmup_ratio * $max_steps}")
 
@@ -99,4 +99,3 @@ python3 -m tunix.cli.grpo_main \
   grpo_config.epsilon=0.2 \
   reward_functions="['tunix/cli/reward_fn/simple_math.py']" \
   "$@"
-

--- a/examples/rl/grpo/gsm8k/verl_compatible/run_llama3.2_1b.sh
+++ b/examples/rl/grpo/gsm8k/verl_compatible/run_llama3.2_1b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 

--- a/examples/sft/mtnt/run_gemma3_4b.sh
+++ b/examples/sft/mtnt/run_gemma3_4b.sh
@@ -28,7 +28,7 @@ echo "  Num Epochs: $num_train_epochs"
 echo "  Warmup Ratio: $warmup_ratio"
 echo "  Train Fraction: $train_fraction"
 
-max_steps_float=$(awk "BEGIN {print $batch_size * $num_batches * $num_train_epochs * $train_fraction}")
+max_steps_float=$(awk "BEGIN {print $num_batches * $num_train_epochs * $train_fraction}")
 
 max_steps=$(printf "%.0f" "$max_steps_float")
 
@@ -55,4 +55,3 @@ python3 -m tunix.cli.grpo_main \
   rl_training_config.max_steps=$max_steps \
   rl_training_config.metrics_logging_options.log_dir="/tmp/tensorboard/grpo_gemma3_4b" \
   "$@"
-


### PR DESCRIPTION
## What changed
This updates the example launch scripts that were computing `max_steps` as `batch_size * num_batches * num_train_epochs * train_fraction`.

Those scripts now compute `max_steps` from `num_batches * num_train_epochs * train_fraction`, which matches the CLI's step-based semantics. Since `warmup_steps` and `decay_steps` are derived from `max_steps` in these scripts, they now stay aligned as well.

## Why
`tunix.cli.grpo_main` treats `max_steps` as optimizer/training steps and caps it against `num_batches * num_train_epochs * train_fraction`.

A handful of example scripts were multiplying by `batch_size`, which effectively turned the value into a sample count. That could overrun training by `batch_size`x and skew warmup/decay schedules relative to the actual number of optimizer steps.

## Impact
The affected examples now match the repo's documented and implemented `max_steps` behavior.

## Validation
- `rg -n '\$batch_size \* \$num_batches \* \$num_train_epochs \* \$train_fraction' . -g '*.sh'`
- `bash -n` on the 8 updated scripts
- `git diff --check`
