### PR TITLE
Update tpu-inference and vllm pinned commits

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-vllm @ git+https://github.com/vllm-project/vllm.git@5e584ce9ecb3cce63f1caab86177aef5c831690f
+vllm @ git+https://github.com/vllm-project/vllm.git@85f638a2b8f9838275b911c44fb0c2abdf604476

--- a/requirements/special_requirements.txt
+++ b/requirements/special_requirements.txt
@@ -2,4 +2,4 @@
 # --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html
 # --pre
 
-tpu-inference @ git+https://github.com/vllm-project/tpu-inference.git@8dd3107ac1d50b823c2a4edd036dd181775b1c94
+tpu-inference @ git+https://github.com/niting/tpu-inference.git@47168722400deeac8499b2918141fb5b8fdf04e3


### PR DESCRIPTION
This PR updates the pinned commits for `tpu-inference` and `vllm` to their latest versions.

Specifically, `tpu-inference` is updated to a commit on `niting/tpu-inference` fork (`47168722400deeac8499b2918141fb5b8fdf04e3`) which contains the fix for Flax NNX sharding metadata propagation. This is temporarily pointing to the fork for testing and should be updated to point to the upstream `vllm-project/tpu-inference` repository once [PR #3232](https://github.com/vllm-project/tpu-inference/pull/3232) is merged.

`vllm` is updated to the latest commit on `main` branch (`85f638a2b8f9838275b911c44fb0c2abdf604476`).
