### PR TITLE
Fix JAX CUDA plugin compatibility, protobuf version error, and mesh syntax deprecation

### DIFF
--- a/examples/qlora_llama3_gpu.ipynb
+++ b/examples/qlora_llama3_gpu.ipynb
@@ -72,8 +72,9 @@
         "\n",
         "if importlib.util.find_spec(\"tunix\") is None:\n",
         "  print(\"Required packages not found. Running full installation...\")\n",
-        "  %pip install 'jax[cuda13]' flax optax transformers datasets qwix huggingface_hub wandb\n",
-        "  %pip install git+https://github.com/google/tunix"
+        "  %pip install -Uq \"jax[cuda13]==0.10.2\" optax transformers datasets qwix huggingface_hub wandb\n",
+        "  %pip install git+https://github.com/google/tunix\n",
+        "  %pip install -Uq \"protobuf<7.0.0\""
       ]
     },
     {
@@ -751,12 +752,20 @@
         "print(f\"Prompt: {prompt}\")\n",
         "print(f\"Generated ({len(generated_ids)} tokens): '{generated_text}'\")"
       ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "oIaGtYvQuiYS"
+      },
+      "execution_count": null,
+      "outputs": []
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3 (ipykernel)",
-      "language": "python",
+      "display_name": "Python 3",
       "name": "python3"
     },
     "language_info": {
@@ -770,8 +779,14 @@
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
       "version": "3.12.3"
-    }
+    },
+    "colab": {
+      "provenance": [],
+      "machine_shape": "hm",
+      "gpuType": "G4"
+    },
+    "accelerator": "GPU"
   },
   "nbformat": 4,
-  "nbformat_minor": 4
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
Resolves critical dependency version mismatches affecting JAX CUDA plugin execution and Protobuf compatibility, and updates deprecated JAX mesh context syntax to ensure stable runtime execution.

## Key Changes

### 1. Dependency & Environment Fixes
- **JAX CUDA Version Pinning:** Updated installation to `pip install "jax[cuda13]==0.10.2"` to eliminate `jaxlib` and `jax-cuda-plugin` PJRT API version mismatches (`PJRT_FFI_UserData_Add_Args size`).
- **Protobuf Versioning:** Added `pip install -U "protobuf<7.0.0"` to resolve Protobuf `VersionError` incompatibilities.

### 2. API Deprecation Updates
- **Mesh Context Syntax:** Replaced deprecated `with mesh:` context manager with `with jax.set_mesh(mesh):`.
