### PR TITLE
[Seq Packing] Unified sequence packing: packed logprob + pack-first (agentic GRPO)

### DIFF
--- a/tests/rl/agentic/agentic_grpo_learner_test.py
+++ b/tests/rl/agentic/agentic_grpo_learner_test.py
@@ -661,13 +661,15 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
     policy_loss_fn = function_registry.get_policy_loss_fn(
         algo_config.policy_loss_fn
     )
-    loss, aux = policy_loss_fn(
+    loss_output = policy_loss_fn(
         model=MockModel(rngs=nnx.Rngs(0)),
         train_example=train_example,
         algo_config=algo_config,
         pad_id=0,
         eos_id=2,
     )
+    loss = loss_output.primary_loss.compute()
+    aux = loss_output.aux_metrics
     chex.assert_shape(loss, ())
     self.assertIn("kl", aux)
 
@@ -736,7 +738,7 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
     policy_loss_fn = function_registry.get_policy_loss_fn(config.policy_loss_fn)
 
     model = MockModel(rngs=nnx.Rngs(0))
-    loss, _ = policy_loss_fn(
+    loss_output = policy_loss_fn(
         model=model,
         train_example=train_example,
         algo_config=config,
@@ -765,10 +767,12 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
 
     expected_loss = float(jnp.mean(per_sequence_loss))
 
+    loss = loss_output.primary_loss.compute()
     np.testing.assert_allclose(loss, expected_loss, rtol=1e-6, atol=1e-6)
 
   def test_process_results_extracts_assistant_text(self):
     class MockTraj:
+
       def __init__(self, index):
         self.traj = {
             "conversation_text": [
@@ -789,6 +793,7 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
     trajectories = [MockTraj(0), MockTraj(1)]
 
     extracted_completions = []
+
     def mock_compute_rewards(prompts, completions, **kwargs):
       extracted_completions.extend(completions)
       return jnp.ones(len(completions), dtype=jnp.float32)
@@ -842,7 +847,9 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
         chat_parser=MockChatParser(),
     )
 
-    with mock.patch.object(learner, "_compute_rewards", side_effect=mock_compute_rewards):
+    with mock.patch.object(
+        learner, "_compute_rewards", side_effect=mock_compute_rewards
+    ):
       with mock.patch.object(
           learner.rl_cluster,
           "get_ref_per_token_logps",

--- a/tests/rl/agentic/agentic_rl_learner_test.py
+++ b/tests/rl/agentic/agentic_rl_learner_test.py
@@ -178,8 +178,8 @@ class AgenticRLLearnerTest(parameterized.TestCase):
       train_dataset = [{'prompt': ['p1']}]
       with self.assertRaisesRegex(
           ValueError,
-          r'compute_logps_micro_batch_size \(2\) must be equal to'
-          r' train_micro_batch_size \(1\)',
+          r'full_batch_size=1 must be a multiple of'
+          r' self\._compute_logps_micro_batch_size=2',
       ):
         learner.train(train_dataset)
 

--- a/tests/rl/common_test.py
+++ b/tests/rl/common_test.py
@@ -24,6 +24,10 @@ from tunix.tests import test_common as tc
 jax.config.update("jax_threefry_partitionable", False)
 jax.config.update("jax_default_matmul_precision", "highest")
 
+def _compute_loss(*args, **kwargs):
+  out = getattr(common, "aggregate_loss")(*args, **kwargs)
+  return out.compute()
+
 
 class CommonTest(parameterized.TestCase):
 
@@ -565,7 +569,7 @@ class CommonTest(parameterized.TestCase):
   ):
     per_token_loss = jnp.array(per_token_loss_list)
     completion_mask = jnp.array(completion_mask_list)
-    actual_loss = common.aggregate_loss(
+    actual_loss = _compute_loss(
         per_token_loss, completion_mask, loss_agg_mode, **kwargs
     )
     np.testing.assert_allclose(actual_loss, expected_loss, rtol=1e-6, atol=1e-6)
@@ -574,7 +578,7 @@ class CommonTest(parameterized.TestCase):
     with self.assertRaisesRegex(
         ValueError, "Unsupported loss aggregation mode"
     ):
-      common.aggregate_loss(jnp.ones((2, 2)), jnp.ones((2, 2)), "invalid-mode")
+      _compute_loss(jnp.ones((2, 2)), jnp.ones((2, 2)), "invalid-mode")
 
   @parameterized.named_parameters(
       dict(
@@ -610,7 +614,7 @@ class CommonTest(parameterized.TestCase):
   )
   def test_invalid_norm(self, norm_val, loss_agg_mode):
     with self.assertRaisesRegex(ValueError, "Invalid 'norm' value"):
-      common.aggregate_loss(
+      _compute_loss(
           jnp.ones((2, 2)),
           jnp.ones((2, 2)),
           loss_agg_mode,
@@ -707,7 +711,7 @@ class CommonTest(parameterized.TestCase):
     per_token_loss = jnp.array([1.0, 2.0, 3.0], dtype=jnp.bfloat16)
     completion_mask = jnp.array([1, 1, 0], dtype=jnp.int32)
 
-    loss = common.aggregate_loss(
+    loss = _compute_loss(
         per_token_loss, completion_mask, loss_agg_mode="token-mean"
     )
     self.assertEqual(loss.dtype, jnp.float32)

--- a/tests/rl/grpo/dapo_learner_test.py
+++ b/tests/rl/grpo/dapo_learner_test.py
@@ -90,22 +90,27 @@ class DAPOlearnerTest(parameterized.TestCase):
         rngs=nnx.Rngs(0),
     )
 
-    # Call DAPO loss function (DAPO sets ref_per_token_logps to None as it doesn't fetch it)
+    # Call DAPO loss function (DAPO sets ref_per_token_logps to None as it
+    # doesn't fetch it).
     dapo_train_example = self.create_train_example()
     dapo_train_example.ref_per_token_logps = None
-    dapo_loss, dapo_aux = dapo_loss_fn_impl(
+    dapo_loss_output = dapo_loss_fn_impl(
         model, dapo_train_example, dapo_config, pad_id, eos_id
     )
+    dapo_loss = dapo_loss_output.primary_loss.compute()
+    dapo_aux = dapo_loss_output.aux_metrics
 
     # Call GRPO loss function
-    grpo_loss, grpo_aux = grpo_loss_fn_impl(
+    grpo_loss_output = grpo_loss_fn_impl(
         model, train_example, grpo_config, pad_id, eos_id
     )
+    grpo_loss = grpo_loss_output.primary_loss.compute()
+    grpo_aux = grpo_loss_output.aux_metrics
 
     # Assert that the loss values are different
     self.assertNotEqual(
-        dapo_loss.item(),
-        grpo_loss.item(),
+        dapo_loss,
+        grpo_loss,
         msg=(
             "DAPO and GRPO loss values should be different for the same input"
             " due to different loss aggregation logics."
@@ -114,7 +119,9 @@ class DAPOlearnerTest(parameterized.TestCase):
 
     self.assertIn("kl", dapo_aux)
     self.assertIn("kl", grpo_aux)
-    self.assertEqual(dapo_aux["kl"], 0.0)  # DAPO does not have KL term.
+    self.assertEqual(
+        dapo_aux["kl"].compute(), 0.0
+    )  # DAPO does not have KL term.
 
 
 class TestDAPOConfigPostInit(parameterized.TestCase):

--- a/tests/rl/grpo/drgrpo_learner_test.py
+++ b/tests/rl/grpo/drgrpo_learner_test.py
@@ -126,9 +126,11 @@ class DrGRPOlearnerTest(parameterized.TestCase):
     )
 
     # Call DrGRPO loss function
-    drgrpo_loss, drgrpo_aux = drgrpo_loss_fn_impl(
+    drgrpo_loss_output = drgrpo_loss_fn_impl(
         model, train_example, drgrpo_config, pad_id, eos_id
     )
+    drgrpo_loss = drgrpo_loss_output.primary_loss.compute()
+    drgrpo_aux = drgrpo_loss_output.aux_metrics
 
     self.assertIn("kl", drgrpo_aux)
     self.assertTrue(jnp.isfinite(drgrpo_loss).all())

--- a/tests/rl/rl_utils_test.py
+++ b/tests/rl/rl_utils_test.py
@@ -15,6 +15,7 @@
 import os
 from absl.testing import absltest
 import chex
+import flax
 from flax import nnx
 import jax
 from jax import sharding
@@ -175,28 +176,174 @@ class UtilsTest(absltest.TestCase):
     with self.assertRaisesRegex(ValueError, 'memory_kind must be one of'):
       utils.put_params_on_memory_kind(params, 'invalid_kind')
 
+  def _create_mock_train_example(
+      self,
+      prompt_len: int,
+      completion_len: int,
+      pad_len: int = 0,
+      cls=common.TrainExample,
+      **kwargs
+  ) -> common.TrainExample:
+    p_ids = jnp.concatenate(
+        [
+            jnp.zeros((1, pad_len), dtype=jnp.int32),
+            jnp.ones((1, prompt_len), dtype=jnp.int32),
+        ],
+        axis=1,
+    )
+    p_mask = jnp.concatenate(
+        [
+            jnp.zeros((1, pad_len), dtype=jnp.int32),
+            jnp.ones((1, prompt_len), dtype=jnp.int32),
+        ],
+        axis=1,
+    )
+
+    c_ids = jnp.concatenate(
+        [
+            jnp.ones((1, completion_len), dtype=jnp.int32) * 2,
+            jnp.zeros((1, pad_len), dtype=jnp.int32),
+        ],
+        axis=1,
+    )
+    c_mask = jnp.concatenate(
+        [
+            jnp.ones((1, completion_len), dtype=jnp.int32),
+            jnp.zeros((1, pad_len), dtype=jnp.int32),
+        ],
+        axis=1,
+    )
+
+    base_kwargs = dict(
+        prompt_ids=p_ids,
+        prompt_mask=p_mask,
+        completion_ids=c_ids,
+        completion_mask=c_mask,
+        advantages=jnp.array([1.5], dtype=jnp.float32),
+        ref_per_token_logps=None,
+        old_per_token_logps=None,
+        segment_ids=None,
+        segment_positions=None,
+    )
+    base_kwargs.update(kwargs)
+    return cls(**base_kwargs)
+
+  def test_unpad_train_example(self):
+    example = self._create_mock_train_example(2, 3, pad_len=2)
+    unpadded = utils.unpad_train_example(example)
+    self.assertLen(unpadded, 1)
+    [item] = unpadded
+    self.assertEqual(item['prompt_ids'].shape, (2,))
+    self.assertEqual(item['completion_ids'].shape, (3,))
+    self.assertFalse(item['adv_is_per_token'])
+
+  def test_pack_sequences_skips_large(self):
+    # A sequence larger than budget should be skipped.
+    example1 = self._create_mock_train_example(5, 6)  # size 11
+    example2 = self._create_mock_train_example(2, 3)  # size 5
+    packed_iterator = utils.pack_sequences(
+        iter([[example1, example2]]), max_token_budget=10
+    )
+    packed_batches = list(packed_iterator)
+    self.assertLen(packed_batches, 1)
+    self.assertEqual(packed_batches[0][0].segment_ids.shape, (1, 10))
+    # Check that only example2 was packed (length 5)
+    self.assertEqual(np.max(packed_batches[0][0].segment_ids), 1)
+
+  def test_pack_sequences_with_dummy_padding(self):
+
+    @flax.struct.dataclass(frozen=True)
+    class PPOTrainExample(common.TrainExample):
+      returns: jax.Array | None = None
+      old_values: jax.Array | None = None
+      policy_version: jax.Array | None = None
+
+    example = self._create_mock_train_example(
+        2,
+        3,
+        cls=PPOTrainExample,
+        ref_per_token_logps=jnp.ones((1, 3)),
+        returns=jnp.ones((1, 3)),
+        old_values=jnp.ones((1, 3)),
+        policy_version=jnp.array([1]),
+    )
+
+    # num_packs=2 with 1 example generates 1 dummy pack.
+    packed_iterator = utils.pack_sequences(
+        iter([[example]]), max_token_budget=10, num_packs=2
+    )
+    packed_batches = list(packed_iterator)
+    [[pack]] = packed_batches
+
+    with self.subTest(name='pack_counts'):
+      self.assertLen(packed_batches, 1)
+      self.assertLen(packed_batches[0], 1)
+
+    with self.subTest(name='batch_size'):
+      self.assertEqual(pack.prompt_ids.shape, (2, 0))
+      self.assertEqual(pack.completion_ids.shape, (2, 10))
+
+    with self.subTest(name='valid_pack_check'):
+      # The arrays are shifted by prompt_len (=2).
+      self.assertEqual(pack.returns[0, 2], 1.0)
+      self.assertEqual(pack.old_values[0, 2], 1.0)
+      self.assertEqual(pack.ref_per_token_logps[0, 2], 1.0)
+      self.assertEqual(pack.policy_version[0], 1)
+
+    with self.subTest(name='dummy_pack_check'):
+      # Dummy pack check (index 1) - per-token features are zero (mask=0
+      # ensures it contributes nothing to loss). policy_version is inherited
+      # from the first real pack so off-policy filtering does not see a
+      # sentinel for padding rows.
+      self.assertEqual(pack.returns[1, 0], 0.0)
+      self.assertEqual(pack.old_values[1, 0], 0.0)
+      self.assertEqual(pack.ref_per_token_logps[1, 0], 0.0)
+      self.assertEqual(pack.policy_version[1], 1)
+
+    with self.subTest(name='policy_version_shape_is_per_row'):
+      # policy_version is a per-row array of shape (num_packs,) where row i
+      # carries the version of pack i. With num_packs=2 we expect length-2.
+      self.assertEqual(pack.policy_version.shape, (2,))
+
+  def test_pack_sequences_version_aware_flush(self):
+    """Items with different policy_versions must land in separate packs."""
+
+    @flax.struct.dataclass(frozen=True)
+    class VersionedExample(common.TrainExample):
+      policy_version: jax.Array | None = None
+
+    # Two examples with different policy_versions. Both fit in the budget so
+    # without version-aware flushing they would share a pack.
+    example_v3 = self._create_mock_train_example(
+        2, 3, cls=VersionedExample, policy_version=jnp.array([3])
+    )
+    example_v7 = self._create_mock_train_example(
+        2, 3, cls=VersionedExample, policy_version=jnp.array([7])
+    )
+
+    packed_iterator = utils.pack_sequences(
+        iter([[example_v3, example_v7]]),
+        max_token_budget=20,  # plenty of room for both
+        num_packs=2,
+    )
+    packed_batches = list(packed_iterator)
+    [[pack]] = packed_batches
+
+    with self.subTest(name='packs_are_separated'):
+      # Each example becomes its own pack -> shape (2, ...) after num_packs=2.
+      self.assertEqual(pack.completion_ids.shape[0], 2)
+
+    with self.subTest(name='per_row_policy_version'):
+      self.assertEqual(pack.policy_version.shape, (2,))
+      self.assertEqual(int(pack.policy_version[0]), 3)
+      self.assertEqual(int(pack.policy_version[1]), 7)
+
   def test_pack_sequences(self):
-    def _create_mock_train_example(
-        prompt_len: int, completion_len: int
-    ) -> common.TrainExample:
-      return common.TrainExample(
-          prompt_ids=jnp.ones((1, prompt_len), dtype=jnp.int32),
-          prompt_mask=jnp.ones((1, prompt_len), dtype=jnp.int32),
-          completion_ids=jnp.ones((1, completion_len), dtype=jnp.int32) * 2,
-          completion_mask=jnp.ones((1, completion_len), dtype=jnp.int32),
-          advantages=jnp.array([1.5], dtype=jnp.float32),
-          ref_per_token_logps=None,
-          old_per_token_logps=None,
-          segment_ids=None,
-          segment_positions=None,
-      )
-
     # 3 sequences with lengths (P+C): (2+3=5), (1+2=3), (3+4=7)
-    example1 = _create_mock_train_example(2, 3)
-    example2 = _create_mock_train_example(1, 2)
-    example3 = _create_mock_train_example(3, 4)
-
-    item_iterator = iter([[example1], [example2], [example3]])
+    example1 = self._create_mock_train_example(2, 3)
+    example2 = self._create_mock_train_example(1, 2)
+    example3 = self._create_mock_train_example(3, 4)
+    item_iterator = iter([[example1, example2, example3]])
 
     # Budget of 10. We expect item 1 (5) and item 2 (3) to fit in the first pack (8).
     # Item 3 (7) will go to the second pack (because 8+7 > 10).
@@ -205,9 +352,6 @@ class UtilsTest(absltest.TestCase):
     )
 
     packed_batches = list(packed_iterator)
-    with self.subTest('pack_counts'):
-      self.assertLen(packed_batches, 2)
-
     pack1 = packed_batches[0][0]
     # Segment IDs should be (5 ones, 3 twos, 2 padding zeros)
     expected_segments_1 = jnp.array(
@@ -224,15 +368,6 @@ class UtilsTest(absltest.TestCase):
         [[0, 0, 1, 1, 1, 0, 1, 1, 0, 0]], dtype=jnp.int32
     )
 
-    with self.subTest('pack1_contents'):
-      self.assertEqual(pack1.prompt_ids.shape, (1, 0))  # prompt_ids is empty
-      self.assertEqual(pack1.completion_ids.shape, (1, 10))  # filled + padded
-      self.assertEqual(pack1.segment_ids.shape, (1, 10))
-      self.assertEqual(pack1.segment_positions.shape, (1, 10))
-      np.testing.assert_array_equal(pack1.segment_ids, expected_segments_1)
-      np.testing.assert_array_equal(pack1.segment_positions, expected_positions_1)
-      np.testing.assert_array_equal(pack1.completion_mask, expected_mask_1)
-
     pack2 = packed_batches[1][0]
     expected_segments_2 = jnp.array([[1] * 7 + [0] * 3], dtype=jnp.int32)
     # Positions should be (0..6, 0, 0, 0)
@@ -244,13 +379,29 @@ class UtilsTest(absltest.TestCase):
         [[0, 0, 0, 1, 1, 1, 1, 0, 0, 0]], dtype=jnp.int32
     )
 
-    with self.subTest('pack2_contents'):
+    with self.subTest(name='pack_counts'):
+      self.assertLen(packed_batches, 2)
+
+    with self.subTest(name='pack1_contents'):
+      self.assertEqual(pack1.prompt_ids.shape, (1, 0))  # prompt_ids is empty
+      self.assertEqual(pack1.completion_ids.shape, (1, 10))  # filled + padded
+      self.assertEqual(pack1.segment_ids.shape, (1, 10))
+      self.assertEqual(pack1.segment_positions.shape, (1, 10))
+      np.testing.assert_array_equal(pack1.segment_ids, expected_segments_1)
+      np.testing.assert_array_equal(
+          pack1.segment_positions, expected_positions_1
+      )
+      np.testing.assert_array_equal(pack1.completion_mask, expected_mask_1)
+
+    with self.subTest(name='pack2_contents'):
       self.assertEqual(pack2.prompt_ids.shape, (1, 0))
       self.assertEqual(pack2.completion_ids.shape, (1, 10))
       self.assertEqual(pack2.segment_ids.shape, (1, 10))
       self.assertEqual(pack2.segment_positions.shape, (1, 10))
       np.testing.assert_array_equal(pack2.segment_ids, expected_segments_2)
-      np.testing.assert_array_equal(pack2.segment_positions, expected_positions_2)
+      np.testing.assert_array_equal(
+          pack2.segment_positions, expected_positions_2
+      )
       np.testing.assert_array_equal(pack2.completion_mask, expected_mask_2)
 
 

--- a/tests/rl/rl_utils_test.py
+++ b/tests/rl/rl_utils_test.py
@@ -237,6 +237,31 @@ class UtilsTest(absltest.TestCase):
     self.assertEqual(item['completion_ids'].shape, (3,))
     self.assertFalse(item['adv_is_per_token'])
 
+  def test_unpad_train_example_none_logps_roundtrip(self):
+    # pack-first groundwork: a token-only TrainExample (no logps) must unpad
+    # cleanly with per-item ref/old logps left as None.
+    example = self._create_mock_train_example(2, 3, pad_len=2)
+    [item] = utils.unpad_train_example(example)
+    self.assertIsNone(item['ref_per_token_logps'])
+    self.assertIsNone(item['old_per_token_logps'])
+
+  def test_pack_sequences_token_only_produces_none_logps(self):
+    # pack-first groundwork: packing TrainExamples that carry no logps must
+    # still pack tokens/segment_ids and leave the packed logps as None, so logp
+    # can be computed on the packed buffer afterwards.
+    example1 = self._create_mock_train_example(2, 3)  # size 5
+    example2 = self._create_mock_train_example(2, 2)  # size 4
+    packed_iterator = utils.pack_sequences(
+        iter([[example1, example2]]), max_token_budget=12
+    )
+    [[pack]] = list(packed_iterator)
+    # Both sequences land in one pack -> two distinct segments.
+    self.assertEqual(pack.segment_ids.shape, (1, 12))
+    self.assertEqual(int(np.max(pack.segment_ids)), 2)
+    # Token-only in -> None logps out.
+    self.assertIsNone(pack.ref_per_token_logps)
+    self.assertIsNone(pack.old_per_token_logps)
+
   def test_pack_sequences_skips_large(self):
     # A sequence larger than budget should be skipped.
     example1 = self._create_mock_train_example(5, 6)  # size 11

--- a/tests/sft/dpo/dpo_trainer_test.py
+++ b/tests/sft/dpo/dpo_trainer_test.py
@@ -270,14 +270,16 @@ class DPOTrainerTest(parameterized.TestCase):
     with mock.patch.object(
         common, "get_per_token_logps", return_value=jnp.array(per_token_logps)
     ):
-      loss, _ = dpo_lib.dpo_loss_fn(
+      loss_output = dpo_lib.dpo_loss_fn(
           model, train_example, beta=0.1, label_smoothing=0
       )
+      loss = loss_output.primary_loss.compute()
       np.testing.assert_allclose(loss, 0.753059, atol=1e-5)
 
-      loss, _ = dpo_lib.dpo_loss_fn(
+      loss_output = dpo_lib.dpo_loss_fn(
           model, train_example, beta=0.1, label_smoothing=0.3
       )
+      loss = loss_output.primary_loss.compute()
       np.testing.assert_allclose(loss, 0.925447, atol=1e-5)
 
   def test_dpo_prepare_inputs_for_strings(self):

--- a/tests/sft/dpo/orpo_trainer_test.py
+++ b/tests/sft/dpo/orpo_trainer_test.py
@@ -255,13 +255,16 @@ class ORPOTrainerTest(parameterized.TestCase):
         "compute_logps",
         return_value=(jnp.array(chosen_logps), jnp.array(rejected_logps), None),
     ):
-      loss, aux = orpo_lib.dpo_loss_fn(
+      loss_output = orpo_lib.dpo_loss_fn(
           model,
           train_example,
           algorithm="orpo",
           lambda_orpo=0.1,
           label_smoothing=0,
       )
+      loss = loss_output.primary_loss.compute()
+      aux = loss_output.aux_metrics
+
       # Loss should be a scalar and finite
       self.assertEqual(loss.shape, ())
       self.assertTrue(jnp.isfinite(loss))
@@ -276,8 +279,8 @@ class ORPOTrainerTest(parameterized.TestCase):
       self.assertIn("odds_ratio", aux)
 
       # Check that accuracy is between 0 and 1
-      self.assertGreaterEqual(aux["rewards/accuracy"], 0.0)
-      self.assertLessEqual(aux["rewards/accuracy"], 1.0)
+      self.assertGreaterEqual(aux["rewards/accuracy"].compute(), 0.0)
+      self.assertLessEqual(aux["rewards/accuracy"].compute(), 1.0)
 
   def test_compute_logps_with_prompt_loss(self):
     """Test compute_logps directly to ensure correct slicing when enable_prompt_loss_orpo=True."""
@@ -373,7 +376,7 @@ class ORPOTrainerTest(parameterized.TestCase):
             jnp.array(prompt_chosen_logps),
         ),
     ):
-      loss, aux = orpo_lib.dpo_loss_fn(
+      out = orpo_lib.dpo_loss_fn(
           model,
           train_example,
           algorithm="orpo",
@@ -381,6 +384,8 @@ class ORPOTrainerTest(parameterized.TestCase):
           label_smoothing=0,
           enable_prompt_loss_orpo=True,
       )
+      loss = out.primary_loss.compute()
+      aux = {k: v.compute() for k, v in out.aux_metrics.items()}
 
       # Assert against mathematically-verified golden values
       self.assertEqual(loss.shape, ())
@@ -428,7 +433,7 @@ class ORPOTrainerTest(parameterized.TestCase):
         "compute_logps",
         return_value=(jnp.array(chosen_logps), jnp.array(rejected_logps), None),
     ):
-      loss, aux = orpo_lib.dpo_loss_fn(
+      out = orpo_lib.dpo_loss_fn(
           model,
           train_example,
           algorithm="orpo",
@@ -436,6 +441,8 @@ class ORPOTrainerTest(parameterized.TestCase):
           label_smoothing=0,
           average_log_prob_orpo=True,
       )
+      loss = out.primary_loss.compute()
+      aux = {k: v.compute() for k, v in out.aux_metrics.items()}
 
       # Assert against mathematically-verified golden values
       self.assertEqual(loss.shape, ())

--- a/tests/sft/peft_trainer_test.py
+++ b/tests/sft/peft_trainer_test.py
@@ -34,6 +34,7 @@ from tunix.sft import checkpoint_manager
 from tunix.sft import hooks
 from tunix.sft import peft_trainer
 from tunix.sft import profiler
+from tunix.sft import utils
 from tunix.tests import test_common as tc
 from tunix.utils import compat
 
@@ -42,6 +43,8 @@ TEST_LEARNING_RATE = 1e-3
 # CPU environment setup to simulate multi device env.
 os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=4'
 
+# Set Precision to highest for numeric stability across different hardware.
+jax.config.update('jax_default_matmul_precision', 'highest')
 
 def create_sharded_model(model_ctor, rngs, mesh):
   @nnx.jit(static_argnums=(0,))
@@ -108,10 +111,14 @@ class PeftTrainerTest(parameterized.TestCase):
   def test_compile_once(self):
     class CountCompiledTimesTrainer(peft_trainer.PeftTrainer):
 
-      def _train_step(self, model, optimizer, inputs):
+      def _train_step(
+          self, model, optimizer, grad_accumulator, inputs, is_update_step
+      ):
         global global_counter
         global_counter += 1
-        return super()._train_step(model, optimizer, inputs)
+        return super()._train_step(
+            model, optimizer, grad_accumulator, inputs, is_update_step
+        )
 
     config = peft_trainer.TrainingConfig(eval_every_n_steps=2, max_steps=100)
     rngs = nnx.Rngs(0)
@@ -634,7 +641,67 @@ class PeftTrainerTest(parameterized.TestCase):
     self.assertEqual(train_invoke, {'foo': 2, 'bar': 4})
     self.assertEqual(eval_invoke, {'foo': 1, 'bar': 16})
 
+  def test_loss_output_format(self):
+    def custom_loss_fn(
+        model: nnx.Module,
+        input_tokens: jax.Array,
+        input_mask: jax.Array,
+        positions: jax.Array,
+        attention_mask: jax.Array,
+        images: jax.Array | None = None,
+    ) -> utils.LossOutput:
+      del model, input_tokens, input_mask, positions, attention_mask, images
+      return utils.LossOutput(
+          primary_loss=utils.WeightedMetric(
+              jnp.array(2.0, dtype=jnp.float32),
+              jnp.array(2.0, dtype=jnp.float32),
+          ),
+          aux_metrics={
+              'foo': utils.WeightedMetric(
+                  jnp.array(10.0, dtype=jnp.float32),
+                  jnp.array(5.0, dtype=jnp.float32),
+              ),
+              'bar': utils.WeightedMetric(
+                  jnp.array(6.0, dtype=jnp.float32),
+                  jnp.array(2.0, dtype=jnp.float32),
+              ),
+          },
+      )
+
+    train_invoke = {'foo': 0.0, 'bar': 0.0}
+    eval_invoke = {'foo': 0.0, 'bar': 0.0}
+
+    class CustomTrainer(peft_trainer.PeftTrainer):
+
+      def _post_process_train_step(self, aux):
+        train_invoke['foo'] += aux['foo']
+        train_invoke['bar'] += aux['bar']
+
+      def _post_process_eval_step(self, aux):
+        eval_invoke['foo'] += aux['foo']
+        eval_invoke['bar'] += aux['bar']
+
+    config = peft_trainer.TrainingConfig(eval_every_n_steps=2, max_steps=100)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0))
+
+    trainer = CustomTrainer(model, optax.sgd(1e-3), config)
+    trainer = trainer.with_gen_model_input_fn(
+        dummy_gen_model_input_fn
+    ).with_loss_fn(
+        custom_loss_fn
+    )  # Note: has_aux=False is default but LossOutput returns aux natively
+
+    trainer.train(self.train_ds, self.eval_ds)
+    # The dataset provides 2 training steps.
+    # foo = 10.0 / 5.0 = 2.0 per step.
+    # bar = 6.0 / 2.0 = 3.0 per step.
+    self.assertEqual(train_invoke, {'foo': 4.0, 'bar': 6.0})
+
+    # Since eval_ds is length 2, it evaluates at step 2.
+    self.assertEqual(eval_invoke, {'foo': 8.0, 'bar': 12.0})
+
   def test_injected_params(self):
+
     config = peft_trainer.TrainingConfig(eval_every_n_steps=2, max_steps=100)
     model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0))
 
@@ -651,6 +718,520 @@ class PeftTrainerTest(parameterized.TestCase):
         trainer.metrics_logger.get_metric('', 'learning_rate', 'train'),
         TEST_LEARNING_RATE,
     )
+
+
+def _unwrap(state):
+  """Unwrap a `State` of `Variable` leaves to raw arrays for numeric checks."""
+  return jax.tree_util.tree_map(
+      lambda v: v[...] if isinstance(v, nnx.Variable) else v,
+      state,
+      is_leaf=lambda x: isinstance(x, nnx.Variable),
+  )
+
+
+class GradientAccumulatorTest(parameterized.TestCase):
+  """Unit tests for the GradientAccumulator module.
+
+  Covers the unified `add(grads, denom=None)` contract:
+
+  * default (`denom=None`): each call contributes 1.0 to the denominator,
+    so `get()` returns the mean of the per-micro-step gradients — the
+    `optax.MultiSteps` semantics expected by callers using a per-batch
+    scalar (mean) loss.
+  * explicit `denom`: caller supplies the unreduced-loss denominator
+    (e.g. token count). `get()` returns `Σg / Σd`, which is the gradient
+    of a single step on the concatenated batch — required when
+    micro-batches have varying effective batch sizes (sequence packing).
+  """
+
+  def _make_accumulator(self):
+    rngs = nnx.Rngs(0)
+    model = nnx.Linear(in_features=4, out_features=2, rngs=rngs)
+    return model, peft_trainer.GradientAccumulator(model, nnx.Param)
+
+  def _ones_like_params(self, model, scale: float = 1.0):
+    """Creates a dummy copy of model parameters filled entirely with the `scale` value."""
+    return jax.tree_util.tree_map(
+        lambda x: jnp.asarray(scale, dtype=x.dtype) * jnp.ones_like(x),
+        nnx.state(model, nnx.Param),
+    )
+
+  def test_default_mode_averages_grads(self):
+    """Default add() returns the mean of micro-step grads.
+
+    Matches ``optax.MultiSteps`` semantics: K micro-steps of size B/K are
+    equivalent to a single step on a batch of size B when the loss
+    function returns a per-batch scalar (mean) value. ``get()`` returns
+    ``(Σ_i grads_i) / max(Σ_i 1, 1)``; here K=2 and the per-step grads
+    have scale 1.0 and 2.0, so the mean is 1.5.
+    """
+    model, acc = self._make_accumulator()
+    acc.add(self._ones_like_params(model, scale=1.0))
+    acc.add(self._ones_like_params(model, scale=2.0))
+    out = _unwrap(acc.get())
+    jax.tree_util.tree_map(
+        lambda v: np.testing.assert_allclose(v, 1.5 * jnp.ones_like(v)),
+        out,
+    )
+
+  @parameterized.named_parameters(
+      dict(testcase_name='equal_denoms', denoms=(4.0, 4.0, 4.0, 4.0)),
+      dict(testcase_name='varying_denoms', denoms=(1.0, 7.0, 3.0, 5.0)),
+      dict(testcase_name='extreme_variance', denoms=(1.0, 1.0, 100.0, 1.0)),
+  )
+  def test_explicit_denom_matches_single_step_baseline(self, denoms):
+    """Passing explicit denom matches the equivalent single-step batch.
+
+    Setup: K micro-batches with denominator d_i and unreduced-sum
+    gradient g_i. The accumulator computes ``Σ_i g_i / Σ_i d_i``, which
+    is ``grad(Σ_i loss_unreduced_i) / Σ_i d_i`` — i.e., a single step on
+    the concatenated batch — for any choice of d_i. The "pre-scale grads
+    by 1/d_i then mean over K" pattern fails this equality when d_i are
+    unequal; this test guards against that regression.
+
+    Args:
+      denoms: A tuple of floats representing the denominators for each
+        micro-batch.
+    """
+    model, acc = self._make_accumulator()
+
+    keys = jax.random.split(jax.random.PRNGKey(0), len(denoms))
+    grads = [
+        jax.tree_util.tree_map(
+            lambda x, k=k: jax.random.normal(k, x.shape, dtype=x.dtype),
+            nnx.state(model, nnx.Param),
+        )
+        for k in keys
+    ]
+
+    for g_i, d_i in zip(grads, denoms):
+      acc.add(g_i, denom=jnp.asarray(d_i, dtype=jnp.float32))
+    accumulated = _unwrap(acc.get())
+
+    total_denom = sum(denoms)
+    expected = jax.tree_util.tree_map(lambda *gs: sum(gs) / total_denom, *grads)
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        accumulated,
+        expected,
+    )
+
+    if len(set(denoms)) > 1:
+      naive_mean = jax.tree_util.tree_map(
+          lambda *gs: sum(g / d for g, d in zip(gs, denoms)) / len(gs),
+          *grads,
+      )
+      diff_tree = jax.tree_util.tree_map(
+          lambda a, b: jnp.max(jnp.abs(a - b)), accumulated, naive_mean
+      )
+      max_naive_diff = jax.tree_util.tree_reduce(
+          jnp.maximum, diff_tree, initializer=jnp.asarray(0.0, jnp.float32)
+      )
+      self.assertGreater(
+          float(max_naive_diff),
+          1e-3,
+          msg=(
+              'naive pre-scale-then-mean and Sigma g / Sigma d should '
+              'disagree when denominators vary; if they agree the test setup '
+              'is degenerate.'
+          ),
+      )
+
+  def test_reset_clears_denom(self):
+    model, acc = self._make_accumulator()
+    acc.add(self._ones_like_params(model), denom=jnp.asarray(7.0, jnp.float32))
+    acc.reset()
+    self.assertEqual(float(acc.denom[...]), 0.0)
+    jax.tree_util.tree_map(
+        lambda v: np.testing.assert_array_equal(v[...], jnp.zeros_like(v[...])),
+        acc.grads,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+
+  # ---------------------------------------------------------------------
+  # End-to-end numerical equivalence tests against `nnx.value_and_grad`.
+  #
+  # The tests above exercise the accumulator with hand-rolled arrays; the
+  # tests below thread the *real* differentiation path (`nnx.value_and_grad`
+  # on a small model) so the assertions hold for the exact pytree shape /
+  # Variable wrappers the production `_train_step` produces.
+  # ---------------------------------------------------------------------
+
+  def _make_model_and_data(self, total_examples: int, seed: int = 42):
+    rngs = nnx.Rngs(seed)
+    model = nnx.Linear(in_features=4, out_features=2, rngs=rngs)
+    keys = jax.random.split(jax.random.PRNGKey(seed), 2)
+    x = jax.random.normal(keys[0], (total_examples, 4))
+    y = jax.random.normal(keys[1], (total_examples, 2))
+    return model, x, y
+
+  @staticmethod
+  def _loss_mean(model, x, y):
+    # Mean over the batch / sequence axis only (sum over feature axis)
+    # so `sum_loss == batch_size * mean_loss`. The full-tensor `jnp.mean`
+    # would divide by `batch_size * feature_dim`, which would only match
+    # the denom-aware path if `denom` were passed as `size * feature_dim`
+    # — pinning the contract to a model-architecture quirk we don't want
+    # the test to rely on.
+    per_example = jnp.sum((model(x) - y) ** 2, axis=-1)
+    return jnp.mean(per_example)
+
+  @staticmethod
+  def _loss_sum(model, x, y):
+    # Matches the reduction of `_loss_mean` modulo division by batch size:
+    # sum over both batch and feature axes.
+    return jnp.sum((model(x) - y) ** 2)
+
+  @parameterized.named_parameters(
+      dict(testcase_name='K1', K=1),
+      dict(testcase_name='K2', K=2),
+      dict(testcase_name='K4', K=4),
+      dict(testcase_name='K8', K=8),
+  )
+  def test_default_mode_K_micro_batches_match_full_batch(self, K):
+    """Default mode: K equal-size micro-batches ≡ one full batch.
+
+    Mean-of-means equals mean-over-all when the micro-batches partition
+    the full batch into equal-size chunks. This is the
+    `optax.MultiSteps`-equivalent contract the unpacked grad-accumulation
+    path relies on.
+    """
+    B = 16
+    self.assertEqual(B % K, 0)
+    micro = B // K
+    model, x, y = self._make_model_and_data(B)
+
+    grad_fn = nnx.value_and_grad(self._loss_mean)
+    _, expected = grad_fn(model, x, y)
+
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+    for i in range(K):
+      _, g = grad_fn(
+          model, x[i * micro : (i + 1) * micro], y[i * micro : (i + 1) * micro]
+      )
+      acc.add(g)
+
+    accumulated = _unwrap(acc.get())
+    expected_arrays = _unwrap(expected)
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        accumulated,
+        expected_arrays,
+    )
+
+  def test_default_mode_K_micro_batches_match_concatenated_baseline_under_jit(
+      self,
+  ):
+    """Same as above but with the accumulator's mutations under `nnx.jit`.
+
+    The unpacked `_train_step` calls `acc.add()` from inside a jit; this
+    test exercises the same trace path so any nnx.Variable / pytree
+    breakage in jitted mutation surfaces here (rather than only at the
+    full trainer integration level).
+    """
+    B = 12
+    K = 3
+    micro = B // K
+    model, x, y = self._make_model_and_data(B, seed=7)
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+
+    @nnx.jit
+    def _add_step(model, acc, x_b, y_b):
+      _, g = nnx.value_and_grad(self._loss_mean)(model, x_b, y_b)
+      acc.add(g)
+
+    for i in range(K):
+      _add_step(
+          model,
+          acc,
+          x[i * micro : (i + 1) * micro],
+          y[i * micro : (i + 1) * micro],
+      )
+
+    accumulated = _unwrap(acc.get())
+    _, expected = nnx.value_and_grad(self._loss_mean)(model, x, y)
+    expected_arrays = _unwrap(expected)
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        accumulated,
+        expected_arrays,
+    )
+
+  @parameterized.named_parameters(
+      dict(testcase_name='small_pack', sizes=(3, 5, 1, 7)),
+      dict(testcase_name='single_dominant_pack', sizes=(1, 1, 28, 2)),
+      dict(testcase_name='single_pack', sizes=(8,)),
+      dict(testcase_name='many_small_packs', sizes=(1, 1, 1, 1, 1, 1, 1, 1)),
+  )
+  def test_explicit_denom_packed_micro_batches_match_full_batch(self, sizes):
+    """Sequence packing: varying-size micro-batches with denom=size.
+
+    Under sequence packing each yielded micro-batch carries a different
+    number of training examples (varying pack sizes). The denom-aware
+    path computes Σ_i grad(sum_loss_i) / Σ_i size_i, which is the
+    gradient of mean(loss_over_all_examples) for *any* partition. Tests
+    span uniform, dominantly-one-pack, single-pack, and
+    many-small-packs partitions to catch regressions where the divisor
+    drifts off-by-one.
+
+    Args:
+      sizes: A tuple of integers representing the sizes of each micro-batch.
+    """
+    total = sum(sizes)
+    model, x, y = self._make_model_and_data(total, seed=13)
+
+    _, expected = nnx.value_and_grad(self._loss_mean)(model, x, y)
+
+    grad_sum = nnx.value_and_grad(self._loss_sum)
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+    start = 0
+    for size in sizes:
+      end = start + size
+      _, g = grad_sum(model, x[start:end], y[start:end])
+      acc.add(g, denom=jnp.asarray(float(size)))
+      start = end
+
+    accumulated = _unwrap(acc.get())
+    expected_arrays = _unwrap(expected)
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        accumulated,
+        expected_arrays,
+    )
+
+  def test_explicit_denom_packed_matches_unpacked_concatenation_under_jit(self):
+    """Packed + denom-aware path under `nnx.jit`, against unpacked baseline.
+
+    Mirrors the production sequence-packing flow: each "pack" is a
+    micro-batch of varying size, fed through a jitted grad-sum step and
+    accumulated with `denom=size`. The expected value is computed *on
+    the same model* via the mean-loss path, so any mismatch isolates the
+    accumulation math (not data setup).
+    """
+    sizes = (2, 4, 1, 3, 6)
+    total = sum(sizes)
+    model, x, y = self._make_model_and_data(total, seed=21)
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+
+    @nnx.jit
+    def _packed_add(model, acc, x_b, y_b, denom):
+      _, g = nnx.value_and_grad(self._loss_sum)(model, x_b, y_b)
+      acc.add(g, denom=denom)
+
+    start = 0
+    for size in sizes:
+      end = start + size
+      _packed_add(
+          model,
+          acc,
+          x[start:end],
+          y[start:end],
+          jnp.asarray(float(size), jnp.float32),
+      )
+      start = end
+
+    accumulated = _unwrap(acc.get())
+    _, expected = nnx.value_and_grad(self._loss_mean)(model, x, y)
+    expected_arrays = _unwrap(expected)
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        accumulated,
+        expected_arrays,
+    )
+
+  def test_default_and_explicit_denom_agree_when_micro_batches_uniform(self):
+    """Sanity bridge: explicit denom with uniform sizes ≡ default mode.
+
+    When every micro-batch has the same size, the default (mean-of-means)
+    path and the denom-aware (sum-of-sums / sum-of-sizes) path must
+    produce the same gradient. This sanity-checks that the unification
+    of `count` and `denom` into a single field hasn't introduced a
+    silent off-by-N (e.g. summing K vs K+1 in one of the branches).
+    """
+    sizes = (4, 4, 4, 4)
+    total = sum(sizes)
+    model, x, y = self._make_model_and_data(total, seed=99)
+
+    # Default (mean) path.
+    acc_default = peft_trainer.GradientAccumulator(model, nnx.Param)
+    grad_mean = nnx.value_and_grad(self._loss_mean)
+    for i, size in enumerate(sizes):
+      s, e = i * size, (i + 1) * size
+      _, g = grad_mean(model, x[s:e], y[s:e])
+      acc_default.add(g)
+    default_out = _unwrap(acc_default.get())
+
+    # Explicit-denom path with uniform sizes.
+    acc_denom = peft_trainer.GradientAccumulator(model, nnx.Param)
+    grad_sum = nnx.value_and_grad(self._loss_sum)
+    start = 0
+    for size in sizes:
+      end = start + size
+      _, g = grad_sum(model, x[start:end], y[start:end])
+      acc_denom.add(g, denom=jnp.asarray(float(size)))
+      start = end
+    denom_out = _unwrap(acc_denom.get())
+
+    jax.tree_util.tree_map(
+        lambda a, b: np.testing.assert_allclose(a, b, rtol=1e-6, atol=1e-6),
+        default_out,
+        denom_out,
+    )
+
+  def test_reset_then_reuse_does_not_leak_state(self):
+    """After `reset()`, a second accumulation cycle must match a fresh acc.
+
+    Guards against state leaking across reset boundaries — e.g. the
+    denom counter not zeroing, or `grads` keeping a residual that would
+    silently bias subsequent updates.
+    """
+    sizes = (4, 4)
+    total = sum(sizes)
+    model, x, y = self._make_model_and_data(total, seed=33)
+    grad_mean = nnx.value_and_grad(self._loss_mean)
+
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+    # First cycle on unrelated data — must be erased by reset.
+    junk_x = jax.random.normal(jax.random.PRNGKey(101), (8, 4))
+    junk_y = jax.random.normal(jax.random.PRNGKey(102), (8, 2))
+    for i in range(2):
+      _, g = grad_mean(
+          model, junk_x[i * 4 : (i + 1) * 4], junk_y[i * 4 : (i + 1) * 4]
+      )
+      acc.add(g)
+    acc.reset()
+
+    # Second cycle on the real data after reset.
+    for i, size in enumerate(sizes):
+      s, e = i * size, (i + 1) * size
+      _, g = grad_mean(model, x[s:e], y[s:e])
+      acc.add(g)
+    after_reset = _unwrap(acc.get())
+
+    # Reference: fresh accumulator on the same real data.
+    acc_fresh = peft_trainer.GradientAccumulator(model, nnx.Param)
+    for i, size in enumerate(sizes):
+      s, e = i * size, (i + 1) * size
+      _, g = grad_mean(model, x[s:e], y[s:e])
+      acc_fresh.add(g)
+    fresh = _unwrap(acc_fresh.get())
+
+    jax.tree_util.tree_map(
+        lambda a, b: np.testing.assert_allclose(a, b, rtol=1e-6, atol=1e-6),
+        after_reset,
+        fresh,
+    )
+
+  @parameterized.named_parameters(
+      dict(testcase_name='bfloat16', dtype=jnp.bfloat16),
+      dict(testcase_name='float16', dtype=jnp.float16),
+      dict(testcase_name='float32', dtype=jnp.float32),
+  )
+  def test_get_preserves_grad_dtype(self, dtype: jnp.dtype):
+    rngs = nnx.Rngs(0)
+    model = nnx.Linear(
+        in_features=4, out_features=2, rngs=rngs, param_dtype=dtype
+    )
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+
+    grads = jax.tree_util.tree_map(
+        lambda v: type(v)(jnp.ones_like(v[...])),
+        nnx.state(model, nnx.Param),
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+    acc.add(grads, denom=jnp.asarray(3.0, dtype=jnp.float32))
+    out = acc.get()
+
+    jax.tree_util.tree_map(
+        lambda v: self.assertEqual(v[...].dtype, dtype),
+        out,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+
+  def test_cond_apply_vs_skip_branches_have_matching_dtypes_in_bf16(self):
+    rngs = nnx.Rngs(0)
+    model = nnx.Linear(
+        in_features=4, out_features=2, rngs=rngs, param_dtype=jnp.bfloat16
+    )
+    optimizer = nnx.Optimizer(model, optax.adam(1e-3), wrt=nnx.Param)
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+
+    x = jnp.ones((2, 4), dtype=jnp.bfloat16)
+    y = jnp.ones((2, 2), dtype=jnp.bfloat16)
+    _, grads = nnx.value_and_grad(lambda m, x, y: jnp.sum((m(x) - y) ** 2))(
+        model, x, y
+    )
+    acc.add(grads, denom=jnp.asarray(1.0, dtype=jnp.float32))
+
+    def apply_updates(model, optimizer, acc):
+      acc_grads = acc.get()
+      optimizer.update(model, acc_grads)
+      acc.reset()
+      return jnp.asarray(0.0, dtype=jnp.float32)
+
+    def skip_updates(model, optimizer, acc):
+      return jnp.asarray(0.0, dtype=jnp.float32)
+
+    @nnx.jit
+    def step(model, optimizer, acc, is_update_step):
+      return nnx.cond(
+          is_update_step, apply_updates, skip_updates, model, optimizer, acc
+      )
+
+    step(model, optimizer, acc, jnp.asarray(False))
+    step(model, optimizer, acc, jnp.asarray(True))
+
+    opt_state_dtypes = jax.tree_util.tree_leaves(
+        jax.tree_util.tree_map(
+            lambda v: v[...].dtype,
+            nnx.state(optimizer, nnx.optimizer.OptState),
+            is_leaf=lambda x: isinstance(x, nnx.Variable),
+        )
+    )
+    float_dtypes = [
+        d for d in opt_state_dtypes if jnp.issubdtype(d, jnp.floating)
+    ]
+    self.assertNotEmpty(float_dtypes)
+    for d in float_dtypes:
+      self.assertEqual(d, jnp.bfloat16)
+
+  def test_peft_trainer_promotes_bf16_opt_state_floats_to_float32(self):
+    """`PeftTrainer.__init__` casts float opt_state leaves to float32.
+
+    `optax.adam` / `optax.adamw` promote their floating-point moments
+    (`mu`, `nu`) to float32 inside `update` whenever the learning rate is
+    a float32 tracer (as produced by `optax.inject_hyperparams`). This test
+    verifies that the trainer casts these to float32 in-place during init.
+    """
+    rngs = nnx.Rngs(0)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=rngs)
+    bf16_state = jax.tree.map(
+        lambda x: x.astype(jnp.bfloat16)
+        if jnp.issubdtype(x.dtype, jnp.floating)
+        else x,
+        nnx.state(model, nnx.Param),
+    )
+    nnx.update(model, bf16_state)
+
+    tx = optax.inject_hyperparams(optax.adamw, hyperparam_dtype=jnp.float32)(
+        learning_rate=1e-3
+    )
+    config = peft_trainer.TrainingConfig(eval_every_n_steps=100, max_steps=1)
+    trainer = peft_trainer.PeftTrainer(model, tx, config)
+
+    opt_state_dtypes = jax.tree_util.tree_leaves(
+        jax.tree_util.tree_map(
+            lambda v: v[...].dtype,
+            nnx.state(trainer.optimizer, nnx.optimizer.OptState),
+            is_leaf=lambda x: isinstance(x, nnx.Variable),
+        )
+    )
+    float_dtypes = [
+        d for d in opt_state_dtypes if jnp.issubdtype(d, jnp.floating)
+    ]
+    self.assertNotEmpty(float_dtypes)
+    for d in float_dtypes:
+      self.assertEqual(d, jnp.float32)
 
 
 if __name__ == '__main__':

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -284,6 +284,41 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         else None,
     ])
 
+  def _compute_packed_logps(self, example: TrainExample) -> TrainExample:
+    # pack-first: old/ref logp were deferred in _process_results (left None);
+    # compute them here on the packed buffer via the segment-aware forward.
+    pad_value = self.rl_cluster.rollout.pad_id()
+    eos_value = self.rl_cluster.rollout.eos_id()
+    micro = (
+        self.rl_cluster.cluster_config.training_config.compute_logps_micro_batch_size
+    )
+    updates = {}
+    if example.old_per_token_logps is None and not self.algo_config.use_rollout_logps:
+      updates["old_per_token_logps"] = self.rl_cluster.get_actor_per_token_logps(
+          prompt_tokens=example.prompt_ids,
+          completion_tokens=example.completion_ids,
+          pad_id=pad_value,
+          eos_id=eos_value,
+          micro_batch_size=micro,
+          segment_ids=example.segment_ids,
+          segment_positions=example.segment_positions,
+      )
+    if example.ref_per_token_logps is None and (
+        self.algo_config.force_compute_kl or self.algo_config.beta != 0.0
+    ):
+      updates["ref_per_token_logps"] = self.rl_cluster.get_ref_per_token_logps(
+          prompt_tokens=example.prompt_ids,
+          completion_tokens=example.completion_ids,
+          pad_id=pad_value,
+          eos_id=eos_value,
+          micro_batch_size=micro,
+          segment_ids=example.segment_ids,
+          segment_positions=example.segment_positions,
+      )
+    if updates:
+      example = example.replace(**updates)
+    return example
+
   def _process_results(
       self,
       trajectories: List[Any],
@@ -436,6 +471,12 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     # when active: one extra trainer forward pass per training step.
     actor_mesh = self.rl_cluster.r2m[rl_cluster_lib.Role.ACTOR]
     have_actor_mesh = actor_mesh is not None and not actor_mesh.empty
+    # pack-first: defer old/ref logp to the packed buffer (computed after
+    # pack_sequences in the consumer). Leave the non-packed path untouched.
+    is_packed = (
+        self.rl_cluster.cluster_config.training_config.max_seq_token_per_tpu
+        is not None
+    )
     rollout_per_token_logps = None
     trainer_per_token_logps = None
     if self.algo_config.use_rollout_logps and padded_old_logprobs:
@@ -467,6 +508,8 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         old_per_token_logps = trainer_per_token_logps
     elif self.algo_config.use_rollout_logps:
       old_per_token_logps = None
+    elif is_packed:
+      old_per_token_logps = None
     else:
       trainer_per_token_logps = self.rl_cluster.get_actor_per_token_logps(
           prompt_tokens=prompt_ids,
@@ -496,7 +539,9 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     if group_id is not None:
       perf_tags[perf_constants.GROUP_ID] = group_id
 
-    if self.algo_config.force_compute_kl or self.algo_config.beta != 0.0:
+    if (
+        self.algo_config.force_compute_kl or self.algo_config.beta != 0.0
+    ) and not is_packed:
       with self.rl_cluster.perf_v2.span(
           perf_constants.REFERENCE_INFERENCE,
           devices=self.rl_cluster.r2m[rl_cluster_lib.Role.REFERENCE].devices,

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -557,6 +557,20 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
 
     logging.debug("Advantages computed: %s", advantages)
 
+    if self.algo_config.degenerate_group_masking:
+      # Masking runs *before* sequence packing, requiring 1-D per-generation
+      # advantages. If 2-D per-token advantages are ever supplied, `jnp.all`
+      # would incorrectly zero out the entire batch instead of per-segment.
+      assert advantages.ndim == 1, (
+          "degenerate_group_masking expects 1-D advantages "
+          f"(per-generation), got shape {advantages.shape}. "
+          "Sequence-packed (2-D) advantages must be filtered before packing."
+      )
+      if jnp.all(jnp.isclose(advantages, 0.0)):
+        logging.info(
+            "Filtering degenerate group %s with all-0 advantages.", group_id
+        )
+        completion_mask = jnp.zeros_like(completion_mask)
     policy_versions = np.array(policy_versions_list, dtype=np.int32)
 
     # Log completion lengths, rewards and env time.

--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -607,6 +607,11 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
         expected_step=expected_step,
     )
 
+  def _compute_packed_logps(self, example: TrainExample) -> TrainExample:
+    # pack-first hook: algorithms that defer old/ref logp under packing compute
+    # them on the packed buffer here. Base is a no-op.
+    return example
+
   @abc.abstractmethod
   def _process_results(
       self,
@@ -738,7 +743,12 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     self._rollout_micro_batch_size = 1
     self._process_in_consumer = False
 
-    if self._compute_logps_micro_batch_size > 1:
+    # pack-first: with packing on, the pack is the logp batch, so logp is
+    # computed on the packed buffer after pack_sequences; do not defer
+    # conversion to the consumer (which would enqueue raw lists pack_sequences
+    # cannot consume).
+    packing_enabled = self._training_config.max_seq_token_per_tpu is not None
+    if self._compute_logps_micro_batch_size > 1 and not packing_enabled:
       if self._compute_logps_micro_batch_size != train_micro_batch_size:
         raise ValueError(
             "compute_logps_micro_batch_size"
@@ -866,6 +876,28 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
         # TODO(b/491970038): handle seq packing case differently
         merged_train_micro_batch = jax.tree.map(
             lambda *xs: jnp.concatenate(xs, axis=0), *train_micro_batch
+        )
+
+      if is_packed:
+        # pack-first: old/ref logp were deferred (left None) so they can be
+        # computed here on the packed buffer (segment-aware forward), sharing
+        # the same packed representation training uses.
+        merged_train_micro_batch = self._compute_packed_logps(
+            merged_train_micro_batch
+        )
+        # Packing efficiency: segment_ids==0 marks padding + dummy packs (real
+        # segments are numbered from 1), i.e. the fraction of wasted compute.
+        seg = np.asarray(merged_train_micro_batch.segment_ids)
+        self.rl_cluster.buffer_metrics_async(
+            {
+                "packing/dummy_ratio": (float((seg == 0).mean()), np.mean),
+                "packing/seqs_per_pack": (
+                    float(seg.max(axis=-1).mean()),
+                    np.mean,
+                ),
+            },
+            mode=rl_cluster_lib.Mode.TRAIN,
+            step=self.rl_cluster.global_steps,
         )
 
       # When ``train_micro_batch_size < mini_batch_size`` we want the trainer

--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -288,6 +288,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             "True for AgenticRLLearner if using vLLM engine. Please set this "
             "before initializing RLCluster."
         )
+
   def _compute_rewards(
       self,
       prompts: List[str],
@@ -802,16 +803,31 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
     train_data_gen = self._data_consumer_batch_generator(
         train_data_queue, train_micro_batch_size
     )
-    if self._training_config.max_seq_token_per_tpu is not None:
+    is_packed = self._training_config.max_seq_token_per_tpu is not None
+    if is_packed:
+      mesh = self.rl_cluster.cluster_config.role_to_mesh[
+          rl_cluster_lib.Role.ACTOR
+      ]
+      # The packed batch size must be a multiple of the FSDP and DP mesh axis
+      # sizes.
+      pack_size = mesh.shape.get("fsdp", 1) * mesh.shape.get("dp", 1)
+
       logging.info(
-          "Using sequence packing with max_seq_token_per_tpu: %d",
+          "Using sequence packing with max_seq_token_per_tpu: %d, "
+          " pack_size: %d",
           self._training_config.max_seq_token_per_tpu,
+          pack_size,
       )
+
       train_data_gen = rl_utils.pack_sequences(
-          train_data_gen, self._training_config.max_seq_token_per_tpu
+          train_data_gen,
+          self._training_config.max_seq_token_per_tpu,
+          target_items_per_update=grad_acc_steps,
+          num_packs=pack_size,
       )
-    micro_batches_since_last_sync = 0
-    micro_batches_per_full_batch = full_batch_size // train_micro_batch_size
+    update_steps_since_last_sync = 0
+    update_steps_per_full_batch = full_batch_size // mini_batch_size
+    unpacked_micro_step_counter = 0
     did_eval_this_global_step = False
     full_batch_chunks = []
     for train_micro_batch in train_data_gen:
@@ -847,6 +863,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
         # GRPO returns a list with a single TrainExample.
         merged_train_micro_batch = train_examples[0]
       else:
+        # TODO(b/491970038): handle seq packing case differently
         merged_train_micro_batch = jax.tree.map(
             lambda *xs: jnp.concatenate(xs, axis=0), *train_micro_batch
         )
@@ -882,7 +899,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
 
       # --- Evaluation Logic on FIRST microbatch ---
       current_eval_dataset = None
-      if micro_batches_since_last_sync == 0:
+      if update_steps_since_last_sync == 0:
         current_train_step = self.rl_cluster.actor_trainer.train_steps
         if (
             all_eval_prompts
@@ -928,9 +945,23 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             chunked_train_micro_batch, current_eval_dataset, skip_jit
         )
 
-      micro_batches_since_last_sync += 1
-
-      if micro_batches_since_last_sync == micro_batches_per_full_batch:
+      # --- Weight Sync Logic ---
+      if is_packed:
+        # `merged_train_micro_batch.is_update_step` is a 0-d jax scalar set
+        # by `pack_sequences`; pull the host-side value before deciding.
+        is_update = bool(
+            np.asarray(merged_train_micro_batch.is_update_step).item()
+        )
+      else:
+        # Mirror `peft_trainer._train_step`'s derivation:
+        # `is_update_step` flips True every `grad_acc_steps` micro-batches.
+        unpacked_micro_step_counter += 1
+        is_update = unpacked_micro_step_counter % grad_acc_steps == 0
+        
+      if is_update:
+        update_steps_since_last_sync += 1
+        
+      if update_steps_since_last_sync == update_steps_per_full_batch:
         # --- Remaining Iterations Training Step ---
         iterations = self._num_iterations()
 
@@ -949,7 +980,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             )
         full_batch_chunks.clear()
 
-        # --- Weight Sync Logic ---
+
         global_step_time = time.time() - self._global_step_start_time
         logging.info(
             f"Global step {self.rl_cluster.global_steps} completed in"
@@ -1091,7 +1122,7 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             self.rl_cluster.perf_v2.export(),
             mode=rl_cluster_lib.Mode.TRAIN,
         )
-        micro_batches_since_last_sync = 0
+        update_steps_since_last_sync = 0
         did_eval_this_global_step = False
         self._global_step_start_time = time.time()
 

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -21,13 +21,14 @@ import jax.numpy as jnp
 import numpy as np
 from tunix.rl import common
 from tunix.rl import function_registry
-
+from tunix.sft import utils as sft_utils
 
 registry = function_registry.default_registry
 
 # ==============================================================================
 # Utils
 # ==============================================================================
+
 
 @registry.register("advantage_estimator", "gae")
 @jax.jit
@@ -128,7 +129,7 @@ def masked_whiten(
   return x
 
 
-@functools.partial(jax.jit, static_argnames=('axis',))
+@functools.partial(jax.jit, static_argnames=("axis",))
 def masked_mean(
     x: jax.Array, mask: jax.Array, axis: int | None = None
 ) -> jax.Array:
@@ -170,7 +171,7 @@ def ppo_policy_loss_fn(
     pad_id,
     eos_id,
     **kwargs,
-):
+) -> sft_utils.LossOutput:
   """PPO policy loss function."""
   epsilon_low = algo_config.epsilon_low
   epsilon_high = algo_config.epsilon_high
@@ -220,28 +221,38 @@ def ppo_policy_loss_fn(
     pg_loss_3 = -epsilon_c * advantages
   else:
     pg_loss_3 = per_token_loss
-  unreduced_pg_clipfrac_lower = (
-      (per_token_loss > pg_loss_3) & (advantages < 0.0)
-  ).astype(jnp.float32)
-  pg_clipfrac_lower = masked_mean(unreduced_pg_clipfrac_lower, completion_mask)
+  unreduced_pg_clipfrac_lower = jnp.sum(
+      ((per_token_loss > pg_loss_3) & (advantages < 0.0)).astype(jnp.float32)
+      * completion_mask
+  )
 
   pg_loss_clipped_dual = jnp.minimum(pg_loss_3, per_token_loss)
   pg_losses = jnp.where(advantages < 0.0, pg_loss_clipped_dual, per_token_loss)
 
+  denominator = jnp.sum(completion_mask)
+  unreduced_pg_clipfrac = jnp.sum(
+      jnp.greater(pg_losses_2, pg_losses_1).astype(jnp.float32)
+      * completion_mask
+  )
+  unreduced_policy_loss = jnp.sum(pg_losses * completion_mask)
+
   aux = {
-      "pg_clipfrac": masked_mean(
-          jnp.greater(pg_losses_2, pg_losses_1), completion_mask
+      "pg_clipfrac": sft_utils.WeightedMetric(
+          unreduced_pg_clipfrac, denominator, min_denom=1.0
       ),
-      "pg_clipfrac_lower": pg_clipfrac_lower,
+      "pg_clipfrac_lower": sft_utils.WeightedMetric(
+          unreduced_pg_clipfrac_lower, denominator, min_denom=1.0
+      ),
   }
 
-  policy_loss = masked_mean(pg_losses, completion_mask)
-  loss = policy_loss
-
   if return_entropy:
-    entropy_loss = masked_mean(token_entropy, completion_mask)  # pyrefly: ignore[unbound-name]
-    loss = loss - entropy_coef * entropy_loss
-    aux["loss/entropy"] = entropy_loss
+    unreduced_entropy = jnp.sum(token_entropy * completion_mask)
+    unreduced_policy_loss = (
+        unreduced_policy_loss - entropy_coef * unreduced_entropy
+    )
+    aux["loss/entropy"] = sft_utils.WeightedMetric(
+        unreduced_entropy, denominator, min_denom=1.0
+    )
 
   # kl penalty term logic as before
   kl_coef = getattr(algo_config, "kl_coef", 0.0)
@@ -252,11 +263,18 @@ def ppo_policy_loss_fn(
         "kl",
         clamp_value=getattr(algo_config, "kl_clamp_value", None),
     )
-    kl_loss = masked_mean(kl, completion_mask)
-    loss = loss + kl_coef * kl_loss
-    aux["kl"] = kl_loss
+    unreduced_kl = jnp.sum(kl * completion_mask)
+    unreduced_policy_loss = unreduced_policy_loss + kl_coef * unreduced_kl
+    aux["kl"] = sft_utils.WeightedMetric(
+        unreduced_kl, denominator, min_denom=1.0
+    )
 
-  return loss, aux
+  return sft_utils.LossOutput(
+      primary_loss=sft_utils.WeightedMetric(
+          unreduced_policy_loss, denominator, min_denom=1.0
+      ),
+      aux_metrics=aux,
+  )
 
 
 @function_registry.register_value_loss_fn("ppo")
@@ -266,7 +284,7 @@ def ppo_value_loss_fn(
     clip_range_value: float | None,
     pad_id: int,
     eos_id: int,
-):
+) -> sft_utils.LossOutput:
   """Computes the value loss for PPO."""
 
   prompt_ids, completion_ids, completion_mask = (
@@ -280,7 +298,8 @@ def ppo_value_loss_fn(
 
   segment_ids = getattr(train_example, "segment_ids", None)
   if segment_ids is not None:
-    # For packed sequences, prompt_ids is empty and completion_ids holds the full sequence.
+    # For packed sequences, prompt_ids is empty and completion_ids holds the
+    # full sequence.
     # We predict values for token t using the model's output at t-1.
     logits_to_keep = completion_ids.shape[1] - 1
   else:
@@ -309,19 +328,32 @@ def ppo_value_loss_fn(
   vf_losses2 = jnp.square(vpred_clipped - returns)
 
   clipped_vf_losses = jnp.maximum(vf_losses1, vf_losses2)
-  # "token mean" style of normalisation.
-  vf_loss = 0.5 * masked_mean(clipped_vf_losses, completion_mask)
 
+  denominator = jnp.sum(completion_mask)
+  unreduced_vf_loss = 0.5 * jnp.sum(clipped_vf_losses * completion_mask)
+  unreduced_vpred_mean = jnp.sum(vpreds * completion_mask)
+  unreduced_vf_clipfrac = jnp.sum(
+      jnp.greater(vf_losses2, vf_losses1).astype(jnp.float32) * completion_mask
+  )
+  unreduced_return_mean = jnp.sum(returns * completion_mask)
+
+  primary_loss = sft_utils.WeightedMetric(
+      unreduced_vf_loss, denominator, min_denom=1.0
+  )
   aux = {
-      "vf_loss": vf_loss,
-      "vpred_mean": masked_mean(vpreds, completion_mask),
-      "vf_clipfrac": masked_mean(
-          jnp.greater(vf_losses2, vf_losses1), completion_mask
+      "vf_loss": primary_loss,
+      "vpred_mean": sft_utils.WeightedMetric(
+          unreduced_vpred_mean, denominator, min_denom=1.0
       ),
-      "return_mean": masked_mean(returns, completion_mask),
+      "vf_clipfrac": sft_utils.WeightedMetric(
+          unreduced_vf_clipfrac, denominator, min_denom=1.0
+      ),
+      "return_mean": sft_utils.WeightedMetric(
+          unreduced_return_mean, denominator, min_denom=1.0
+      ),
   }
 
-  return vf_loss, aux
+  return sft_utils.LossOutput(primary_loss=primary_loss, aux_metrics=aux)
 
 
 # ==============================================================================
@@ -337,7 +369,7 @@ def grpo_loss_fn(
     pad_id,
     eos_id,
     **kwargs,
-):
+) -> sft_utils.LossOutput:
   """GRPO loss function.
 
   The loss aims to maximize the expected advantage of the chosen actions while
@@ -354,7 +386,7 @@ def grpo_loss_fn(
     eos_id: The eos ID from.
 
   Returns:
-    A tuple containing the loss and an aux dictionary.
+    A LossOutput containing the loss and an aux dictionary.
   """
   beta = algo_config.beta
   epsilon = algo_config.epsilon
@@ -401,7 +433,8 @@ def grpo_loss_fn(
 
   seq_importance_ratio = per_token_logps - old_per_token_logps
   # Record KL divergence before clipping.
-  ppo_kl = masked_mean(-seq_importance_ratio, completion_mask)
+  token_denom = jnp.sum(completion_mask)
+  unreduced_ppo_kl = jnp.sum(-seq_importance_ratio * completion_mask)
 
   seq_importance_ratio = jnp.clip(seq_importance_ratio, max=20.0, min=-20.0)
 
@@ -429,8 +462,8 @@ def grpo_loss_fn(
 
   per_token_loss = jnp.maximum(pg_loss_1, pg_loss_2).astype(jnp.float32)
 
-  clipped_fraction = masked_mean(
-      jnp.greater(pg_loss_2, pg_loss_1), completion_mask
+  unreduced_clip_frac = jnp.sum(
+      jnp.greater(pg_loss_2, pg_loss_1).astype(jnp.float32) * completion_mask
   )
 
   # dual-clip ppo loss
@@ -442,11 +475,11 @@ def grpo_loss_fn(
   # pg_clipfrac_lower measures how often dual-clip ppo kicks in.
   # It kicks in when the standard clipped loss is larger than pg_loss_3
   # for instances with negative advantages.
-  unreduced_pg_clipfrac_lower = (
+  per_token_pg_clipfrac_lower = (
       (per_token_loss > pg_loss_3) & (adv < 0.0)
   ).astype(jnp.float32)
   pg_clipfrac_lower = common.aggregate_loss(
-      unreduced_pg_clipfrac_lower, completion_mask, loss_aggregation_mode
+      per_token_pg_clipfrac_lower, completion_mask, loss_aggregation_mode
   )
 
   pg_loss_clipped_dual = jnp.minimum(pg_loss_3, per_token_loss)
@@ -461,7 +494,7 @@ def grpo_loss_fn(
   if sampler_is_weights is not None:
     per_token_loss = per_token_loss * sampler_is_weights.astype(jnp.float32)
 
-  loss = common.aggregate_loss(
+  weighted_loss = common.aggregate_loss(
       per_token_loss, completion_mask, loss_aggregation_mode
   )
   # Per-token diagnostics — log only over assistant tokens (completion_mask).
@@ -483,11 +516,15 @@ def grpo_loss_fn(
       (jnp.abs(adv_broadcast) > 1e-8).astype(jnp.float32), completion_mask
   )
   aux = {
-      "kl": 0.0,
-      "kl_loss": 0.0,
-      "pg_loss": loss,
-      "pg_clipfrac": clipped_fraction,
-      "ppo_kl": ppo_kl,
+      "kl": sft_utils.WeightedMetric(jnp.array(0.0), jnp.array(1.0)),
+      "kl_loss": sft_utils.WeightedMetric(jnp.array(0.0), jnp.array(1.0)),
+      "pg_loss": weighted_loss,
+      "pg_clipfrac": sft_utils.WeightedMetric(
+          unreduced_clip_frac, token_denom, min_denom=1.0
+      ),
+      "ppo_kl": sft_utils.WeightedMetric(
+          unreduced_ppo_kl, token_denom, min_denom=1.0
+      ),
       "pg_clipfrac_lower": pg_clipfrac_lower,
       "is_ratio/mean": is_ratio_mean,
       "is_ratio/max": is_ratio_max,
@@ -518,22 +555,26 @@ def grpo_loss_fn(
         algo_config.kl_loss_mode,
         clamp_value=algo_config.kl_clamp_value,
     )
-    # Log mean KL.
-    aux["kl"] = jnp.astype(  # pyrefly: ignore[bad-assignment]
-        (kl * completion_mask).sum() / jnp.clip(completion_mask.sum(), min=1),
-        jnp.float32,
+    unreduced_kl = jnp.astype(jnp.sum(kl * completion_mask), jnp.float32)
+    aux["kl"] = sft_utils.WeightedMetric(
+        unreduced_kl, token_denom, min_denom=1.0
     )
     kl_loss = common.aggregate_loss(kl, completion_mask, loss_aggregation_mode)
     aux["kl_loss"] = kl_loss  # pyrefly: ignore[bad-assignment]
     if beta is not None and beta != 0.0:
-      loss = loss + beta * kl_loss
+      weighted_loss = sft_utils.WeightedMetric(
+          weighted_loss.unreduced_sum + beta * kl_loss.unreduced_sum,
+          weighted_loss.denominator,
+          eps=weighted_loss.eps,
+          min_denom=weighted_loss.min_denom,
+      )
 
   entropy_loss = common.aggregate_loss(
       token_entropy, completion_mask, loss_aggregation_mode
   )
   aux["entropy"] = entropy_loss
 
-  return loss, aux
+  return sft_utils.LossOutput(primary_loss=weighted_loss, aux_metrics=aux)
 
 
 @function_registry.register_advantage_estimator("grpo")

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -106,6 +106,7 @@ class TrainExample:
   old_per_token_logps: jax.Array | None
   segment_ids: jax.Array | None = None
   segment_positions: jax.Array | None = None
+  is_update_step: jax.Array | None = None
   # Truncated importance-sampling correction weights for off-policy
   # correction between the rollout sampler and the trainer. Per-token,
   # detached, multiplied into the policy-gradient loss BEFORE aggregation
@@ -676,7 +677,7 @@ def aggregate_loss(
     completion_mask: jax.Array,
     loss_agg_mode: str,
     **kwargs: Any,
-) -> jax.Array:
+) -> utils.WeightedMetric:
   """Aggregate loss based on the loss aggregation mode.
 
   Args:
@@ -693,15 +694,17 @@ def aggregate_loss(
   if loss_agg_mode == "token-mean":
     # sum all the token loss, and average by total number of completion tokens
     # in the batch
-    loss = (per_token_loss * completion_mask).sum() / (
-        jnp.clip(completion_mask.sum(), min=1)
-    )
+    unreduced_sum = (per_token_loss * completion_mask).sum()
+    denominator = completion_mask.sum()
+    min_denom = 1.0
   elif loss_agg_mode == "sequence-mean-token-mean":
     seq_mask = completion_mask.sum(axis=-1)  # per-sequence token count
     seq_loss = ((per_token_loss * completion_mask).sum(axis=-1)) / jnp.clip(
-        seq_mask, min=1
+        seq_mask, min=1.0
     )
-    loss = seq_loss.mean()
+    unreduced_sum = seq_loss.sum()
+    denominator = per_token_loss.shape[0]
+    min_denom = 1.0
   elif loss_agg_mode == "sequence-mean-token-scale":
     # Look up custom normalization factor, default to max response length.
     norm = _check_get_norm(kwargs, per_token_loss.shape[-1])
@@ -710,20 +713,23 @@ def aggregate_loss(
     seq_loss = (per_token_loss * completion_mask).sum(axis=-1) / jnp.clip(
         norm, min=1e-6
     )
-    loss = seq_loss.mean()
+    unreduced_sum = seq_loss.sum()
+    denominator = per_token_loss.shape[0]
+    min_denom = 1.0
   elif loss_agg_mode == "seq-mean-token-sum":
     # 1) sum token losses within each sequence
     # 2) average only across sequences that have at least one valid token
     seq_loss = (per_token_loss * completion_mask).sum(axis=-1)
     seq_mask = (completion_mask.sum(axis=-1) > 0).astype(jnp.float32)
-    loss = (seq_loss * seq_mask).sum() / jnp.clip(seq_mask.sum(), min=1e-6)
+    unreduced_sum = (seq_loss * seq_mask).sum()
+    denominator = seq_mask.sum()
+    min_denom = 1e-6
   elif loss_agg_mode == "sequence-mean-token-sum-norm":
     # Get custom normalization factor from kwargs, default to batch size.
     norm = _check_get_norm(kwargs, per_token_loss.shape[0])
-
-    # Sum the per-sequence sums and normalize
-    # TODO(sizhi): Experiment with loss in precision if loss is fp16.
-    loss = (per_token_loss * completion_mask).sum() / jnp.clip(norm, min=1e-6)
+    unreduced_sum = (per_token_loss * completion_mask).sum()
+    denominator = norm
+    min_denom = 1e-6
   else:
     raise ValueError(
         f"Unsupported loss aggregation mode: {loss_agg_mode}. Supported modes:"
@@ -731,7 +737,11 @@ def aggregate_loss(
         " 'sequence-mean-token-scale', 'seq-mean-token-sum',"
         " 'sequence-mean-token-sum-norm'."
     )
-  return loss
+  return utils.WeightedMetric(
+      jnp.asarray(unreduced_sum, dtype=jnp.float32),
+      jnp.asarray(denominator, dtype=jnp.float32),
+      min_denom=min_denom,
+  )
 
 
 def compute_entropy_from_logits(logits: jax.Array) -> jax.Array:

--- a/tunix/rl/inference/inference_worker.py
+++ b/tunix/rl/inference/inference_worker.py
@@ -56,6 +56,8 @@ class InferenceWorker:
       pad_id: int,
       eos_id: int,
       temperature: float = 1.0,
+      segment_ids: jax.Array | None = None,
+      segment_positions: jax.Array | None = None,
   ) -> jax.Array:
     graphdef, state = self._model_states.get("reference")  # pyrefly: ignore[not-iterable]
     if graphdef is None:
@@ -69,6 +71,8 @@ class InferenceWorker:
         eos_id=eos_id,
         stop_gradient=True,
         temperature=temperature,
+        segment_ids=segment_ids,
+        segment_positions=segment_positions,
     )
 
   def get_values(

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -988,6 +988,8 @@ class RLCluster:
       pad_id: int,
       eos_id: int,
       micro_batch_size: int | None = None,
+      segment_ids: jax.Array | None = None,
+      segment_positions: jax.Array | None = None,
   ) -> jax.Array:
     """Gets the per-token logps of the reference model."""
     batch_size = prompt_tokens.shape[0]
@@ -1008,6 +1010,22 @@ class RLCluster:
           completion_tokens,
           self.cluster_config.training_config.data_sharding_axis,
       )
+      dest_segment_ids = (
+          None
+          if segment_ids is None
+          else sharding_utils.shard_input(
+              segment_ids,
+              self.cluster_config.training_config.data_sharding_axis,
+          )
+      )
+      dest_segment_positions = (
+          None
+          if segment_positions is None
+          else sharding_utils.shard_input(
+              segment_positions,
+              self.cluster_config.training_config.data_sharding_axis,
+          )
+      )
       self._maybe_load_model_from_cpu(
           self.inference_worker.get_model("reference"), Role.REFERENCE
       )
@@ -1023,6 +1041,16 @@ class RLCluster:
                 pad_id,
                 eos_id,
                 temperature=temperature,
+                segment_ids=(
+                    None
+                    if dest_segment_ids is None
+                    else dest_segment_ids[batch_slice]
+                ),
+                segment_positions=(
+                    None
+                    if dest_segment_positions is None
+                    else dest_segment_positions[batch_slice]
+                ),
             )
         )
       ref_per_token_logps = jnp.concatenate(outs, axis=0)
@@ -1073,6 +1101,8 @@ class RLCluster:
       eos_id: int,
       micro_batch_size: int | None = None,
       temperature: float | None = None,
+      segment_ids: jax.Array | None = None,
+      segment_positions: jax.Array | None = None,
   ) -> jax.Array:
     """Gets per-token logps from the actor model on the trainer side.
 
@@ -1103,6 +1133,22 @@ class RLCluster:
       dest_completion_tokens = sharding_utils.shard_input(
           completion_tokens,
           self.cluster_config.training_config.data_sharding_axis,
+      )
+      dest_segment_ids = (
+          None
+          if segment_ids is None
+          else sharding_utils.shard_input(
+              segment_ids,
+              self.cluster_config.training_config.data_sharding_axis,
+          )
+      )
+      dest_segment_positions = (
+          None
+          if segment_positions is None
+          else sharding_utils.shard_input(
+              segment_positions,
+              self.cluster_config.training_config.data_sharding_axis,
+          )
       )
 
       # Use the anchor (start-of-global-step) actor weights so old_per_token_logps
@@ -1139,6 +1185,16 @@ class RLCluster:
                 stop_gradient=True,
                 temperature=temperature,
                 chunk_size=self.cluster_config.training_config.compute_logps_chunk_size,
+                segment_ids=(
+                    None
+                    if dest_segment_ids is None
+                    else dest_segment_ids[batch_slice]
+                ),
+                segment_positions=(
+                    None
+                    if dest_segment_positions is None
+                    else dest_segment_positions[batch_slice]
+                ),
             )
         )
       actor_per_token_logps = jnp.concatenate(outs, axis=0)

--- a/tunix/rl/rl_learner.py
+++ b/tunix/rl/rl_learner.py
@@ -719,12 +719,24 @@ class RLLearner(abc.ABC, Generic[TConfig]):
 
     train_data_gen = queue_iterator()
     if self._training_config.max_seq_token_per_tpu is not None:
+      mesh = self.rl_cluster.cluster_config.role_to_mesh[
+          rl_cluster_lib.Role.ACTOR
+      ]
+      # The packed batch size must be a multiple of the FSDP and DP mesh axis
+      # sizes.
+      pack_size = mesh.shape.get("fsdp", 1) * mesh.shape.get("dp", 1)
+
       logging.info(
-          "Using sequence packing with max_seq_token_per_tpu: %d",
+          "Using sequence packing with max_seq_token_per_tpu: %d, "
+          " pack_size: %d",
           self._training_config.max_seq_token_per_tpu,
+          pack_size,
       )
       train_data_gen = rl_utils.pack_sequences(
-          train_data_gen, self._training_config.max_seq_token_per_tpu
+          train_data_gen,
+          self._training_config.max_seq_token_per_tpu,
+          target_items_per_update=grad_acc_steps,
+          num_packs=pack_size,
       )
 
     curr_eval_ds = None

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -16,7 +16,7 @@
 
 from itertools import chain  # pylint: disable=g-importing-member
 import operator
-from typing import Any, Iterator, List, Optional
+from typing import Any, Iterator, Mapping, Optional, Sequence
 
 from absl import logging
 from flax import nnx
@@ -162,7 +162,7 @@ def get_batch_slice(tree: Any, batch_slice: slice) -> Any:
   )
 
 
-def merge_micro_batches(batches: List[dict[str, Any]]) -> dict[str, Any]:
+def merge_micro_batches(batches: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
   """Merges micro-batch dictionaries into a single batch.
 
   Concatenates values from a list of micro-batch dicts. Values are concatenated
@@ -178,11 +178,12 @@ def merge_micro_batches(batches: List[dict[str, Any]]) -> dict[str, Any]:
     return {}
 
   merged = {}
-
-  for key in batches[0].keys():
+  first_batch, *_ = batches
+  for key in first_batch.keys():
     all_values = [item[key] for item in batches]
+    first_value, *_ = all_values
 
-    if isinstance(all_values[0], list):
+    if isinstance(first_value, list):
       merged[key] = list(chain.from_iterable(all_values))
     else:
       merged[key] = tree_util.tree_map(
@@ -314,6 +315,9 @@ def unpad_train_example(example: common.TrainExample) -> list[dict[str, Any]]:
     p_len = int(np.sum(p_mask[i]))
     c_len = int(np.sum(c_mask[i]))
 
+    # `policy_version` is per-row: row `i` of the input maps to scalar
+    # `policy_version_np[i]`. We slice with `i:i+1` to keep a 1-D shape so that
+    # `pack_sequences` can stack scalars from multiple items unambiguously.
     item = {
         "prompt_ids": p_ids[i, -p_len:] if p_len > 0 else p_ids[i, :0],
         "prompt_mask": p_mask[i, -p_len:] if p_len > 0 else p_mask[i, :0],
@@ -321,34 +325,82 @@ def unpad_train_example(example: common.TrainExample) -> list[dict[str, Any]]:
         "completion_mask": c_mask[i, :c_len],
         "advantages": adv[i, :c_len] if adv_is_per_token else adv[i],
         "adv_is_per_token": adv_is_per_token,
-        "ref_per_token_logps": ref_logps[i, :c_len] if has_ref else None,  # pyrefly: ignore[unbound-name]
-        "old_per_token_logps": old_logps[i, :c_len] if has_old else None,  # pyrefly: ignore[unbound-name]
-        "returns": returns_np[i, :c_len] if has_returns else None,  # pyrefly: ignore[unbound-name]
-        "old_values": old_values_np[i, :c_len] if has_old_values else None,  # pyrefly: ignore[unbound-name]
-        "policy_version": policy_version_np if has_policy_version else None,  # pyrefly: ignore[unbound-name]
+        "ref_per_token_logps": ref_logps[i, :c_len] if has_ref else None,
+        "old_per_token_logps": old_logps[i, :c_len] if has_old else None,
+        "returns": returns_np[i, :c_len] if has_returns else None,
+        "old_values": old_values_np[i, :c_len] if has_old_values else None,
+        "policy_version": (
+            policy_version_np[i : i + 1] if has_policy_version else None
+        ),
     }
     res.append(item)
   return res
 
 
 def pack_sequences(
-    item_iterator: Iterator[list[common.TrainExample]],
+    item_iterator: Iterator[Sequence[common.TrainExample]],
     max_token_budget: int,
     pad_id: int = 0,
+    target_items_per_update: int | None = None,
+    num_packs: int = 1,
 ) -> Iterator[list[common.TrainExample]]:
-  """Packs a stream of TrainExamples into 1D sequences up to a token budget."""
-  buffer = []
-  current_tokens = 0
-  example_cls = common.TrainExample
+  """Packs a stream of TrainExamples into 1D sequences up to a token budget and stacks them into 2D batches of shape [num_packs, max_token_budget].
 
-  def _flush_buffer() -> list[common.TrainExample]:
-    nonlocal buffer, current_tokens
-    if not buffer:
-      return []
+  Args:
+    item_iterator: Stream of lists of TrainExamples.
+    max_token_budget: The maximum number of tokens in a packed sequence.
+    pad_id: The vocabulary id used for padding.
+    target_items_per_update: Accumulate items over microbatches, and set `is_update_step=True` when reaching threshold.
+    num_packs: Group into chunks of size num_packs. Emits batches of shape [num_packs, sequence_length].
 
-    # TODO(noghabi): Pad to the next power of 2 instead of user defined
-    # max_token_budget if the seq is short. This will incur an additional
-    # compilation on trainer side, but also will result in faster compute.
+  Yields:
+    A stream of packed sequences, stacked in chunks of [num_packs, ...].
+  """
+  accumulated_items = 0
+
+  def _flush_pack(pack_items, example_cls, first_item) -> common.TrainExample:
+    has_policy_version = first_item.get("policy_version") is not None
+    kwargs = {}
+    tracked_per_token_keys = []
+    
+    if first_item.get("ref_per_token_logps") is not None:
+      tracked_per_token_keys.append("ref_per_token_logps")
+    if first_item.get("old_per_token_logps") is not None:
+      tracked_per_token_keys.append("old_per_token_logps")
+    if first_item.get("returns") is not None:
+      tracked_per_token_keys.append("returns")
+    if first_item.get("old_values") is not None:
+      tracked_per_token_keys.append("old_values")
+
+    if not pack_items:
+      p_ids_arr = jnp.zeros((1, 0), dtype=jnp.int32)
+      p_mask_arr = jnp.zeros((1, 0), dtype=jnp.int32)
+      c_ids_arr = jnp.full((1, max_token_budget), pad_id, dtype=jnp.int32)
+      c_mask_arr = jnp.zeros((1, max_token_budget), dtype=jnp.int32)
+      adv_arr = jnp.zeros((1, max_token_budget), dtype=jnp.float32)
+      seg_arr = jnp.zeros((1, max_token_budget), dtype=jnp.int32)
+      pos_arr = jnp.zeros((1, max_token_budget), dtype=jnp.int32)
+      
+      kwargs.update(
+          prompt_ids=p_ids_arr,
+          prompt_mask=p_mask_arr,
+          completion_ids=c_ids_arr,
+          completion_mask=c_mask_arr,
+          advantages=adv_arr,
+          ref_per_token_logps=None,
+          old_per_token_logps=None,
+          segment_ids=seg_arr,
+          segment_positions=pos_arr,
+      )
+      for k in tracked_per_token_keys:
+        kwargs[k] = jnp.zeros((1, max_token_budget), dtype=jnp.float32)
+      if has_policy_version:
+        kwargs["policy_version"] = first_item["policy_version"]
+      return example_cls(**kwargs)  # pytype: disable=wrong-keyword-args
+
+    current_tokens = sum(
+        len(it["prompt_ids"]) + len(it["completion_ids"]) for it in pack_items
+    )
     pad_len = max_token_budget - current_tokens
 
     packed_c_ids = []
@@ -357,13 +409,18 @@ def pack_sequences(
     packed_segment_ids = []
     packed_positions = []
 
-    tracked_per_token_keys = [
-        k for k in _OPTIONAL_PER_TOKEN_KEYS if buffer[0].get(k) is not None
-    ]
     per_token_feature_buffers = {k: [] for k in tracked_per_token_keys}
-    has_policy_version = buffer[0].get("policy_version") is not None
 
-    for i, item in enumerate(buffer, start=1):
+    if has_policy_version:
+      versions = [
+          int(np.asarray(item["policy_version"]).item()) for item in pack_items
+      ]
+      assert all(v == versions[0] for v in versions), (
+          "pack_sequences invariant violation: heterogeneous policy_versions"
+          f" within a single pack: {versions}"
+      )
+
+    for i, item in enumerate(pack_items, start=1):
       p_ids = item["prompt_ids"]
       c_ids = item["completion_ids"]
       seq_len = len(p_ids) + len(c_ids)
@@ -371,7 +428,6 @@ def pack_sequences(
       packed_c_ids.extend([p_ids, c_ids])
       packed_c_mask.extend([np.zeros_like(p_ids), item["completion_mask"]])
 
-      # Expand advantage to shape [c_len] to match completion length
       if item["adv_is_per_token"]:
         packed_adv.extend([
             np.zeros_like(p_ids, dtype=np.float32),
@@ -396,11 +452,9 @@ def pack_sequences(
       arr = np.concatenate(arr_list) if arr_list else np.array([])
       return np.pad(arr, (0, length), constant_values=val)
 
-    # Empty prompt arrays
     p_ids_arr = jnp.zeros((1, 0), dtype=jnp.int32)
     p_mask_arr = jnp.zeros((1, 0), dtype=jnp.int32)
 
-    # Pad all lists by pad_len
     c_ids_arr = jnp.array(_pad(packed_c_ids, pad_id, pad_len))[None, :]
     c_mask_arr = jnp.array(_pad(packed_c_mask, 0, pad_len))[None, :]
     adv_arr = jnp.array(_pad(packed_adv, 0.0, pad_len))[None, :]
@@ -419,47 +473,99 @@ def pack_sequences(
         completion_ids=c_ids_arr,
         completion_mask=c_mask_arr,
         advantages=adv_arr,
-        ref_per_token_logps=None,  # Will be overridden if present in tracked_per_token_keys.
-        old_per_token_logps=None,  # Will be overridden if present in tracked_per_token_keys.
+        ref_per_token_logps=None,
+        old_per_token_logps=None,
         segment_ids=seg_arr,
         segment_positions=pos_arr,
     )
     for k in tracked_per_token_keys:
       kwargs[k] = per_token_features[k]
+
     if has_policy_version:
-      kwargs["policy_version"] = buffer[0]["policy_version"]
+      kwargs["policy_version"] = pack_items[0]["policy_version"]
 
-    packed_example = example_cls(**kwargs)  # pytype: disable=wrong-keyword-args
-
-    buffer.clear()
-    current_tokens = 0
-    return [packed_example]
+    return example_cls(**kwargs)  # pytype: disable=wrong-keyword-args
 
   for item_list in item_iterator:
+    accumulated_items += 1
+
+    all_unpadded_items = []
+    example_cls = common.TrainExample
     for example in item_list:
       example_cls = type(example)
-      unpadded_items = unpad_train_example(example)
-      for item in unpadded_items:
-        tokens = len(item["prompt_ids"]) + len(item["completion_ids"])
+      all_unpadded_items.extend(unpad_train_example(example))
 
-        # If a single item is strictly larger than budget, we skip or truncate.
-        # Ideally, budget > max_prompt_length + max_response_length.
-        if tokens > max_token_budget:
-          logging.warning(
-              "Skipping single sequence with length %d exceeding budget %d",
-              tokens,
-              max_token_budget,
-          )
-          continue
+    if not all_unpadded_items:
+      continue
 
-        if current_tokens + tokens > max_token_budget:
-          yield _flush_buffer()
+    first_item, *_ = all_unpadded_items
 
-        buffer.append(item)
-        current_tokens += tokens
+    packs = []
+    current_pack_items = []
+    current_tokens = 0
 
-  if buffer:
-    yield _flush_buffer()
+    def _version_changed(item: Mapping[str, Any]) -> bool:
+      if not current_pack_items:
+        return False
+      a = current_pack_items[0].get("policy_version")
+      b = item.get("policy_version")
+      if a is None or b is None:
+        return False
+      return int(np.asarray(a).item()) != int(np.asarray(b).item())
+
+    for item in all_unpadded_items:
+      tokens = len(item["prompt_ids"]) + len(item["completion_ids"])
+
+      if tokens > max_token_budget:
+        logging.warning(
+            "Skipping single sequence with length %d exceeding budget %d",
+            tokens, max_token_budget,
+        )
+        continue
+
+      if current_tokens + tokens > max_token_budget or _version_changed(item):
+        packs.append(current_pack_items)
+        current_pack_items = []
+        current_tokens = 0
+
+      current_pack_items.append(item)
+      current_tokens += tokens
+
+    if current_pack_items:
+      packs.append(current_pack_items)
+
+    if not packs:
+      continue
+
+    while len(packs) % num_packs != 0:
+      packs.append([])
+
+    chunks = [packs[i : i + num_packs] for i in range(0, len(packs), num_packs)]
+
+    for chunk_idx, chunk in enumerate(chunks):
+      chunk_examples = []
+      for p in chunk:
+        chunk_examples.append(_flush_pack(p, example_cls, first_item))
+
+      merged_example = jax.tree.map(
+          lambda first_x, *rest_xs: None
+          if first_x is None
+          else jnp.concatenate((first_x, *rest_xs), axis=0),
+          *chunk_examples,
+      )
+
+      is_update = False
+      if target_items_per_update and accumulated_items >= target_items_per_update:
+        if chunk_idx == len(chunks) - 1:
+          is_update = True
+          accumulated_items = 0
+
+      merged_example = merged_example.replace(
+          is_update_step=jnp.array([is_update], dtype=jnp.bool_)
+      )
+
+      yield [merged_example]
+
 
 
 VERIFY_UPDATE_PARAMS_KEY = "VERIFY_UPDATE_PARAMS_SRC_TO_TGT_MODULE_NAME"

--- a/tunix/sft/dpo/dpo_trainer.py
+++ b/tunix/sft/dpo/dpo_trainer.py
@@ -26,17 +26,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
+
 # TODO(abheesht): We should move TokenizerAdapter outside `generate`.
 from tunix.generate import tokenizer_adapter
 from tunix.rl import common
 from tunix.sft import peft_trainer
+from tunix.sft import utils as sft_utils
 from typing_extensions import override
 
-
 RawImageType = (
-    str
-    | np.ndarray
-    | list[str | np.ndarray | list[str | np.ndarray] | None]
+    str | np.ndarray | list[str | np.ndarray | list[str | np.ndarray] | None]
 )
 
 
@@ -450,7 +449,7 @@ def dpo_loss_fn(
     label_smoothing: float = 0.0,
     enable_prompt_loss_orpo: bool = False,
     average_log_prob_orpo: bool = False,
-) -> tuple[jax.Array, dict[str, jax.Array]]:
+) -> sft_utils.LossOutput:
   """DPO/ORPO loss function.
 
   Args:
@@ -535,19 +534,47 @@ def dpo_loss_fn(
     # Compute odds ratio for logging
     odds_ratio = jnp.exp(log_odds)
 
+    denominator = jnp.array(batch_size, dtype=jnp.float32)
     aux = {
-        "rewards/chosen": chosen_rewards.mean(),
-        "rewards/rejected": rejected_rewards.mean(),
-        "rewards/margin": (chosen_rewards - rejected_rewards).mean(),
-        "rewards/accuracy": (chosen_rewards > rejected_rewards).mean(),
-        "log_probs/chosen": chosen_logps.mean(),
-        "log_probs/rejected": rejected_logps.mean(),
-        "odds_ratio": odds_ratio.mean(),
-        "sft_loss": sft_loss.mean(),
-        "or_loss": or_loss.mean(),
+        "rewards/chosen": sft_utils.WeightedMetric(
+            chosen_rewards.sum(), denominator, min_denom=1.0
+        ),
+        "rewards/rejected": sft_utils.WeightedMetric(
+            rejected_rewards.sum(), denominator, min_denom=1.0
+        ),
+        "rewards/margin": sft_utils.WeightedMetric(
+            (chosen_rewards - rejected_rewards).sum(),
+            denominator,
+            min_denom=1.0,
+        ),
+        "rewards/accuracy": sft_utils.WeightedMetric(
+            (chosen_rewards > rejected_rewards).sum(),
+            denominator,
+            min_denom=1.0,
+        ),
+        "log_probs/chosen": sft_utils.WeightedMetric(
+            chosen_logps.sum(), denominator, min_denom=1.0
+        ),
+        "log_probs/rejected": sft_utils.WeightedMetric(
+            rejected_logps.sum(), denominator, min_denom=1.0
+        ),
+        "odds_ratio": sft_utils.WeightedMetric(
+            odds_ratio.sum(), denominator, min_denom=1.0
+        ),
+        "sft_loss": sft_utils.WeightedMetric(
+            sft_loss.sum(), denominator, min_denom=1.0
+        ),
+        "or_loss": sft_utils.WeightedMetric(
+            or_loss.sum(), denominator, min_denom=1.0
+        ),
     }
 
-    return total_loss.mean(), aux
+    return sft_utils.LossOutput(
+        primary_loss=sft_utils.WeightedMetric(
+            total_loss.sum(), denominator, min_denom=1.0
+        ),
+        aux_metrics=aux,
+    )
   else:
     # DPO loss
     chosen_log_ratio = chosen_logps
@@ -566,16 +593,39 @@ def dpo_loss_fn(
     chosen_rewards = beta * chosen_log_ratio
     rejected_rewards = beta * rejected_log_ratio
 
+    batch_size = train_example.completion_mask.shape[0] // 2
+    denominator = jnp.array(batch_size, dtype=jnp.float32)
     aux = {
-        "rewards/chosen": chosen_rewards.mean(),
-        "rewards/rejected": rejected_rewards.mean(),
-        "rewards/margin": (chosen_rewards - rejected_rewards).mean(),
-        "rewards/accuracy": (chosen_rewards > rejected_rewards).mean(),
-        "log_probs/chosen": chosen_logps.mean(),
-        "log_probs/rejected": rejected_logps.mean(),
+        "rewards/chosen": sft_utils.WeightedMetric(
+            chosen_rewards.sum(), denominator, min_denom=1.0
+        ),
+        "rewards/rejected": sft_utils.WeightedMetric(
+            rejected_rewards.sum(), denominator, min_denom=1.0
+        ),
+        "rewards/margin": sft_utils.WeightedMetric(
+            (chosen_rewards - rejected_rewards).sum(),
+            denominator,
+            min_denom=1.0,
+        ),
+        "rewards/accuracy": sft_utils.WeightedMetric(
+            (chosen_rewards > rejected_rewards).sum(),
+            denominator,
+            min_denom=1.0,
+        ),
+        "log_probs/chosen": sft_utils.WeightedMetric(
+            chosen_logps.sum(), denominator, min_denom=1.0
+        ),
+        "log_probs/rejected": sft_utils.WeightedMetric(
+            rejected_logps.sum(), denominator, min_denom=1.0
+        ),
     }
 
-    return losses.mean(), aux
+    return sft_utils.LossOutput(
+        primary_loss=sft_utils.WeightedMetric(
+            losses.sum(), denominator, min_denom=1.0
+        ),
+        aux_metrics=aux,
+    )
 
 
 def _generate_ids_and_masks(
@@ -667,9 +717,9 @@ def process_dpo_record(
   Args:
       record: A dictionary, containing "prompts", "images", "chosen_responses",
         "rejected_responses" as keys. For text fields, the values can be a
-        single string, or a list of strings. For `"images"`, the fields can be
-        a path (str), a NumPy array, list of paths, list of arrays, list of
-        lists of paths/arrays, or just None.
+        single string, or a list of strings. For `"images"`, the fields can be a
+        path (str), a NumPy array, list of paths, list of arrays, list of lists
+        of paths/arrays, or just None.
       tokenizer: The tokenizer or processor to use for converting text into
         token IDs.
       max_prompt_length: The maximum length for the tokenized prompts. Any

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -133,6 +133,17 @@ class MetricsBuffer:
     return np.mean(np.array([np.array(x) for x in self.losses]))
 
 
+def _compute_legacy_aux(loss_output: utils.LossOutput) -> Dict[str, Any]:
+  """Computes legacy aux metrics from a LossOutput."""
+  legacy_aux = {}
+  for k, v in loss_output.aux_metrics.items():
+    if isinstance(v, utils.WeightedMetric):
+      legacy_aux[k] = v.compute()
+    else:
+      legacy_aux[k] = v
+  return legacy_aux
+
+
 def _calculate_global_batch_size(train_example: Any) -> int:
   """Calculates the global batch size from a training example.
 
@@ -164,6 +175,98 @@ def _calculate_global_batch_size(train_example: Any) -> int:
   )
 
 
+class GradientAccumulator(nnx.Module):
+  """Accumulates gradients over multiple micro-steps.
+
+  Unifies standard (unweighted) micro-batch averaging with sequence packing
+  (weighted, denom-aware) accumulation.
+
+  Averaging behavior (optax.MultiSteps semantics):
+    When `add(grads)` is called without a denom, each micro-step implicitly
+    adds 1.0 to the denominator. `get()` computes `Σ_grads / Σ_1`, which
+    is the exact mean of the micro-step gradients. This is mathematically
+    equivalent to a single optimization step on a batch of size `B =
+    micro_batch_size * grad_acc_steps` when the loss is a mean-reduction
+    (e.g., standard cross-entropy).
+
+  Packing-aware behavior (Sum of Grads / Sum of Sizes):
+    Under sequence packing, each yielded micro-batch contains a varying
+    number of valid target tokens or training examples. The loss is
+    computed as an *unreduced sum* over the packed batch. Callers pass the
+    true size of the pack via `add(grads, denom=size)`. `get()` computes
+    `Σ_grad(sum_loss_i) / Σ_size_i`, recovering the true global mean
+    gradient across all items in the accumulated batch, avoiding the bias
+    introduced by averaging pre-scaled micro-batch gradients of unequal
+    sizes.
+  """
+
+  def __init__(self, model: nnx.Module, wrt: type[nnx.Variable]):
+    state = nnx.state(model, wrt)
+    self.grads = nnx.data(jax.tree_util.tree_map(jnp.zeros_like, state))
+    self.denom = nnx.Variable(jnp.zeros((), dtype=jnp.float32))
+
+  def add(self, grads: Any, denom: jax.Array | None = None):
+    def _add(acc_var, g_var):
+      g = g_var[...] if isinstance(g_var, nnx.Variable) else g_var
+      acc_var[...] = acc_var[...] + g
+
+    jax.tree_util.tree_map(
+        _add,
+        self.grads,
+        grads,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+
+    if denom is None:
+      denom_val = jnp.asarray(1.0, dtype=jnp.float32)
+    else:
+      denom_val = denom.astype(jnp.float32)
+    self.denom[...] = self.denom[...] + denom_val
+
+  def get(self):
+    scale = 1.0 / jnp.maximum(self.denom[...], jnp.asarray(1.0, jnp.float32))
+
+    return jax.tree_util.tree_map(
+        lambda v: type(v)(v[...] * scale.astype(v[...].dtype)),
+        self.grads,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+
+  def reset(self):
+    def _zero_in_place(v):
+      v[...] = jnp.zeros_like(v[...])
+
+    jax.tree_util.tree_map(
+        _zero_in_place,
+        self.grads,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+    self.denom[...] = jnp.zeros_like(self.denom[...])
+
+
+def _promote_opt_state_floats_to_float32(optimizer: nnx.Optimizer) -> None:
+  """Cast the optimizer state's floating-point leaves to float32 in-place.
+
+  Args:
+    optimizer: The nnx.Optimizer instance whose state will be modified.
+  """
+
+  def _cast(v):
+    if isinstance(v, nnx.Variable):
+      val = v.value
+      if (
+          hasattr(val, "dtype")
+          and jnp.issubdtype(val.dtype, jnp.floating)
+          and val.dtype != jnp.float32
+      ):
+        v.value = val.astype(jnp.float32)
+
+  opt_state = nnx.state(optimizer, nnx.optimizer.OptState)
+  jax.tree_util.tree_map(
+      _cast, opt_state, is_leaf=lambda x: isinstance(x, nnx.Variable)
+  )
+
+
 class PeftTrainer:
   """PEFT trainer for LoRA. Only LoRA parameters are updated.
 
@@ -174,6 +277,8 @@ class PeftTrainer:
       use `optax.schedules.inject_hyperparams` to inject learning rate as a
       hyperparameter. For example: ``optimizer =
       optax.schedules.inject_hyperparams(optax.sgd)(learning_rate=learning_rate_schedule)``
+    grad_accumulator: The gradient accumulator to use for accumulating gradients
+      over multiple micro-steps.
     loss_fn: The loss function to use.
     eval_loss_fn: The loss function to use for evaluation.
     gen_model_input_fn: The function to generate model input from training
@@ -186,7 +291,7 @@ class PeftTrainer:
     data_hooks: The data hooks to use.
   """
 
-  supports_sequence_packing = False
+  supports_sequence_packing = True
 
   def __init__(
       self,
@@ -209,14 +314,13 @@ class PeftTrainer:
     self.model = model
     self.config = training_config
     self._lora_enabled = utils.is_lora_enabled(self.model)
-    if training_config.gradient_accumulation_steps is not None:
-      optimizer = optax.MultiSteps(  # pyrefly: ignore[bad-assignment]
-          optimizer, training_config.gradient_accumulation_steps
-      )
-    if self._lora_enabled:
-      self.optimizer = nnx.Optimizer(self.model, optimizer, wrt=nnx.LoRAParam)
-    else:
-      self.optimizer = nnx.Optimizer(self.model, optimizer, wrt=nnx.Param)
+    wrt_target = nnx.LoRAParam if self._lora_enabled else nnx.Param
+    self.optimizer = nnx.Optimizer(self.model, optimizer, wrt=wrt_target)
+    # Promote floating-point leaves to float32 in-place to match the dtype of
+    # the optimizer update function branch (which is float32 due to
+    # `optax.inject_hyperparams`).
+    _promote_opt_state_floats_to_float32(self.optimizer)
+    self.grad_accumulator = GradientAccumulator(self.model, wrt_target)
 
     self.loss_fn = _default_loss_fn
     self.eval_loss_fn = _default_loss_fn
@@ -299,7 +403,8 @@ class PeftTrainer:
   def with_loss_fn(
       self,
       loss_fn: Callable[
-          Concatenate[nnx.Module, P], ArrayLike | Tuple[ArrayLike, Any]
+          Concatenate[nnx.Module, P],
+          ArrayLike | Tuple[ArrayLike, Any] | utils.LossOutput,
       ],
       has_aux: bool = False,
   ):
@@ -329,14 +434,21 @@ class PeftTrainer:
     return self
 
   def _train_step(
-      self, model: nnx.Module, optimizer: nnx.Optimizer, inputs: Any
+      self,
+      model: nnx.Module,
+      optimizer: nnx.Optimizer,
+      grad_accumulator: GradientAccumulator,
+      inputs: Any,
+      is_update_step: jax.Array,
   ) -> Tuple[ArrayLike, Any | None, ArrayLike]:
     """Main body for one train step.
 
     Args:
       model: The model to train.
       optimizer: The optimizer to use.
+      grad_accumulator: The gradient accumulator to use.
       inputs: The training input.
+      is_update_step: Whether to update the model.
 
     Returns:
       A tuple containing the loss, auxiliary data (or None if has_aux is False),
@@ -344,26 +456,83 @@ class PeftTrainer:
     """
     inputs = self.gen_model_input_fn(inputs)
 
+    @functools.wraps(self.loss_fn)
+    def diff_fn(model, *args, **kwargs):
+      out = self.loss_fn(model, *args, **kwargs)
+      if isinstance(out, utils.LossOutput):
+        return out.primary_loss.unreduced_sum, out
+      elif self._has_aux:
+        return out[0], out[1]
+      else:
+        return out, None
+
     grad_fn = nnx.value_and_grad(
-        self.loss_fn,
+        diff_fn,
         argnums=nnx.DiffState(0, nnx.LoRAParam) if self._lora_enabled else 0,
-        has_aux=self._has_aux,
+        has_aux=True,
     )
-    out, grads = grad_fn(model, **inputs)
-    grad_norm = optax.global_norm(grads)
-    optimizer.update(model, grads)
-    if self._has_aux:
-      loss, aux = out
-      return loss, aux, grad_norm
+    (loss_val, aux), grads = grad_fn(model, **inputs)
+
+    if isinstance(aux, utils.LossOutput):
+      # Scale the unreduced gradients using the metric's scale computation
+      scale = aux.primary_loss.compute_scale()
+      grads = jax.tree.map(lambda g: g * scale, grads)
+
+      # Compute exactly equivalent legacy loss val
+      loss_val = aux.primary_loss.compute()
+
+    # TODO(b/491970038): update denom for sequence packing.
+    grad_accumulator.add(grads, denom=jnp.asarray(1.0, dtype=jnp.float32))
+
+    def apply_updates(model, optimizer, grad_accumulator):
+      acc_grads = grad_accumulator.get()
+      # Compute the norm in float32 to 1) match `skip_updates()` return type and
+      # meet the requirement of `nnx.cond` that both branches return the same
+      # dtype, 2) for production-size models the sum-of-squares over bf16 grads
+      # quickly exhausts bf16 and float32 is needed for numerical stability.
+      norm = optax.global_norm(
+          jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), acc_grads)
+      )
+      optimizer.update(model, acc_grads)
+      grad_accumulator.reset()
+      return norm
+
+    def skip_updates(model, optimizer, grad_accumulator):
+      return jnp.array(0.0, dtype=jnp.float32)
+
+    # If the mesh is not empty, then we need to replicate the is_update_step
+    # across all devices to avoid deadlock so that all devices see the same
+    # update step.
+    mesh = pxla.thread_resources.env.physical_mesh
+    if not mesh.empty:
+      is_update_step = jax.lax.with_sharding_constraint(
+          is_update_step, jax.sharding.PartitionSpec()
+      )
+
+    grad_norm = nnx.cond(
+        is_update_step,
+        apply_updates,
+        skip_updates,
+        model,
+        optimizer,
+        grad_accumulator,
+    )
+
+    if isinstance(aux, utils.LossOutput):
+      return loss_val, _compute_legacy_aux(aux), grad_norm
+    elif self._has_aux:
+      return loss_val, aux, grad_norm
     else:
-      return out, None, grad_norm
+      return loss_val, None, grad_norm
 
   def _eval_step(
       self, model: nnx.Module, inputs: Any
   ) -> ArrayLike | Tuple[ArrayLike, Any]:
     inputs = self.gen_model_input_fn(inputs)
     out = self.eval_loss_fn(model, **inputs)
-    if self._has_aux:
+    if isinstance(out, utils.LossOutput):
+      return out.primary_loss.compute(), _compute_legacy_aux(out)
+    elif self._has_aux:
       loss, aux = out  # pyrefly: ignore[not-iterable]
       return loss, aux
     else:
@@ -375,7 +544,9 @@ class PeftTrainer:
     """Creates the train step function."""
     return self._train_step
 
-  def create_eval_step_fn(self) -> Callable[..., ArrayLike]:
+  def create_eval_step_fn(
+      self,
+  ) -> Callable[..., ArrayLike | Tuple[ArrayLike, Any]]:
     """Creates the eval step function."""
     return self._eval_step  # pyrefly: ignore[bad-return]
 
@@ -396,6 +567,21 @@ class PeftTrainer:
         optimizer_state, optimizer_pspecs
     )
     nnx.update(self.optimizer, optimizer_sharded_state)
+
+    wrt_target = nnx.LoRAParam if self._lora_enabled else nnx.Param
+    model_state = nnx.state(self.model, wrt_target)
+    model_pspecs = nnx.get_partition_spec(model_state)
+
+    # Partition Gradients similar to the model
+    grads_sharded = jax.lax.with_sharding_constraint(
+        self.grad_accumulator.grads, model_pspecs
+    )
+    self.grad_accumulator.grads = grads_sharded
+
+    # Denominator is a scalar — replicate across all devices
+    self.grad_accumulator.denom[...] = jax.lax.with_sharding_constraint(
+        self.grad_accumulator.denom[...], jax.sharding.PartitionSpec()
+    )
 
   def jit_train_and_eval_step(
       self, skip_jit: bool = False, cache_nnx_graph: bool = False
@@ -419,7 +605,7 @@ class PeftTrainer:
     if self._jitted_train_step_fn is None:
       self._shard_optimizer(pxla.thread_resources.env.physical_mesh)
       self._jitted_train_step_fn = nnx.jit(
-          train_step, donate_argnames=("optimizer",)
+          train_step, donate_argnames=("optimizer", "grad_accumulator")
       )
       self._jitted_eval_step_fn = nnx.jit(eval_step)
 
@@ -431,7 +617,10 @@ class PeftTrainer:
           return functools.partial(f, *args)
 
       self._jitted_train_step_fn = maybe_cache_and_partial(
-          self._jitted_train_step_fn, self.model, self.optimizer
+          self._jitted_train_step_fn,
+          self.model,
+          self.optimizer,
+          self.grad_accumulator,
       )
       self._jitted_eval_step_fn = maybe_cache_and_partial(
           self._jitted_eval_step_fn, self.model
@@ -696,6 +885,28 @@ class PeftTrainer:
             perf_constants.MINI_BATCH: mini_batch,
         }
 
+        self._iter_steps += 1
+
+        is_update_step_val = None
+        if (
+            isinstance(train_example, dict)
+            and "is_update_step" in train_example
+        ):
+          val = train_example["is_update_step"]
+          if val is not None:
+            is_update_step_val = bool(np.asarray(val).item())
+        elif hasattr(train_example, "is_update_step"):
+          val = train_example.is_update_step
+          if val is not None:
+            is_update_step_val = bool(np.asarray(val).item())
+
+        if is_update_step_val is None:
+          is_update_step_val = (
+              self._iter_steps
+              % self.config.get_with_default("gradient_accumulation_steps", 1)
+              == 0
+          )
+
         with self._perf_tracer.span(
             "peft_train_step",
             pxla.thread_resources.env.physical_mesh.devices,
@@ -704,7 +915,10 @@ class PeftTrainer:
             pxla.thread_resources.env.physical_mesh.devices,
             tags=tags,
         ) as span_v2:
-          train_loss, aux, grad_norm = train_step(train_example)
+          train_loss, aux, grad_norm = train_step(
+              train_example,
+              is_update_step=jnp.array(is_update_step_val, dtype=jnp.bool_),
+          )
           span.device_end([train_loss])
           span_v2.async_end([train_loss])
 
@@ -717,13 +931,8 @@ class PeftTrainer:
         )
         # NB: put this after self._buffer_metrics is important
         self._post_process_train_step(aux)
-        self._iter_steps += 1
 
-        if (
-            self._iter_steps
-            % self.config.get_with_default("gradient_accumulation_steps", 1)
-            == 0
-        ):
+        if is_update_step_val:
           self._train_steps += 1
           self._write_train_metrics()
 
@@ -857,7 +1066,7 @@ def _default_loss_fn(
     positions: jax.Array,
     attention_mask: jax.Array,
     images: jax.Array | None = None,
-) -> ArrayLike:
+) -> utils.LossOutput | ArrayLike:
   """Default loss function for PEFT training."""
   # Weird kwargs workaround because not all models support `images` right now.
   kwargs = {} if images is None else {"images": images}
@@ -875,8 +1084,12 @@ def _default_loss_fn(
   one_hot = one_hot * target_mask.astype(one_hot.dtype)[..., None]
 
   # Define the normalization factor.
-  norm_factor = 1 / (jnp.sum(target_mask) + 1e-8)
+  denominator = jnp.sum(target_mask)
 
   # Return the negative log likelihood (NLL) loss.
   # Equivalent to: optax.softmax_cross_entropy(logits, one_hot).mean()
-  return -jnp.sum(jax.nn.log_softmax(logits) * one_hot) * norm_factor
+  unreduced_loss = -jnp.sum(jax.nn.log_softmax(logits) * one_hot)
+  return utils.LossOutput(
+      primary_loss=utils.WeightedMetric(unreduced_loss, denominator, eps=1e-8),
+      aux_metrics={},
+  )

--- a/tunix/sft/utils.py
+++ b/tunix/sft/utils.py
@@ -19,10 +19,11 @@ import contextlib
 import functools
 import gc
 import time
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from absl import logging
 from flax import nnx
+import flax.struct
 import humanize
 import jax
 import jax.numpy as jnp
@@ -178,3 +179,54 @@ def show_hbm_usage(title=""):
           used / limit,
           devices[i],
       )
+
+
+@flax.struct.dataclass
+class WeightedMetric:
+  """A metric that requires weighted reduction.
+
+  Attributes:
+    unreduced_sum: The sum of the metric values. Should be a scalar ().
+    denominator: The weight or count of valid tokens/examples. Should be a
+      scalar ().
+    eps: Optional epsilon added to denominator for numerical stability.
+    min_denom: Optional minimum bound for the denominator.
+  """
+
+  unreduced_sum: jax.Array
+  denominator: jax.Array
+  eps: float | None = flax.struct.field(default=None, pytree_node=False)
+  min_denom: float | None = flax.struct.field(default=None, pytree_node=False)
+
+  def compute_scale(self) -> jax.Array:
+    """Safely computes the scale factor (1 / denominator) with bounds."""
+    denom = self.denominator
+    if self.eps is not None:
+      denom = denom + self.eps
+    if self.min_denom is not None:
+      denom = jnp.maximum(denom, self.min_denom)
+
+    # JAX Safe Division: Prevent division-by-zero NaNs from poisoning gradients
+    # We replace 0s with 1.0 *before* dividing.
+    safe_denom = jnp.where(denom == 0, 1.0, denom)
+
+    # Calculate scale, masking out pure zero denominators to 0.0
+    scale = 1.0 / safe_denom
+    return jnp.where(denom == 0, 0.0, scale)
+
+  def compute(self) -> jax.Array:
+    """Safely computes total / count with optional legacy equivalence bounds."""
+    return self.unreduced_sum * self.compute_scale()
+
+
+@flax.struct.dataclass
+class LossOutput:
+  """Output of a loss function containing unreduced primary loss and aux metrics.
+
+  Attributes:
+    primary_loss: The main loss to be optimized.
+    aux_metrics: A dictionary of auxiliary metrics.
+  """
+
+  primary_loss: WeightedMetric
+  aux_metrics: Dict[str, WeightedMetric]


### PR DESCRIPTION
## What

Extends the FSDP sequence-packing forward to the **logprob** path so logprob and
training share one packed representation (`segment_ids`), like veRL / slime.

### P1 — packed logprob forward
- `inference_worker` / `rl_cluster` `get_ref_per_token_logps` and
  `get_actor_per_token_logps` thread `segment_ids` / `segment_positions` through
  to `compute_per_token_logps`. Default `None` → the padded path is unchanged.

### P2 — pack-first data flow (agentic GRPO)
- `_process_results` defers old/ref logprob when packing (token-only
  `TrainExample`); `_compute_packed_logps` computes them on the packed buffer
  **after** `pack_sequences`, sharing the representation training already uses.
- Do **not** enable `_process_in_consumer` under packing — fixes the raw-list
  `'list' object has no attribute 'prompt_ids'` crash. Non-packed path unchanged.
- Adds `packing/dummy_ratio` and `packing/seqs_per_pack` metrics.

## Scope
Pack-first (P2) currently covers the **agentic GRPO** learner. The P1 logprob
API is generic (usable by other algorithms). Non-agentic learners and PPO's
critic/value path are not yet wired for pack-first.

## Stacking
Sits on top of the FSDP-packing change (`[Seq Packing] support fsdp packing`).
Until that lands on `main`, this PR shows it too; it will drop out once merged.

## Test
`tests/rl/rl_utils_test.py`: token-only `pack_sequences` / `unpad_train_example`
cases (packed batch keeps `segment_ids`, leaves logps `None`).
