### PR TITLE
Update the gemma4 weight mapping to latest tpu_inference model weight pytree

### DIFF
--- a/tests/generate/utils_test.py
+++ b/tests/generate/utils_test.py
@@ -464,14 +464,21 @@ class UtilsTest(parameterized.TestCase):
     )
 
   def test_transfer_state_with_mappings_gemma4(self):
-    """Test transfer_state_with_mappings for Gemma4."""
+    """Test transfer_state_with_mappings for Gemma4 (fused qkv/gate_up)."""
     from tunix.models.gemma4.mapping_vllm_jax import VLLM_JAX_MAPPING
 
-    # Mock source state (Tunix style)
+    # Mock source state (Tunix style): q_einsum (N=4, D=16, H=8) and
+    # kv_einsum (2, K=2, D=16, H=8) fuse into qkv_proj; gate_proj/up_proj
+    # (D=16, F=32) fuse into gate_up_proj.
+    q_val = jnp.arange(4 * 16 * 8, dtype=jnp.float32).reshape(4, 16, 8)
+    kv_val = jnp.arange(2 * 2 * 16 * 8, dtype=jnp.float32).reshape(2, 2, 16, 8)
+    gate_val = jnp.arange(16 * 32, dtype=jnp.float32).reshape(16, 32)
+    up_val = jnp.arange(16 * 32, dtype=jnp.float32).reshape(16, 32) + 1000.0
     src_params = {
-        "layers.0.attn.kv_einsum.w": MockParam(
-            jnp.arange(2 * 2 * 16 * 8, dtype=jnp.float32).reshape(2, 2, 16, 8)
-        ),
+        "layers.0.attn.q_einsum.w": MockParam(q_val),
+        "layers.0.attn.kv_einsum.w": MockParam(kv_val),
+        "layers.0.mlp.gate_proj.kernel": MockParam(gate_val),
+        "layers.0.mlp.up_proj.kernel": MockParam(up_val),
         "layers.0.moe.gating_einsum": MockParam(
             jnp.arange(4 * 2 * 8 * 16, dtype=jnp.float32).reshape(4, 2, 8, 16)
         ),
@@ -481,13 +488,15 @@ class UtilsTest(parameterized.TestCase):
     }
     src_state = MockState(src_params)
 
-    # Mock destination state (vLLM Jax backend style)
+    # Mock destination state (vLLM Jax backend style). qkv_proj fuses Q
+    # (4*8=32), K (2*8=16) and V (2*8=16) into a single (16, 64) kernel;
+    # gate_up_proj fuses gate/up (32 each) into a (16, 64) kernel.
     dst_params = {
-        "model.layers.0.self_attn.k_proj.weight": MockParam(
-            jnp.zeros((16, 2, 8), dtype=jnp.float32)
+        "model.layers.0.self_attn.qkv_proj.weight": MockParam(
+            jnp.zeros((16, 64), dtype=jnp.float32)
         ),
-        "model.layers.0.self_attn.v_proj.weight": MockParam(
-            jnp.zeros((16, 2, 8), dtype=jnp.float32)
+        "model.layers.0.mlp.gate_up_proj.weight": MockParam(
+            jnp.zeros((16, 64), dtype=jnp.float32)
         ),
         "model.layers.0.experts.kernel_gating_upproj_EDF": MockParam(
             jnp.zeros((4, 2, 8, 16), dtype=jnp.float32)
@@ -498,9 +507,9 @@ class UtilsTest(parameterized.TestCase):
     }
     dst_state = MockState(dst_params)
 
-    # Apply preprocessing if it exists in mapping
+    # Apply preprocessing (fuses q_einsum+kv_einsum and gate_proj+up_proj).
     if 'preprocess_src_state' in VLLM_JAX_MAPPING:
-      src_state = VLLM_JAX_MAPPING['preprocess_src_state'](src_state)
+      src_state = VLLM_JAX_MAPPING['preprocess_src_state'](src_state, tp_size=1)
 
     key_mappings = VLLM_JAX_MAPPING['to_hf_mappings']
     transpose_keys = VLLM_JAX_MAPPING['to_hf_transpose_keys']
@@ -513,23 +522,23 @@ class UtilsTest(parameterized.TestCase):
     )
 
     # Assertions
-    src_val = jnp.arange(2 * 2 * 16 * 8, dtype=jnp.float32).reshape(2, 2, 16, 8)
-    k_val_src = src_val[0]
-    v_val_src = src_val[1]
-
-    expected_k = jnp.transpose(k_val_src, (1, 0, 2))
-    expected_v = jnp.transpose(v_val_src, (1, 0, 2))
+    expected_q = jnp.transpose(q_val, (1, 0, 2)).reshape(16, -1)
+    expected_k = jnp.transpose(kv_val[0], (1, 0, 2)).reshape(16, -1)
+    expected_v = jnp.transpose(kv_val[1], (1, 0, 2)).reshape(16, -1)
+    expected_qkv = jnp.concatenate([expected_q, expected_k, expected_v], axis=-1)
 
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["model.layers.0.self_attn.k_proj.weight"],
-            expected_k,
+            new_tgt_state.params["model.layers.0.self_attn.qkv_proj.weight"],
+            expected_qkv,
         )
     )
