### PR TITLE
[Seq Packing] Loss normalization under packing (P3): unpack aggregation + global grad weighting

### DIFF
--- a/tests/rl/common_test.py
+++ b/tests/rl/common_test.py
@@ -718,5 +718,90 @@ class CommonTest(parameterized.TestCase):
     self.assertAlmostEqual(loss, 1.5, places=5)
 
 
+class AggregateLossPackedTest(parameterized.TestCase):
+  """Pins that packing-aware aggregate_loss_packed == rectangular aggregate_loss.
+
+  Packed [P=3, T=5]: seq0 (prompt@0 + completion@1,2), seq1 (completion@0),
+  seq2 (completion@0,1), plus a fully-dummy pack row. Unpacking must reproduce
+  the per-sequence [N=3, R=3] rectangle so every loss_agg_mode reduces correctly.
+  """
+
+  _MODES = (
+      "token-mean",
+      "sequence-mean-token-mean",
+      "sequence-mean-token-scale",
+      "seq-mean-token-sum",
+      "sequence-mean-token-sum-norm",
+  )
+
+  def _packed(self):
+    loss = jnp.array(
+        [[9, 2, 4, 6, 0], [8, 10, 0, 0, 0], [0, 0, 0, 0, 0]], jnp.float32
+    )
+    mask = jnp.array(
+        [[0, 1, 1, 1, 0], [1, 1, 0, 0, 0], [0, 0, 0, 0, 0]], jnp.int32
+    )
+    seg = jnp.array(
+        [[1, 1, 1, 2, 0], [1, 1, 0, 0, 0], [0, 0, 0, 0, 0]], jnp.int32
+    )
+    pos = jnp.array(
+        [[0, 1, 2, 0, 0], [0, 1, 0, 0, 0], [0, 0, 0, 0, 0]], jnp.int32
+    )
+    return loss, mask, seg, pos
+
+  def _rectangular(self):
+    # Hand-built [N=3, R=3], independent of make_unpack_indices.
+    loss = jnp.array([[9, 2, 4], [6, 0, 0], [8, 10, 0]], jnp.float32)
+    mask = jnp.array([[0, 1, 1], [1, 0, 0], [1, 1, 0]], jnp.int32)
+    return loss, mask
+
+  @parameterized.parameters(*_MODES)
+  def test_packed_equals_rectangular(self, mode):
+    loss, mask, seg, pos = self._packed()
+    rloss, rmask = self._rectangular()
+    got = common.aggregate_loss_packed(
+        loss, mask, mode, segment_ids=seg, segment_positions=pos,
+        n_max=3, r_max=3,
+    ).compute()
+    expected = common.aggregate_loss(rloss, rmask, mode).compute()
+    np.testing.assert_allclose(got, expected, atol=1e-4)
+
+  def test_token_mean_ground_truth(self):
+    # completion losses = [2,4,6,8,10] -> 30/5 = 6.0.
+    loss, mask, seg, pos = self._packed()
+    got = common.aggregate_loss_packed(
+        loss, mask, "token-mean", segment_ids=seg, segment_positions=pos,
+        n_max=3, r_max=3,
+    ).compute()
+    np.testing.assert_allclose(got, 6.0, atol=1e-4)
+
+  @parameterized.parameters(
+      "token-mean",
+      "sequence-mean-token-mean",
+      "sequence-mean-token-scale",
+      "seq-mean-token-sum",
+  )
+  def test_empty_padding_row_does_not_pollute(self, mode):
+    # n_max=4 adds an empty row; decision-B (non-empty-row denom) keeps the
+    # result identical to the tight n_max=3.
+    loss, mask, seg, pos = self._packed()
+    tight = common.aggregate_loss_packed(
+        loss, mask, mode, segment_ids=seg, segment_positions=pos,
+        n_max=3, r_max=3,
+    ).compute()
+    padded = common.aggregate_loss_packed(
+        loss, mask, mode, segment_ids=seg, segment_positions=pos,
+        n_max=4, r_max=3,
+    ).compute()
+    np.testing.assert_allclose(padded, tight, atol=1e-4)
+
+  @parameterized.parameters(*_MODES)
+  def test_none_segments_matches_original(self, mode):
+    rloss, rmask = self._rectangular()
+    got = common.aggregate_loss_packed(rloss, rmask, mode).compute()
+    expected = common.aggregate_loss(rloss, rmask, mode).compute()
+    np.testing.assert_allclose(got, expected, atol=1e-6)
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/sft/peft_trainer_test.py
+++ b/tests/sft/peft_trainer_test.py
@@ -1234,5 +1234,70 @@ class GradientAccumulatorTest(parameterized.TestCase):
       self.assertEqual(d, jnp.float32)
 
 
