### PR TITLE
[Seq Packing] KK load balancing: balance packs across DP shards (P5)

### DIFF
--- a/tests/rl/rl_utils_test.py
+++ b/tests/rl/rl_utils_test.py
@@ -372,8 +372,10 @@ class UtilsTest(absltest.TestCase):
 
     # Budget of 10. We expect item 1 (5) and item 2 (3) to fit in the first pack (8).
     # Item 3 (7) will go to the second pack (because 8+7 > 10).
+    # first_fit asserts this exact arrival-order layout (KK may reorder/regroup).
     packed_iterator = utils.pack_sequences(
-        item_iterator, max_token_budget=10, pad_id=0
+        item_iterator, max_token_budget=10, pad_id=0,
+        packing_strategy="first_fit",
     )
 
     packed_batches = list(packed_iterator)
@@ -428,6 +430,69 @@ class UtilsTest(absltest.TestCase):
           pack2.segment_positions, expected_positions_2
       )
       np.testing.assert_array_equal(pack2.completion_mask, expected_mask_2)
+
+  def test_karmarkar_karp_balances_partitions(self):
+    # Known answer: [8,7,6,5,4] into 2 groups has minimal spread 2 (14 vs 16),
+    # beating greedy first-fit's spread 4.
+    vals = [8, 7, 6, 5, 4]
+    groups = utils.karmarkar_karp(vals, 2)
+    self.assertEqual(
+        sorted(sum(vals[i] for i in g) for g in groups), [14, 16]
+    )
+    # [8..1] into 4 groups balances perfectly to 9 each (8+1, 7+2, 6+3, 5+4).
+    vals = [8, 7, 6, 5, 4, 3, 2, 1]
+    groups = utils.karmarkar_karp(vals, 4)
+    self.assertEqual(
+        sorted(sum(vals[i] for i in g) for g in groups), [9, 9, 9, 9]
+    )
+
+  def test_karmarkar_karp_partitions_all_indices_once(self):
+    # No sequence dropped or duplicated: every index appears exactly once.
+    vals = [5, 4, 3, 3, 3, 2, 7, 1]
+    groups = utils.karmarkar_karp(vals, 3)
+    flat = sorted(i for g in groups for i in g)
+    self.assertEqual(flat, list(range(len(vals))))
+
+  def test_karmarkar_karp_more_partitions_than_items(self):
+    # k > n: every item placed, extra groups left empty.
+    groups = utils.karmarkar_karp([3, 1], 4)
+    self.assertLen(groups, 4)
+    self.assertEqual(sum(len(g) for g in groups), 2)
+
+  def test_pack_sequences_kk_preserves_all_sequences(self):
+    # KK (default) must place every sequence in exactly one pack (no drop/dup).
+    examples = [self._create_mock_train_example(2, 3) for _ in range(10)]
+    batches = list(
+        utils.pack_sequences(iter([examples]), max_token_budget=20, num_packs=2)
+    )
+    total_segments = 0
+    for [pack] in batches:
+      seg = np.asarray(pack.segment_ids)
+      # segments in a pack row are numbered 1..m, so per-row max == #sequences.
+      total_segments += int(seg.max(axis=-1).sum())
+    self.assertEqual(total_segments, 10)
+
+  def test_pack_sequences_kk_respects_budget(self):
+    # 9 sequences of size 5 into budget 12: a naive 3-per-pack split (15) would
+    # overflow, so the capacity guard must bump k until every pack fits.
+    examples = [self._create_mock_train_example(2, 3) for _ in range(9)]
+    batches = list(
+        utils.pack_sequences(iter([examples]), max_token_budget=12, num_packs=1)
+    )
+    for [pack] in batches:
+      seg = np.asarray(pack.segment_ids)
+      self.assertLessEqual(int((seg != 0).sum()), 12)
+
+  def test_pack_sequences_invalid_strategy_raises(self):
+    example = self._create_mock_train_example(2, 3)
+    with self.assertRaisesRegex(ValueError, r'packing_strategy must be'):
+      list(
+          utils.pack_sequences(
+              iter([[example]]),
+              max_token_budget=10,
+              packing_strategy='bogus',
+          )
+      )
 
 
 if __name__ == '__main__':

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -14,6 +14,7 @@
 
 """Simple utils used by RL algorithms."""
 
+import heapq
 from itertools import chain  # pylint: disable=g-importing-member
 import operator
 from typing import Any, Iterator, Mapping, Optional, Sequence
@@ -337,12 +338,121 @@ def unpad_train_example(example: common.TrainExample) -> list[dict[str, Any]]:
   return res
 
 
