### PR TITLE
Fix `AttributeError` with the `SentencePieceProcessor` during tokenizer initialization

### DIFF
--- a/tunix/generate/tokenizer_adapter.py
+++ b/tunix/generate/tokenizer_adapter.py
@@ -260,7 +260,7 @@ class Tokenizer(TokenizerAdapter):
         options.append('eos')
 
       extra_options_str = ':'.join(options)
-      if extra_options_str:
+      if extra_options_str and hasattr(tokenizer, 'SetEncodeExtraOptions'):
         tokenizer.SetEncodeExtraOptions(extra_options_str)
     else:
       raise ValueError(f'Unsupported tokenizer_type: {tokenizer_type}')


### PR DESCRIPTION
The `examples/grpo_gemma.ipynb` notebook fails with the following error:

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
/tmp/ipykernel_10327/2792172388.py in <cell line: 0>()
----> 1 tokenizer = tokenizer_lib.Tokenizer(tokenizer_path=GEMMA_TOKENIZER_PATH)
      2 if tokenizer.eos_id() not in EOS_TOKENS:
      3   EOS_TOKENS.append(tokenizer.eos_id())
      4   print(f"Using EOS token IDs: {EOS_TOKENS}")

/usr/local/lib/python3.12/dist-packages/tunix/generate/tokenizer_adapter.py in __init__(self, tokenizer_type, tokenizer_path, add_bos, add_eos, hf_access_token)
    262       extra_options_str = ':'.join(options)
    263       if extra_options_str:
--> 264         tokenizer.SetEncodeExtraOptions(extra_options_str)
    265     else:
    266       raise ValueError(f'Unsupported tokenizer_type: {tokenizer_type}')

AttributeError: 'SentencePieceProcessor' object has no attribute 'SetEncodeExtraOptions'
```
during the tokenizer initialization with

```python
tokenizer = tokenizer_lib.Tokenizer(tokenizer_path=GEMMA_TOKENIZER_PATH)
```

- This is failing because the `SetEncodeExtraOptions` attribute is removed from `SentencePieceProcessor` in the latest version of `senctencepiece` with the [PR #1266](https://github.com/google/sentencepiece/pull/1266)
- To have backward compatibility with the older versions of `sentencepiece`, instead of removing the code related to `extra_options`, the check is tested only when the `SetEncodeExtraOptions` attribute is available with `SentencePieceProcessor`.

Failure case: Colab [gist](https://colab.research.google.com/gist/rajasekharporeddy/b75f518f770edb84fc2dfc63553bc331/grpo_gemma.ipynb)


- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
