### PR TITLE
Fix garbage collection of pending cancellation_task in AgenticRLLearner

### DIFF
--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -228,6 +228,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     self.tokenizer = rl_cluster.tokenizer
     self.policy_version = self.rl_cluster.global_steps
     self._rollout_sync_lock = agentic_utils.RolloutSyncLock()
+    self._background_tasks: Set[asyncio.Task] = set()
     self._full_batch_size = 0
     self._process_in_consumer: bool = False
 
@@ -575,7 +576,8 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             await producer_task
 
         cancellation_task = asyncio.create_task(await_cancellation())
-        del cancellation_task
+        self._background_tasks.add(cancellation_task)
+        cancellation_task.add_done_callback(self._background_tasks.discard)
 
   def _batch_to_train_example(
       self,


### PR DESCRIPTION
Resolves: https://b.corp.google.com/issues/529908041

**Problem**

In AgenticRLLearner._orchestrator_producer, the background task cancellation is scheduled using a temporary coroutine:

```
cancellation_task = asyncio.create_task(await_cancellation())
del cancellation_task
```

Using del cancellation_task immediately discards the local strong reference to the task. Since the asyncio event loop only holds a weak reference, the Python garbage collector can reclaim the task before await_cancellation() completes. When garbage collection happens mid-execution, it aborts the task and can leave the background producer_task dangling or raise RuntimeError warnings.

**Solution**

Store a strong reference to cancellation_task in a class-level set self._background_tasks during its execution:

1. Defined self._background_tasks: Set[asyncio.Task] = set() in __init__.
2. Added cancellation_task to the set upon creation, registering a callback to discard the reference via add_done_callback(self._background_tasks.discard) once it is finished.

This preserves the original non-blocking design of the generator's finally block while guaranteeing the cancellation task completes safely.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