+class TrainStepGlobalWeightedTest(parameterized.TestCase):
+  """Pins that _train_step accumulates the GLOBAL weighted mean, not a
+  mean-of-means, after b/491970038.
+
+  Emulates the _train_step recipe: grad(unreduced_sum_i) accumulated with the
+  loss's real per-micro-batch denom -> get() = Sum grads / Sum denom. With
+  uneven denoms this must equal the global weighting and differ from the old
+  mean-of-means (grad_i/denom_i averaged equally).
+  """
+
+  @staticmethod
+  def _unwrap(state):
+    return jax.tree_util.tree_map(
+        lambda v: v[...] if isinstance(v, nnx.Variable) else v,
+        state,
+        is_leaf=lambda x: isinstance(x, nnx.Variable),
+    )
+
+  @staticmethod
+  def _loss_sum(model, x, y):
+    return jnp.sum((model(x) - y) ** 2)
+
+  def test_train_step_recipe_is_global_weighted(self):
+    d1, d2 = 2, 6  # uneven micro-batch denominators
+    rngs = nnx.Rngs(0)
+    model = nnx.Linear(in_features=4, out_features=2, rngs=rngs)
+    k = jax.random.split(jax.random.PRNGKey(0), 2)
+    x = jax.random.normal(k[0], (d1 + d2, 4))
+    y = jax.random.normal(k[1], (d1 + d2, 2))
+
+    grad_fn = nnx.value_and_grad(self._loss_sum)
+    _, g1 = grad_fn(model, x[:d1], y[:d1])
+    _, g2 = grad_fn(model, x[d1:], y[d1:])
+    g1, g2 = self._unwrap(g1), self._unwrap(g2)
+
+    # New recipe: NO local 1/denom scale; add grad(sum) with the real denom.
+    acc = peft_trainer.GradientAccumulator(model, nnx.Param)
+    acc.add(g1, denom=jnp.asarray(float(d1)))
+    acc.add(g2, denom=jnp.asarray(float(d2)))
+    result = self._unwrap(acc.get())
+
+    global_weighted = jax.tree_util.tree_map(
+        lambda a, b: (a + b) / (d1 + d2), g1, g2
+    )
+    mean_of_means = jax.tree_util.tree_map(
+        lambda a, b: (a / d1 + b / d2) / 2.0, g1, g2
+    )
+
+    # Now equals the global weighting ...
+    jax.tree_util.tree_map(
+        lambda a, e: np.testing.assert_allclose(a, e, rtol=1e-6, atol=1e-6),
+        result,
+        global_weighted,
+    )
+    # ... and is NOT the old mean-of-means (uneven denoms).
+    max_diff = jax.tree_util.tree_reduce(
+        jnp.maximum,
+        jax.tree_util.tree_map(
+            lambda a, b: jnp.max(jnp.abs(a - b)), result, mean_of_means
+        ),
+        initializer=jnp.asarray(0.0),
+    )
+    self.assertGreater(float(max_diff), 1e-3)
+
+
 if __name__ == '__main__':
   absltest.main()

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -239,6 +239,13 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     policy_loss_fn = function_registry.get_policy_loss_fn(
         self.algo_config.policy_loss_fn
     )