+
+    expected_gate_up = jnp.concatenate([gate_val, up_val], axis=-1)
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["model.layers.0.self_attn.v_proj.weight"],
-            expected_v,
+            new_tgt_state.params["model.layers.0.mlp.gate_up_proj.weight"],
+            expected_gate_up,
         )
     )
 
@@ -544,6 +553,99 @@ class UtilsTest(parameterized.TestCase):
         jnp.array_equal(
             new_tgt_state.params["model.layers.0.experts.kernel_down_proj_EFD"],
             src_params["layers.0.moe.linear"].value,
+        )
+    )
+
+  def test_preprocess_src_state_gemma4_tp_interleaving(self):
+    """qkv_fused/gate_up_fused are TP-interleaved by preprocess_src_state."""
+    from tunix.models.gemma4.mapping_vllm_jax import VLLM_JAX_MAPPING
+
+    q_val = jnp.arange(4 * 16 * 8, dtype=jnp.float32).reshape(4, 16, 8)
+    kv_val = jnp.arange(2 * 2 * 16 * 8, dtype=jnp.float32).reshape(2, 2, 16, 8)
+    gate_val = jnp.arange(16 * 32, dtype=jnp.float32).reshape(16, 32)
+    up_val = jnp.arange(16 * 32, dtype=jnp.float32).reshape(16, 32) + 1000.0
+    src_state = MockState({
+        "layers.0.attn.q_einsum.w": MockParam(q_val),
+        "layers.0.attn.kv_einsum.w": MockParam(kv_val),
+        "layers.0.mlp.gate_proj.kernel": MockParam(gate_val),
+        "layers.0.mlp.up_proj.kernel": MockParam(up_val),
+    })
+
+    preprocess_fn = VLLM_JAX_MAPPING['preprocess_src_state']
+    fused_state = preprocess_fn(src_state, tp_size=4)
+
+    expected_q = jnp.transpose(q_val, (1, 0, 2)).reshape(16, -1)
+    expected_k = jnp.transpose(kv_val[0], (1, 0, 2)).reshape(16, -1)
+    expected_v = jnp.transpose(kv_val[1], (1, 0, 2)).reshape(16, -1)
+    # Shard 0 (of 4) should hold [Q_shard0, K_shard0, V_shard0] contiguous.
+    q_chunk = expected_q.shape[-1] // 4
+    k_chunk = expected_k.shape[-1] // 4
+    v_chunk = expected_v.shape[-1] // 4
+    shard0 = jnp.concatenate(
+        [expected_q[:, :q_chunk], expected_k[:, :k_chunk], expected_v[:, :v_chunk]],
+        axis=-1,
+    )
+
+    actual_qkv = fused_state.params["layers.0.attn.qkv_fused.w"].value
+    self.assertEqual(actual_qkv.shape, (16, 64))
+    self.assertTrue(jnp.array_equal(actual_qkv[:, : shard0.shape[-1]], shard0))
+
+    gate_chunk = gate_val.shape[-1] // 4
+    up_chunk = up_val.shape[-1] // 4
+    shard0_gate_up = jnp.concatenate(
+        [gate_val[:, :gate_chunk], up_val[:, :up_chunk]], axis=-1
+    )
+    actual_gate_up = fused_state.params["layers.0.mlp.gate_up_fused.kernel"].value
+    self.assertEqual(actual_gate_up.shape, (16, 64))
+    self.assertTrue(
+        jnp.array_equal(
+            actual_gate_up[:, : shard0_gate_up.shape[-1]], shard0_gate_up
+        )
+    )
+
+  def test_transfer_state_with_mappings_gemma4_k_eq_v_unfused(self):
+    """GLOBAL layers with k_eq_v keep separate (unfused) q_proj/k_proj."""
+    from tunix.models.gemma4.mapping_vllm_jax import VLLM_JAX_MAPPING
+
+    q_val = jnp.arange(4 * 16 * 8, dtype=jnp.float32).reshape(4, 16, 8)
+    k_val = jnp.arange(2 * 16 * 8, dtype=jnp.float32).reshape(2, 16, 8) + 500.0
+    src_state = MockState({
+        "layers.0.attn.q_einsum.w": MockParam(q_val),
+        "layers.0.attn.k_einsum.w": MockParam(k_val),
+    })
+    dst_state = MockState({
+        "model.layers.0.self_attn.q_proj.weight": MockParam(
+            jnp.zeros((16, 4, 8), dtype=jnp.float32)
+        ),
+        "model.layers.0.self_attn.k_proj.weight": MockParam(
+            jnp.zeros((16, 2, 8), dtype=jnp.float32)
+        ),
+    })
+
+    key_mappings = VLLM_JAX_MAPPING['to_hf_mappings']
+    transpose_keys = VLLM_JAX_MAPPING['to_hf_transpose_keys']
+    preprocess_fn = VLLM_JAX_MAPPING['preprocess_src_state']
+
+    # No kv_einsum present, so preprocessing leaves q_einsum/k_einsum as-is.
+    src_state = preprocess_fn(src_state, tp_size=1)
+
+    new_tgt_state = utils.transfer_state_with_mappings(
+        src_state,
+        dst_state,
+        key_mappings=key_mappings,
+        transpose_keys=transpose_keys,
+    )
+
+    self.assertTrue(
+        jnp.array_equal(
+            new_tgt_state.params["model.layers.0.self_attn.q_proj.weight"],
+            jnp.transpose(q_val, (1, 0, 2)),
+        )
+    )
+    self.assertTrue(
+        jnp.array_equal(
+            new_tgt_state.params["model.layers.0.self_attn.k_proj.weight"],
+            jnp.transpose(k_val, (1, 0, 2)),
         )
     )
 

