### PR TITLE
Fix beam search test helper indexing

### DIFF
--- a/tests/generate/beam_search_test.py
+++ b/tests/generate/beam_search_test.py
@@ -18,15 +18,31 @@ class BeamSearchTest(absltest.TestCase):
   def _check_content_equal_per_beam(
       self, beam_content: jnp.ndarray, original_content: jnp.ndarray
   ) -> None:
+    batch_size = original_content.shape[0]
     self.assertEqual(
-        beam_content.shape[0], original_content.shape[0] * self.beam_size
+        beam_content.shape[0], batch_size * self.beam_size
     )
     if len(original_content.shape) > 1:
       self.assertEqual(beam_content.shape[1:], original_content.shape[1:])
-      for i in range(0, self.batch_size * self.beam_size, self.beam_size):
+    for batch_idx in range(batch_size):
+      for beam_idx in range(self.beam_size):
         self.assertTrue(
-            jnp.allclose(beam_content[i * self.beam_size], original_content[i])
+            jnp.allclose(
+                beam_content[batch_idx * self.beam_size + beam_idx],
+                original_content[batch_idx],
+            )
         )
+
+  def test_check_content_equal_per_beam(self) -> None:
+    original_token_buffer = jnp.array([[1, 2], [3, 4]])
+    beam_token_buffer = jnp.repeat(
+        original_token_buffer, self.beam_size, axis=0
+    )
+    self._check_content_equal_per_beam(beam_token_buffer, original_token_buffer)
+
+    original_done = jnp.array([False, True])
+    beam_done = jnp.repeat(original_done, self.beam_size, axis=0)
+    self._check_content_equal_per_beam(beam_done, original_done)
 
   def test_initialization(self) -> None:
     cache = sampler_lib._init_cache(


### PR DESCRIPTION
## What changed
This fixes `_check_content_equal_per_beam()` in `tests/generate/beam_search_test.py` so it iterates by `batch_idx` and `beam_idx` when comparing replicated beam content back to the original batch entries.

It also adds a focused regression test that exercises both 2D beam-expanded content and 1D beam-expanded flags.

## Why
The helper previously stepped `i` by `beam_size` and then indexed `beam_content[i * beam_size]` and `original_content[i]`.

With `batch_size=2` and `beam_size=2`, the second loop iteration reached `beam_content[4]` and `original_content[2]`, which are both out of bounds.

## Impact
The beam search tests now validate per-batch/per-beam replication correctly, and the regression test covers the path that used to go out of bounds.

## Validation
- `uv run --extra test python tests/generate/beam_search_test.py`