+    # Static upper bound on real sequences per packed micro-batch (train_micro
+    # prompts x num_generations); used to unpack [P, T] -> [n_max, T] for
+    # sequence-packing-aware loss aggregation. Only consumed when packing is on.
+    training_cfg = self.rl_cluster.cluster_config.training_config
+    unpack_n_max = (
+        training_cfg.train_micro_batch_size or training_cfg.mini_batch_size or 0
+    ) * self.algo_config.num_generations
     loss_fn = lambda model, train_example, algo_config: policy_loss_fn(
         model,
         train_example,
@@ -246,6 +253,7 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         pad_id=self.rl_cluster.rollout.pad_id(),
         eos_id=self.rl_cluster.rollout.eos_id(),
         compute_logps_chunk_size=self.rl_cluster.cluster_config.training_config.compute_logps_chunk_size,
+        unpack_n_max=unpack_n_max,
     )
 
     self.rl_cluster.actor_trainer.with_loss_fn(

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -398,6 +398,12 @@ def grpo_loss_fn(
   )
   epsilon_c = getattr(algo_config, "epsilon_c", None)
   loss_aggregation_mode = algo_config.loss_agg_mode
+  # Sequence-packing: unpack per-token tensors to [n_max, r_max] (row = sequence)
+  # before aggregation so every loss_agg_mode reduces per-sequence. None -> the
+  # non-packed path is unchanged. r_max = T (a sequence fits in one pack row).
+  seg_ids = getattr(train_example, "segment_ids", None)
+  seg_pos = getattr(train_example, "segment_positions", None)
+  unpack_n_max = kwargs.get("unpack_n_max", 0)
 
   completion_ids, completion_mask = (
       train_example.completion_ids,
@@ -478,8 +484,10 @@ def grpo_loss_fn(
   per_token_pg_clipfrac_lower = (
       (per_token_loss > pg_loss_3) & (adv < 0.0)
   ).astype(jnp.float32)
-  pg_clipfrac_lower = common.aggregate_loss(
-      per_token_pg_clipfrac_lower, completion_mask, loss_aggregation_mode
+  pg_clipfrac_lower = common.aggregate_loss_packed(
+      per_token_pg_clipfrac_lower, completion_mask, loss_aggregation_mode,
+      segment_ids=seg_ids, segment_positions=seg_pos,
+      n_max=unpack_n_max, r_max=per_token_pg_clipfrac_lower.shape[1],
   )
 
   pg_loss_clipped_dual = jnp.minimum(pg_loss_3, per_token_loss)
@@ -494,8 +502,10 @@ def grpo_loss_fn(
   if sampler_is_weights is not None:
     per_token_loss = per_token_loss * sampler_is_weights.astype(jnp.float32)
 
-  weighted_loss = common.aggregate_loss(
-      per_token_loss, completion_mask, loss_aggregation_mode
+  weighted_loss = common.aggregate_loss_packed(
+      per_token_loss, completion_mask, loss_aggregation_mode,
+      segment_ids=seg_ids, segment_positions=seg_pos,
+      n_max=unpack_n_max, r_max=per_token_loss.shape[1],
   )
   # Per-token diagnostics — log only over assistant tokens (completion_mask).
   is_ratio_mean = masked_mean(is_ratio, completion_mask)
@@ -559,7 +569,11 @@ def grpo_loss_fn(
     aux["kl"] = sft_utils.WeightedMetric(
         unreduced_kl, token_denom, min_denom=1.0
     )
-    kl_loss = common.aggregate_loss(kl, completion_mask, loss_aggregation_mode)
+    kl_loss = common.aggregate_loss_packed(
+        kl, completion_mask, loss_aggregation_mode,
+        segment_ids=seg_ids, segment_positions=seg_pos,
+        n_max=unpack_n_max, r_max=kl.shape[1],
+    )
     aux["kl_loss"] = kl_loss  # pyrefly: ignore[bad-assignment]
     if beta is not None and beta != 0.0:
       weighted_loss = sft_utils.WeightedMetric(
@@ -569,8 +583,10 @@ def grpo_loss_fn(
           min_denom=weighted_loss.min_denom,
       )
 
-  entropy_loss = common.aggregate_loss(
-      token_entropy, completion_mask, loss_aggregation_mode
+  entropy_loss = common.aggregate_loss_packed(
+      token_entropy, completion_mask, loss_aggregation_mode,
+      segment_ids=seg_ids, segment_positions=seg_pos,
+      n_max=unpack_n_max, r_max=token_entropy.shape[1],
   )
   aux["entropy"] = entropy_loss
 

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -703,7 +703,10 @@ def aggregate_loss(
         seq_mask, min=1.0
     )
     unreduced_sum = seq_loss.sum()
-    denominator = per_token_loss.shape[0]
+    # Count non-empty rows so unpacked [N_max, R] padding rows do not inflate the
+    # denominator (matches seq-mean-token-sum). For a fully-populated batch this
+    # equals shape[0], so the non-packed path is unchanged.
+    denominator = (seq_mask > 0).sum()
     min_denom = 1.0
   elif loss_agg_mode == "sequence-mean-token-scale":
     # Look up custom normalization factor, default to max response length.
@@ -714,7 +717,7 @@ def aggregate_loss(
         norm, min=1e-6
     )
     unreduced_sum = seq_loss.sum()
-    denominator = per_token_loss.shape[0]
+    denominator = (completion_mask.sum(axis=-1) > 0).sum()
     min_denom = 1.0
   elif loss_agg_mode == "seq-mean-token-sum":
     # 1) sum token losses within each sequence
@@ -742,6 +745,69 @@ def aggregate_loss(
       jnp.asarray(denominator, dtype=jnp.float32),
       min_denom=min_denom,
   )
+
+
+def make_unpack_indices(
+    segment_ids: jax.Array,
+    segment_positions: jax.Array,
+    n_max: int,
+) -> tuple[jax.Array, jax.Array]:
+  # segment_ids/segment_positions: [P, T]. Local segment id (1-indexed within a
+  # pack, 0 = padding/dummy) and local position within that sequence. Returns
+  # per-token scatter targets (g, pos) into a compact [n_max, R] grid where each
+  # row is one sequence. Padding tokens get an out-of-range row (n_max) so a
+  # mode='drop' scatter discards them.
+  segs_per_pack = segment_ids.max(axis=-1)  # [P] real segment count per pack
+  pack_offset = jnp.concatenate([
+      jnp.zeros((1,), segs_per_pack.dtype),
+      jnp.cumsum(segs_per_pack)[:-1],
+  ])  # [P] global index of each pack's first sequence
+  valid = segment_ids > 0
+  g = pack_offset[:, None] + (segment_ids - 1)  # [P, T] global sequence index
+  g = jnp.where(valid, g, n_max)  # sentinel row -> dropped
+  pos = jnp.where(valid, segment_positions, 0)
+  return g, pos
+
+
+def aggregate_loss_packed(
+    per_token_loss: jax.Array,
+    completion_mask: jax.Array,
+    loss_agg_mode: str,
+    segment_ids: jax.Array | None = None,
+    segment_positions: jax.Array | None = None,
+    n_max: int = 0,
+    r_max: int = 0,
+    **kwargs: Any,
+) -> utils.WeightedMetric:
+  # Sequence-packing-aware aggregate_loss. segment_ids is None (no packing) ->
+  # delegate unchanged. Packed -> unpack the per-token [P, T] tensors to
+  # rectangular [n_max, r_max] (row = sequence, veRL pad_input equivalent) so
+  # every loss_agg_mode reduces per-sequence correctly.
+  if segment_ids is None:
+    return aggregate_loss(
+        per_token_loss, completion_mask, loss_agg_mode, **kwargs
+    )
+  # n_max is a static upper bound on the number of sequences in one packed
+  # micro-batch (train_micro_batch_size * num_generations). It must be positive
+  # and >= the real sequence count: make_unpack_indices routes any token whose
+  # global sequence index reaches n_max to an out-of-range row that the
+  # mode='drop' scatter discards, so an undersized n_max silently drops real
+  # sequences. This assert catches the n_max == 0 case (packing enabled but no
+  # train_micro/mini batch size); the dynamic count > n_max case relies on the
+  # producer never emitting more than n_max sequences per micro-batch.
+  assert n_max > 0, (
+      "aggregate_loss_packed requires n_max > 0 on the packed path; got"
+      f" {n_max} (is train_micro_batch_size or mini_batch_size set when"
+      " sequence packing is enabled?)."
+  )
+  g, pos = make_unpack_indices(segment_ids, segment_positions, n_max)
+  x_nr = jnp.zeros((n_max, r_max), per_token_loss.dtype).at[g, pos].set(
+      per_token_loss, mode="drop"
+  )
+  m_nr = jnp.zeros((n_max, r_max), completion_mask.dtype).at[g, pos].set(
+      completion_mask, mode="drop"
+  )
+  return aggregate_loss(x_nr, m_nr, loss_agg_mode, **kwargs)
 
 
 def compute_entropy_from_logits(logits: jax.Array) -> jax.Array:

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -474,15 +474,17 @@ class PeftTrainer:
     (loss_val, aux), grads = grad_fn(model, **inputs)
 
     if isinstance(aux, utils.LossOutput):
-      # Scale the unreduced gradients using the metric's scale computation
-      scale = aux.primary_loss.compute_scale()
-      grads = jax.tree.map(lambda g: g * scale, grads)
-
-      # Compute exactly equivalent legacy loss val
+      # Compute exactly equivalent legacy loss val for logging.
       loss_val = aux.primary_loss.compute()
 
-    # TODO(b/491970038): update denom for sequence packing.
-    grad_accumulator.add(grads, denom=jnp.asarray(1.0, dtype=jnp.float32))
+      # Accumulate the UNREDUCED gradients (d/dparam of the sum) weighted by the
+      # loss's real denominator, so the optimizer step sees the GLOBAL weighted
+      # mean (Sum grads / Sum denom) across micro-batches rather than a
+      # mean-of-means. The denom is token-count for token-mean and sequence-count
+      # for sequence-mean, so each mode is normalized correctly (b/491970038).
+      grad_accumulator.add(grads, denom=aux.primary_loss.denominator)
+    else:
+      grad_accumulator.add(grads, denom=jnp.asarray(1.0, dtype=jnp.float32))
 
     def apply_updates(model, optimizer, grad_accumulator):
       acc_grads = grad_accumulator.get()


### PR DESCRIPTION
## What

Loss normalization correctness under sequence packing (P3), stacked on the packed-logprob + pack-first PR (#1659). Two independent layers:

### Layer 1 — per-sequence aggregation (unpack, veRL `pad_input` equivalent)
With packing, `per_token_loss` is `[num_packs, T]` where each row holds ~8 sequences, but `aggregate_loss` only knows `completion_mask` — it treats a whole pack row as one sequence, so every sequence-mean mode is wrong (only token-mean is packing-invariant).

Fix (mirrors veRL, which unpacks logprobs back to `[batch, resp_len]` before the loss so aggregation is transparent to packing):
- `common.py`: `make_unpack_indices` + `aggregate_loss_packed`. It scatters the packed `[num_packs, T]` tensor back to a rectangular `[n_max, T]` (row = sequence) via a `segment_ids` scatter, then runs the original `aggregate_loss` so all 5 modes reduce per-sequence. `segment_ids=None` delegates unchanged (non-packed path byte-identical).
- `common.py`: `sequence-mean-token-mean` / `sequence-mean-token-scale` denominators use the non-empty-row count so unpacked padding rows do not inflate them.
- `algo_core.py`: 4 `aggregate_loss` call sites (clipfrac / main loss / kl / entropy) → `aggregate_loss_packed`.
- `agentic_grpo_learner.py`: pass `unpack_n_max = train_micro_batch_size * num_generations` (a static config constant).

### Layer 2 — cross-micro-batch gradient (b/491970038)
`peft_trainer` accumulated a mean-of-means (local `1/denom` scale + `denom=1`). Since `diff_fn` differentiates the unreduced sum, `grads = grad(sum)`. Now it accumulates `grad(sum)` with the loss's real denominator, so the optimizer sees `Σ grads / Σ denom` — token-weighted for token-mean, sequence-weighted for sequence-mean. This is exact per mode (each mode contributes its own denominator), whereas veRL uses a fixed sequence count.

## Tests
- `tests/rl/common_test.py::AggregateLossPackedTest` — all 5 modes: `aggregate_loss_packed(packed) == aggregate_loss(rectangular)` (atol 1e-4); token-mean ground truth; decision-B empty-row protection; `segment_ids=None` matches the original (non-packed unchanged).
- `tests/sft/peft_trainer_test.py::TrainStepGlobalWeightedTest` — uneven denominators across micro-batches: `get() == Σ grads / Σ denom` (global), and differs from mean-of-means.

## Notes
Stacked on `yuxzhang/unified_seqpack` (#1659); depends on its `LossOutput` / `WeightedMetric` infra. Re-target to `main` once #1659 merges.