--- a/tunix/generate/mappings.py
+++ b/tunix/generate/mappings.py
@@ -81,7 +81,7 @@ class MappingConfig:
   to_hf_hook_fns: Optional[Dict[str, Any]] = None
   to_hf_transpose_keys: Optional[Dict[str, Tuple[int, ...]]] = None
   lora_to_hf_transpose_keys: Optional[Dict[str, Tuple[int, ...]]] = None
-  preprocess_src_state: Optional[Callable[[Any], Any]] = None
+  preprocess_src_state: Optional[Callable[..., Any]] = None
 
   @classmethod
   def build(

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -202,7 +202,9 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
     if self.to_hf_key_mappings:
       preprocess_fn = self.config.mapping_config.preprocess_src_state
       if preprocess_fn:
-        updated_weights = preprocess_fn(updated_weights)
+        updated_weights = preprocess_fn(
+            updated_weights, tp_size=self.args.get("tensor_parallel_size", 1)
+        )
 
       utils.transfer_state_with_mappings(
           src_state=updated_weights,

--- a/tunix/models/gemma4/mapping_vllm_jax.py
+++ b/tunix/models/gemma4/mapping_vllm_jax.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Tuple
 from flax import nnx
+import jax
+import jax.numpy as jnp
 
 Sharding = Tuple[str | None, ...]
 MappingEntry = Tuple[str, Sharding]
@@ -29,21 +31,27 @@ TO_HF_MAPPINGS = {
         'model.layers.*.input_layernorm.weight',
         (None,),
     ),
+    # GLOBAL layers with `attention_k_eq_v` keep separate (unfused) Q/K
+    # kernels (no V; V==K); `preprocess_src_state` leaves those layers'
+    # q_einsum/k_einsum untouched, so these two entries only ever match them.
     'layers.*.attn.q_einsum.w': (
         'model.layers.*.self_attn.q_proj.weight',
         (None, 'model', None),
-    ),
-    'layers.*.attn._query_norm.scale': (
-        'model.layers.*.self_attn.q_norm.weight',
-        (None,),
     ),
     'layers.*.attn.k_einsum.w': (
         'model.layers.*.self_attn.k_proj.weight',
         (None, 'model', None),
     ),
-    'layers.*.attn.v_einsum.w': (
-        'model.layers.*.self_attn.v_proj.weight',
-        (None, 'model', None),
+    # Every other layer fuses Q, K, V into a single qkv_proj kernel.
+    # `preprocess_src_state` combines that layer's q_einsum + kv_einsum into
+    # this synthetic, already TP-interleaved `qkv_fused` entry.
+    'layers.*.attn.qkv_fused.w': (
+        'model.layers.*.self_attn.qkv_proj.weight',
+        (None, 'model'),
+    ),
+    'layers.*.attn._query_norm.scale': (
+        'model.layers.*.self_attn.q_norm.weight',
+        (None,),
     ),
     'layers.*.attn._key_norm.scale': (
         'model.layers.*.self_attn.k_norm.weight',
@@ -61,12 +69,11 @@ TO_HF_MAPPINGS = {
         'model.layers.*.pre_feedforward_layernorm.weight',
         (None,),
     ),
-    'layers.*.mlp.gate_proj.kernel': (
-        'model.layers.*.mlp.gate_proj.weight',
-        (None, 'model'),
-    ),
-    'layers.*.mlp.up_proj.kernel': (
-        'model.layers.*.mlp.up_proj.weight',
+    # Gemma4MLP always fuses gate_proj/up_proj into one gate_up_proj kernel;
+    # `preprocess_src_state` combines them into this synthetic,
+    # TP-interleaved `gate_up_fused` entry.
+    'layers.*.mlp.gate_up_fused.kernel': (
+        'model.layers.*.mlp.gate_up_proj.weight',
         (None, 'model'),
     ),
     'layers.*.mlp.down_proj.kernel': (
@@ -145,31 +152,106 @@ LORA_TO_HF_MAPPINGS: Dict[str, MappingEntry] = {}
 TO_HF_TRANSPOSE_KEYS = {
     'layers.*.attn.q_einsum.w': (1, 0, 2),
     'layers.*.attn.k_einsum.w': (1, 0, 2),
-    'layers.*.attn.v_einsum.w': (1, 0, 2),
 }
 
-def preprocess_src_state(src_state: Any) -> Any:
-  if hasattr(src_state, 'flat_state'):
-    flat_state = list(src_state.flat_state())
-    new_flat_state = []
-    for keys, param in flat_state:
-      src_key = '.'.join(str(k) for k in keys)
-      if 'attn.kv_einsum.w' in src_key:
-        val = param.value if hasattr(param, 'value') else param
-        k_val = val[0]
-        v_val = val[1]
-        k_keys = keys[:-2] + ('k_einsum', 'w')
-        v_keys = keys[:-2] + ('v_einsum', 'w')
-        if hasattr(param, 'value'):
-          new_flat_state.append((k_keys, nnx.Param(k_val)))
-          new_flat_state.append((v_keys, nnx.Param(v_val)))
-        else:
-          new_flat_state.append((k_keys, k_val))
-          new_flat_state.append((v_keys, v_val))
-      else:
-        new_flat_state.append((keys, param))
-    src_state = src_state.from_flat_path(new_flat_state)
-  return src_state
+
+def _reorder_for_tp_sharding(concatenated, split_sizes, tp_size):
+  """Reorders parts concatenated on the last axis into a per-shard layout.
+
+  `concatenated` holds `split_sizes` parts back to back on its last axis
+  (`[part0, part1, ...]`). This reorders it so each of the `tp_size` equal
+  contiguous chunks of the last axis holds a slice of every part
+  (`[part0_shard_i, part1_shard_i, ...]`), which is the on-device layout
+  tpu_inference's fused linear layers (`JaxQKVParallelLinear`,
+  `JaxMergedColumnParallelLinear`) expect from their kernel. Mirrors
+  `tpu_inference.layers.common.utils.reorder_concatenated_tensor_for_sharding`.
+  """
+  if tp_size <= 1:
+    return concatenated
+  lead_shape = concatenated.shape[:-1]
+  parts = []
+  offset = 0
+  for size in split_sizes:
+    if size % tp_size != 0:
+      raise ValueError(f'Part size {size} is not divisible by tp_size {tp_size}.')
+    part = jax.lax.slice_in_dim(concatenated, offset, offset + size, axis=-1)
+    parts.append(part.reshape(lead_shape + (tp_size, size // tp_size)))
+    offset += size
+  reordered = jnp.concatenate(parts, axis=-1)
+  return reordered.reshape(lead_shape + (sum(split_sizes),))
+
+
+def preprocess_src_state(src_state: Any, tp_size: int = 1) -> Any:
+  """Fuses Q/K/V and gate/up projections to match tpu_inference's kernels.
+
+  tpu_inference's Gemma4Attention fuses Q, K, V into a single `qkv_proj`
+  kernel on every layer except GLOBAL layers with `attention_k_eq_v` (which
+  keep separate `q_proj`/`k_proj`; V is not materialized, V==K).
+  Gemma4MLP always fuses `gate_proj`/`up_proj` into a single `gate_up_proj`
+  kernel. This combines the corresponding tunix-native params
+  (`q_einsum`+`kv_einsum`, `gate_proj`+`up_proj`) into synthetic
+  `qkv_fused`/`gate_up_fused` entries that TO_HF_MAPPINGS targets 1:1, and
+  TP-interleaves them into the layout the fused kernel expects on-device.
+  """
+  if not hasattr(src_state, 'flat_state'):
+    return src_state
+
+  by_key = {
+      '.'.join(str(k) for k in keys): (keys, param)
+      for keys, param in src_state.flat_state()
+  }
+
+  def value_of(param):
+    return param.value if hasattr(param, 'value') else param
+
+  def wrap_like(param, val):
+    return nnx.Param(val) if hasattr(param, 'value') else val
+
+  consumed = set()
+  fused_entries = []
+
+  for src_key, (keys, param) in by_key.items():
+    if src_key.endswith('attn.kv_einsum.w'):
+      q_key = src_key[: -len('kv_einsum.w')] + 'q_einsum.w'
+      if q_key not in by_key:
+        raise ValueError(f'Missing {q_key} to fuse with {src_key}.')
+      q_val = value_of(by_key[q_key][1])
+      kv_val = value_of(param)
+      k_val, v_val = kv_val[0], kv_val[1]
+      # (N,D,H) -> (D,N,H) -> (D,N*H); same for K/V with num_kv_heads.
+      q_t = jnp.transpose(q_val, (1, 0, 2)).reshape(q_val.shape[1], -1)
+      k_t = jnp.transpose(k_val, (1, 0, 2)).reshape(k_val.shape[1], -1)
+      v_t = jnp.transpose(v_val, (1, 0, 2)).reshape(v_val.shape[1], -1)
+      concatenated = jnp.concatenate([q_t, k_t, v_t], axis=-1)
+      fused_val = _reorder_for_tp_sharding(
+          concatenated, [q_t.shape[-1], k_t.shape[-1], v_t.shape[-1]], tp_size
+      )
+      fused_keys = keys[:-2] + ('qkv_fused', 'w')
+      fused_entries.append((fused_keys, wrap_like(param, fused_val)))
+      consumed.add(src_key)
+      consumed.add(q_key)
+    elif src_key.endswith('mlp.gate_proj.kernel'):
+      up_key = src_key[: -len('gate_proj.kernel')] + 'up_proj.kernel'
+      if up_key not in by_key:
+        raise ValueError(f'Missing {up_key} to fuse with {src_key}.')
+      gate_val = value_of(param)
+      up_val = value_of(by_key[up_key][1])
+      concatenated = jnp.concatenate([gate_val, up_val], axis=-1)
+      fused_val = _reorder_for_tp_sharding(
+          concatenated, [gate_val.shape[-1], up_val.shape[-1]], tp_size
+      )
+      fused_keys = keys[:-2] + ('gate_up_fused', 'kernel')
+      fused_entries.append((fused_keys, wrap_like(param, fused_val)))
+      consumed.add(src_key)
+      consumed.add(up_key)
+
+  new_flat_state = [
+      (keys, param)
+      for src_key, (keys, param) in by_key.items()
+      if src_key not in consumed
+  ] + fused_entries
+
+  return src_state.from_flat_path(new_flat_state)
 
 
 VLLM_JAX_MAPPING: Dict[str, Any] = {


### PR DESCRIPTION
Latest tpu_inference model weight pytree has been updated to fuse gate and up proj, q, k, v proj when k != v. Update the weight mapping rules in tunix accordingly.

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