+def karmarkar_karp(vals, k):
+  """Partition indices [0, len(vals)) into k groups with balanced sums.
+
+  Karmarkar-Karp largest-differencing heuristic: repeatedly merge the two most
+  imbalanced arrangements, pairing each arrangement's largest bucket with the
+  other's smallest, until one arrangement (the k groups) remains. Returns k
+  lists of indices into vals; groups may be empty when k > len(vals).
+  """
+
+  class _Set:  # one bucket (one pack): running sum + which sequences it holds
+    def __init__(self):
+      self.sum = 0
+      self.items = []
+
+    def add(self, idx, val):
+      self.items.append((idx, val))
+      self.sum += val
+
+    def merge(self, other):
+      for idx, val in other.items:
+        self.items.append((idx, val))
+        self.sum += val
+
+    def __lt__(self, other):
+      return self.sum < other.sum
+
+  class _State:  # one arrangement of k buckets, kept sorted by sum descending
+    def __init__(self, idx, val, k):
+      self.k = k
+      self.sets = [_Set() for _ in range(k)]
+      self.sets[0].add(idx, val)
+      self.sets.sort(reverse=True)
+
+    @property
+    def spread(self):
+      return self.sets[0].sum - self.sets[-1].sum
+
+    def merge(self, other):
+      # Pair our i-th largest bucket with other's i-th smallest (big + small).
+      for i in range(self.k):
+        self.sets[i].merge(other.sets[self.k - 1 - i])
+      self.sets.sort(reverse=True)
+
+    def __lt__(self, other):
+      # heapq is a min-heap; invert so the largest-spread state pops first.
+      return self.spread > other.spread
+
+    def partitions(self):
+      return [[idx for idx, _ in s.items] for s in self.sets]
+
+  pq = []
+  for idx, val in enumerate(vals):
+    heapq.heappush(pq, _State(idx, val, k))
+  while len(pq) > 1:
+    a = heapq.heappop(pq)
+    b = heapq.heappop(pq)
+    a.merge(b)
+    heapq.heappush(pq, a)
+  return pq[0].partitions()
+
+
+def group_by_version(valid):
+  """Group (item, tokens) pairs by policy_version so a pack never mixes versions.
+
+  Returns groups in first-seen version order. When no item carries a
+  policy_version (synchronous training) everything lands in a single group.
+  """
+  groups = {}
+  order = []
+  for item, tokens in valid:
+    v = item.get("policy_version")
+    key = None if v is None else int(np.asarray(v).item())
+    if key not in groups:
+      groups[key] = []
+      order.append(key)
+    groups[key].append((item, tokens))
+  return [groups[key] for key in order]
+
+
+def balanced_pack(items_with_tokens, max_token_budget, num_packs):
+  """Split (item, tokens) pairs into KK-balanced packs, each <= max_token_budget.
+
+  Balances by token count via Karmarkar-Karp. Picks the pack count k as the
+  smallest multiple of num_packs whose average pack fits the budget, then bumps
+  k by num_packs until every pack fits (a static-shape capacity guard the
+  balancing itself does not enforce).
+  """
+  tokens = [t for _, t in items_with_tokens]
+  # TODO: balancing by token count ignores attention's O(L^2) cost, so packs
+  # can still be attention-imbalanced when sequence lengths vary. For long
+  # context, switch to a length-squared-aware workload.
+  workloads = tokens
+  n = len(items_with_tokens)
+
+  k = -(-sum(tokens) // max_token_budget)  # ceil(total / budget)
+  k = -(-k // num_packs) * num_packs  # round up to a num_packs multiple
+  k = min(k, n)
+
+  while True:
+    groups = karmarkar_karp(workloads, k)
+    if k >= n or all(
+        sum(tokens[i] for i in g) <= max_token_budget for g in groups
+    ):
+      break
+    k = min(n, k + num_packs)
+  return [[items_with_tokens[i][0] for i in g] for g in groups]
+
+
 def pack_sequences(
     item_iterator: Iterator[Sequence[common.TrainExample]],
     max_token_budget: int,
     pad_id: int = 0,
     target_items_per_update: int | None = None,
     num_packs: int = 1,
+    packing_strategy: str = "kk",
 ) -> Iterator[list[common.TrainExample]]:
   """Packs a stream of TrainExamples into 1D sequences up to a token budget and stacks them into 2D batches of shape [num_packs, max_token_budget].
 
@@ -352,10 +462,16 @@ def pack_sequences(
     pad_id: The vocabulary id used for padding.
     target_items_per_update: Accumulate items over microbatches, and set `is_update_step=True` when reaching threshold.
     num_packs: Group into chunks of size num_packs. Emits batches of shape [num_packs, sequence_length].
+    packing_strategy: "kk" (default) balances sequences across packs with
+      Karmarkar-Karp; "first_fit" fills each pack greedily in arrival order.
 
   Yields:
     A stream of packed sequences, stacked in chunks of [num_packs, ...].
   """
+  if packing_strategy not in ("kk", "first_fit"):
+    raise ValueError(
+        f"packing_strategy must be 'kk' or 'first_fit', got {packing_strategy!r}"
+    )
   accumulated_items = 0
 
   def _flush_pack(pack_items, example_cls, first_item) -> common.TrainExample:
@@ -500,39 +616,55 @@ def pack_sequences(
 
     first_item, *_ = all_unpadded_items
 
-    packs = []
-    current_pack_items = []
-    current_tokens = 0
+    if packing_strategy == "first_fit":
+      packs = []
+      current_pack_items = []
+      current_tokens = 0
 
-    def _version_changed(item: Mapping[str, Any]) -> bool:
-      if not current_pack_items:
-        return False
-      a = current_pack_items[0].get("policy_version")
-      b = item.get("policy_version")
-      if a is None or b is None:
-        return False
-      return int(np.asarray(a).item()) != int(np.asarray(b).item())
+      def _version_changed(item: Mapping[str, Any]) -> bool:
+        if not current_pack_items:
+          return False
+        a = current_pack_items[0].get("policy_version")
+        b = item.get("policy_version")
+        if a is None or b is None:
+          return False
+        return int(np.asarray(a).item()) != int(np.asarray(b).item())
 
-    for item in all_unpadded_items:
-      tokens = len(item["prompt_ids"]) + len(item["completion_ids"])
+      for item in all_unpadded_items:
+        tokens = len(item["prompt_ids"]) + len(item["completion_ids"])
 
-      if tokens > max_token_budget:
-        logging.warning(
-            "Skipping single sequence with length %d exceeding budget %d",
-            tokens, max_token_budget,
-        )
-        continue
+        if tokens > max_token_budget:
+          logging.warning(
+              "Skipping single sequence with length %d exceeding budget %d",
+              tokens, max_token_budget,
+          )
+          continue
 
-      if current_tokens + tokens > max_token_budget or _version_changed(item):
+        if current_tokens + tokens > max_token_budget or _version_changed(item):
+          packs.append(current_pack_items)
+          current_pack_items = []
+          current_tokens = 0
+
+        current_pack_items.append(item)
+        current_tokens += tokens
+
+      if current_pack_items:
         packs.append(current_pack_items)
-        current_pack_items = []
-        current_tokens = 0
+    else:  # "kk": Karmarkar-Karp balanced packing (default)
+      valid = []
+      for item in all_unpadded_items:
+        tokens = len(item["prompt_ids"]) + len(item["completion_ids"])
+        if tokens > max_token_budget:
+          logging.warning(
+              "Skipping single sequence with length %d exceeding budget %d",
+              tokens, max_token_budget,
+          )
+          continue
+        valid.append((item, tokens))
 
-      current_pack_items.append(item)
-      current_tokens += tokens
-
-    if current_pack_items:
-      packs.append(current_pack_items)
+      packs = []
+      for group in group_by_version(valid):
+        packs.extend(balanced_pack(group, max_token_budget, num_packs))
 
     if not packs:
       continue


### PR DESCRIPTION
## What

Load balancing for sequence packing (P5), stacked on the loss-normalization PR (#1662). Replaces the greedy first-fit packer with Karmarkar-Karp balanced packing so the `[num_packs, T]` rows — one per DP shard — carry near-equal work.

### Why stacked on P3 (not parallel)
KK changes *which sequences land in which pack / how many sequences per microbatch*, which changes each microbatch's sequence count and denominator. P3's Layer 2 (global gradient weighting, `Σgrads / Σdenom`) is exactly what keeps the loss correct when microbatch denominators vary. So KK's regrouping is only end-to-end correct on top of P3 — hence the sequential stack.

### Change
- `utils.py`:
  - `karmarkar_karp(vals, k)` — largest-differencing heuristic (pure python + `heapq`): each sequence starts as its own arrangement, repeatedly merge the two most imbalanced arrangements (pairing each one's largest bucket with the other's smallest) until one k-bucket arrangement remains.
  - `group_by_version(valid)` — a pack never mixes `policy_version`s (single group under synchronous training).
  - `balanced_pack(...)` — balances by token count; picks `k` = smallest multiple of `num_packs` whose average pack fits the budget, then bumps `k += num_packs` until every pack fits `T` (a static-shape capacity guard KK itself does not enforce). Balances by workload, capacity-checks by tokens — kept separate for a future attention-aware (`L^2`) workload; see TODO.
  - `pack_sequences`: new `packing_strategy` arg — `"kk"` (default) or `"first_fit"`. The first-fit block is unchanged, kept as a fallback.

### What KK buys (and what it doesn't)
- **Straggler removal (main win):** balanced per-shard token counts → no shard lags the step.
- **Dummy ratio:** improves only in quantized jumps (the microbatch count is rounded to a `num_packs` multiple), so the gain is real but lumpy; balancing by token count also leaves attention O(L^2) imbalanced (TODO).

## Tests (`tests/rl/rl_utils_test.py`)
- `karmarkar_karp` known answers: `[8,7,6,5,4]` k=2 → spread 2 (14/16); `[8..1]` k=4 → all 9. No drop/dup; `k > n` leaves empty groups.
- `pack_sequences` KK: preserves all sequences (no drop/dup); capacity guard keeps every pack `<= T`; invalid strategy raises. The existing first-fit layout test is pinned to `packing_strategy="first_fit"`.

## Notes
Stacked on `yuxzhang/seqpack_loss_norm` (#1662). Re-target to `main` once the parent PRs merge.
