### PR TITLE
Fix degenerate group masking for multi-group batching in GRPO learner

### DIFF
--- a/tests/rl/agentic/agentic_grpo_learner_test.py
+++ b/tests/rl/agentic/agentic_grpo_learner_test.py
@@ -996,6 +996,95 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
       [res_group4] = learner._process_results(group4)
       self.assertTrue(jnp.any(res_group4.old_per_token_logps == 0.0))
 
+  def test_process_results_masks_zero_advantage_multi_group(self):
+    class MockTraj:
+
+      def __init__(self, index, group_id, reward):
+        self.traj = {
+            "conversation_text": [
+                {"role": "user", "content": "user query"},
+                {"role": "assistant", "content": f"msg {index}"},
+            ],
+            "conversation_tokens": np.array([1, 2, 3]),
+            "conversation_masks": np.array([1, 1, 1]),
+            "old_logprobs": None,
+            "policy_version": 0,
+            "trajectory_reward": reward,
+            "prompt_tokens": np.array([4, 5]),
+            "original_input": {"prompts": "hello"},
+            "group_id": group_id,
+        }
+
+    # Group 1: non-degenerate (different rewards)
+    group1 = [MockTraj(0, "group1", -1.0), MockTraj(1, "group1", 1.0)]
+    # Group 2: degenerate (same rewards)
+    group2 = [MockTraj(2, "group2", 0.0), MockTraj(3, "group2", 0.0)]
+    combined_groups = group1 + group2
+
+    vocab = _mock_vocab()
+    tokenizer = tokenizer_adapter.TokenizerAdapter(vocab)
+    model = test_common.ToyTransformer(
+        config=test_common.ModelConfig(vocab_size=vocab.GetPieceSize()),
+        rngs=nnx.Rngs(0),
+    )
+    ref_model = test_common.ToyTransformer(
+        config=test_common.ModelConfig(vocab_size=vocab.GetPieceSize()),
+        rngs=nnx.Rngs(0),
+    )
+    mesh = pxla.thread_resources.env.physical_mesh
+    cluster_config = rl_cluster_lib.ClusterConfig(
+        role_to_mesh={
+            rl_cluster_lib.Role.ACTOR: mesh,
+            rl_cluster_lib.Role.REFERENCE: mesh,
+            rl_cluster_lib.Role.ROLLOUT: mesh,
+        },
+        rollout_engine="vanilla",
+        offload_to_cpu=False,
+        training_config=rl_cluster_lib.RLTrainingConfig(
+            actor_optimizer=optax.sgd(1e-3),
+            eval_every_n_steps=100,
+        ),
+        rollout_config=base_rollout.RolloutConfig(
+            max_prompt_length=32,
+            max_tokens_to_generate=10,
+            return_logprobs=True,
+        ),
+    )
+    rl_cluster = rl_cluster_lib.RLCluster(
+        actor=model,
+        reference=ref_model,
+        tokenizer=tokenizer,
+        cluster_config=cluster_config,
+    )
+    grpo_config = agentic_grpo_learner.GRPOConfig(
+        beta=0.1,
+        epsilon=0.2,
+        num_generations=2,
+        loss_algo="grpo",
+        degenerate_group_masking=True,
+        max_response_length=10,
+    )
+
+    learner = agentic_grpo_learner.GRPOLearner(
+        rl_cluster=rl_cluster,
+        reward_fns=None,
+        algo_config=grpo_config,
+        chat_parser=MockChatParser(),
+    )
+
+    with mock.patch.object(
+        learner.rl_cluster,
+        "get_ref_per_token_logps",
+        return_value=jnp.zeros((4, 10)),
+        autospec=True,
+    ) as mock_get_ref:
+      [res] = learner._process_results(combined_groups)
+
+      # Group 1 should remain intact
+      self.assertTrue(jnp.any(res.completion_mask[:2] > 0))
+      # Group 2 should be masked out
+      self.assertFalse(jnp.any(res.completion_mask[2:] > 0))
+
   def test_checkpointing(self):
     ckpt_dir = tempfile.mkdtemp()
     self.addCleanup(shutil.rmtree, ckpt_dir)

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -557,11 +557,32 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     logging.debug("Advantages computed: %s", advantages)
 
     if self.algo_config.degenerate_group_masking:
-      if jnp.all(jnp.isclose(advantages, 0.0)):
-        logging.info(
-            "Filtering degenerate group %s with all-0 advantages.", group_id
+      advantages_np = np.asarray(advantages)
+      advantages_grouped = advantages_np.reshape(-1, self.algo_config.num_generations)
+      is_degenerate = np.all(np.isclose(advantages_grouped, 0.0), axis=-1)
+      if np.any(is_degenerate):
+        group_ids = []
+        for i in range(advantages_grouped.shape[0]):
+          idx = i * self.algo_config.num_generations
+          g_id = trajectories[idx].traj.get("group_id")
+          if g_id is None:
+            g_id = trajectories[idx].traj.get("original_input", {}).get("group_id")
+          group_ids.append(g_id)
+
+        for i, degenerate in enumerate(is_degenerate):
+          if degenerate:
+            logging.info(
+                "Filtering degenerate group %s with all-0 advantages.",
+                group_ids[i],
+            )
+
+        is_degenerate_expanded = np.repeat(is_degenerate, self.algo_config.num_generations)
+        is_degenerate_expanded_jax = jnp.asarray(is_degenerate_expanded)
+        completion_mask = jnp.where(
+            is_degenerate_expanded_jax[:, None],
+            jnp.zeros_like(completion_mask),
+            completion_mask,
         )
-        completion_mask = jnp.zeros_like(completion_mask)
 
     policy_versions = np.array(policy_versions_list, dtype=np.int32)
 


### PR DESCRIPTION
Fixes a bug where degenerate group masking was applied incorrectly to multi-group batches (e.g. when process_in_consumer=True), resulting in either no masking or incorrectly masking out the entire batch. Adds a unit test for cases where the input contain multiple groups.

**Problem**

See also: https://b.corp.google.com/issues/529897561

When process_in_consumer is enabled, the GRPO learner's _process_results method receives a concatenated batch containing trajectories from multiple generation groups.

The previous degenerate group masking implementation:

1. Checked for degeneracy across the entire batch at once via jnp.all(jnp.isclose(advantages, 0.0)). This meant groups were only masked if all groups in the entire batch had all-0 advantages.
2. When triggered, it masked out the entire batch using completion_mask = jnp.zeros_like(completion_mask) instead of masking only the specific degenerate group.

The correct implementation should check and apply masking at group level.

**Solution**

1. Reshaped advantages to [num_groups, num_generations] to evaluate each group's degeneracy independently.
2. Replaced jnp.all checking with a per-group check on the reshaped advantages.
3. Created a boolean mask that is expanded/repeated num_generations times to selectively mask only the sequences corresponding to degenerate groups inside completion_mask.
4. Group IDs for any filtered degenerate groups are logged individually.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
