### PR TITLE
[tunix] Add model-agnostic JAX diffusion training contracts

### DIFF
--- a/tests/diffusion/types_test.py
+++ b/tests/diffusion/types_test.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for framework-neutral diffusion contracts."""
+
+from absl.testing import absltest
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import jax.sharding as shd
+import numpy as np
+from tunix.diffusion import interfaces
+from tunix.diffusion import types
+from tunix.sft import sharding_utils
+
+
+def _batch(
+    *,
+    model_inputs=None,
+    target_ids=None,
+    loss_weights=None,
+) -> types.DiffusionTokenBatch:
+  if model_inputs is None:
+    model_inputs = {
+        "input_tokens": jnp.array([[1, 2, 3], [4, 5, 6]], dtype=jnp.int32),
+        "noise_levels": jnp.array([0.25, 0.75], dtype=jnp.float32),
+    }
+  if target_ids is None:
+    target_ids = jnp.array([[2, 3, 4], [5, 6, 7]], dtype=jnp.int32)
+  if loss_weights is None:
+    loss_weights = jnp.ones((2, 3), dtype=jnp.float32)
+  return types.DiffusionTokenBatch.create(
+      model_inputs=model_inputs,
+      target_ids=target_ids,
+      loss_weights=loss_weights,
+  )
+
+
+class _ToyModel(nnx.Module):
+
+  def __init__(self, vocab_size: int):
+    self.bias = nnx.Param(jnp.arange(vocab_size, dtype=jnp.float32))
+
+  def score(self, input_tokens: jax.Array) -> jax.Array:
+    bias = self.bias[...]
+    return jax.nn.one_hot(input_tokens, bias.shape[0]) + bias
+
+
+def _score_fn(model: nnx.Module, model_inputs: types.ModelInputs) -> jax.Array:
+  return model.score(model_inputs["input_tokens"])
+
+
+class DiffusionTokenBatchTest(absltest.TestCase):
+
+  def test_requires_rank_two_integer_targets(self):
+    with self.assertRaisesRegex(ValueError, "shape \\[batch, length\\]"):
+      _batch(target_ids=jnp.ones((2, 3, 1), dtype=jnp.int32))
+    with self.assertRaisesRegex(TypeError, "integer dtype"):
+      _batch(target_ids=jnp.ones((2, 3), dtype=jnp.float32))
+
+  def test_requires_matching_real_loss_weights(self):
+    with self.assertRaisesRegex(ValueError, "must match target_ids shape"):
+      _batch(loss_weights=jnp.ones((2, 2), dtype=jnp.float32))
+    with self.assertRaisesRegex(TypeError, "real numeric or boolean"):
+      _batch(loss_weights=jnp.ones((2, 3), dtype=jnp.complex64))
+
+  def test_accepts_boolean_and_integer_loss_weights(self):
+    self.assertEqual(
+        _batch(loss_weights=jnp.ones((2, 3), dtype=bool)).loss_weights.dtype,
+        jnp.bool_,
+    )
+    self.assertEqual(
+        _batch(
+            loss_weights=jnp.ones((2, 3), dtype=jnp.int32)
+        ).loss_weights.dtype,
+        jnp.int32,
+    )
+
+  def test_rejects_invalid_loss_weight_values(self):
+    with self.assertRaisesRegex(ValueError, "finite"):
+      _batch(loss_weights=jnp.array([[jnp.nan, 1, 1], [1, 1, 1]]))
+    with self.assertRaisesRegex(ValueError, "finite"):
+      _batch(loss_weights=jnp.array([[jnp.inf, 1, 1], [1, 1, 1]]))
+    with self.assertRaisesRegex(ValueError, "nonnegative"):
+      _batch(loss_weights=jnp.array([[-1.0, 1, 1], [1, 1, 1]]))
+
+  def test_rejects_negative_active_targets_but_allows_inactive_sentinels(self):
+    target_ids = jnp.array([[-1, 2, 3], [4, 5, 6]], dtype=jnp.int32)
+    with self.assertRaisesRegex(ValueError, "active target_ids"):
+      _batch(target_ids=target_ids)
+
+    batch = _batch(
+        target_ids=target_ids,
+        loss_weights=jnp.array([[0, 1, 1], [1, 1, 1]], dtype=jnp.float32),
+    )
+    self.assertEqual(int(batch.target_ids[0, 0]), -1)
+
+  def test_requires_nonempty_batch_major_array_inputs(self):
+    with self.assertRaisesRegex(ValueError, "at least one array"):
+      _batch(model_inputs={})
+    with self.assertRaisesRegex(TypeError, "must be a JAX or NumPy array"):
+      _batch(model_inputs={"tokens": [[1, 2, 3], [4, 5, 6]]})
+    with self.assertRaisesRegex(ValueError, "not scalar"):
+      _batch(model_inputs={"temperature": jnp.array(1.0)})
+    with self.assertRaisesRegex(ValueError, "batch size 3; expected 2"):
+      _batch(model_inputs={"tokens": jnp.ones((3, 3), dtype=jnp.int32)})
+    with self.assertRaisesRegex(TypeError, "real numeric or boolean"):
+      _batch(model_inputs={"tokens": np.array([["a"], ["b"]])})
+
+  def test_is_a_jax_pytree_and_jittable(self):
+    batch = _batch()
+    leaves, tree_def = jax.tree.flatten(batch)
+
+    self.assertLen(leaves, 4)
+    restored = jax.tree.unflatten(tree_def, leaves)
+    np.testing.assert_array_equal(restored.target_ids, batch.target_ids)
+
+    @jax.jit
+    def weighted_targets(value):
+      return value.target_ids * value.loss_weights
+
+    np.testing.assert_array_equal(
+        weighted_targets(batch), batch.target_ids.astype(jnp.float32)
+    )
+
+  def test_array_leaves_are_compatible_with_data_sharding(self):
+    batch = _batch()
+    mesh = shd.Mesh(np.array(jax.devices()[:1]), ("data",))
+
+    with mesh:
+      sharded_batch = sharding_utils.shard_input(batch, ("data",))
+
+    for leaf in jax.tree.leaves(sharded_batch):
+      self.assertIsInstance(leaf, jax.Array)
+      self.assertEqual(leaf.sharding.spec, shd.PartitionSpec("data"))
+
+
+class DiffusionLogitsTest(absltest.TestCase):
+
+  def test_scores_are_target_aligned_and_jittable(self):
+    batch = _batch()
+    model = _ToyModel(vocab_size=8)
+
+    @nnx.jit
+    def score(model, batch):
+      return interfaces.compute_diffusion_logits(model, batch, _score_fn)
+
+    scores = score(model, batch)
+    self.assertEqual(scores.shape, (2, 3, 8))
+    self.assertEqual(scores.dtype, jnp.float32)
+
+  def test_rejects_non_target_aligned_scores(self):
+    batch = _batch()
+    with self.assertRaisesRegex(ValueError, "align with target_ids"):
+      types.validate_diffusion_logits(
+          batch, jnp.ones((2, 2, 8), dtype=jnp.float32)
+      )
+    with self.assertRaisesRegex(ValueError, "non-empty vocabulary"):
+      types.validate_diffusion_logits(
+          batch, jnp.ones((2, 3, 0), dtype=jnp.float32)
+      )
+
+  def test_rejects_invalid_score_rank_and_dtype(self):
+    batch = _batch()
+    with self.assertRaisesRegex(ValueError, "shape \\[batch, length, vocab\\]"):
+      types.validate_diffusion_logits(
+          batch, jnp.ones((2, 3), dtype=jnp.float32)
+      )
+    with self.assertRaisesRegex(TypeError, "floating-point dtype"):
+      types.validate_diffusion_logits(
+          batch, jnp.ones((2, 3, 8), dtype=jnp.int32)
+      )
+
+  def test_rejects_active_targets_outside_vocabulary(self):
+    batch = _batch(
+        target_ids=jnp.array([[2, 8, 4], [5, 6, 7]], dtype=jnp.int32)
+    )
+    with self.assertRaisesRegex(ValueError, "smaller than vocabulary size 8"):
+      types.validate_diffusion_logits(
+          batch, jnp.ones((2, 3, 8), dtype=jnp.float32)
+      )
+
+  def test_validated_scorer_rejects_misaligned_implementation(self):
+    def misaligned_score_fn(model, model_inputs):
+      del model
+      batch_size = model_inputs["input_tokens"].shape[0]
+      return jnp.ones((batch_size, 1, 8), dtype=jnp.float32)
+
+    with self.assertRaisesRegex(ValueError, "align with target_ids"):
+      interfaces.compute_diffusion_logits(
+          _ToyModel(vocab_size=8), _batch(), misaligned_score_fn
+      )
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tunix/diffusion/__init__.py
+++ b/tunix/diffusion/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Framework-neutral contracts for diffusion training."""
+
+# pylint: disable=g-importing-member
+
+from tunix.diffusion.interfaces import compute_diffusion_logits
+from tunix.diffusion.interfaces import DiffusionBatchAdapter
+from tunix.diffusion.interfaces import DiffusionLogitsFn
+from tunix.diffusion.types import DiffusionTokenBatch
+
+__all__ = [
+    "DiffusionBatchAdapter",
+    "DiffusionLogitsFn",
+    "DiffusionTokenBatch",
+    "compute_diffusion_logits",
+]

--- a/tunix/diffusion/interfaces.py
+++ b/tunix/diffusion/interfaces.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Callable interfaces for framework-neutral diffusion integrations."""
+
+from typing import Protocol, TypeVar
+
+from flax import nnx
+from tunix.diffusion import types
+
+RawBatchT_contra = TypeVar("RawBatchT_contra", contravariant=True)
+
+
+class DiffusionBatchAdapter(Protocol[RawBatchT_contra]):
+  """Converts an external batch to Tunix's canonical diffusion batch."""
+
+  def __call__(self, batch: RawBatchT_contra, /) -> types.DiffusionTokenBatch:
+    ...
+
+
+class DiffusionLogitsFn(Protocol):
+  """Computes target-aligned token logits for a diffusion model."""
+
+  def __call__(
+      self,
+      model: nnx.Module,
+      model_inputs: types.ModelInputs,
+      /,
+  ) -> types.Array:
+    ...
+
+
+def compute_diffusion_logits(
+    model: nnx.Module,
+    batch: types.DiffusionTokenBatch,
+    logits_fn: DiffusionLogitsFn,
+) -> types.Array:
+  """Computes diffusion logits and validates target alignment."""
+
+  batch.validate()
+  logits = logits_fn(model, batch.model_inputs)
+  return types.validate_diffusion_logits(batch, logits)

--- a/tunix/diffusion/types.py
+++ b/tunix/diffusion/types.py
@@ -1,0 +1,200 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Data types shared by diffusion training objectives."""
+
+from collections.abc import Mapping
+from typing import Any, TypeAlias
+
+import flax
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+Array: TypeAlias = jax.Array | np.ndarray
+ModelInputs: TypeAlias = Mapping[str, Any]
+
+
+def _shape_and_dtype(name: str, value: Any) -> tuple[tuple[int, ...], Any]:
+  if not isinstance(value, (jax.Array, jax.core.Tracer, np.ndarray)):
+    raise TypeError(f"{name} must be a JAX or NumPy array")
+  return tuple(value.shape), value.dtype
+
+
+def _is_loss_weight_dtype(dtype: Any) -> bool:
+  return (
+      jnp.issubdtype(dtype, jnp.bool_)
+      or jnp.issubdtype(dtype, jnp.integer)
+      or jnp.issubdtype(dtype, jnp.floating)
+  )
+
+
+def _concrete_numpy(value: Any) -> np.ndarray | None:
+  """Returns eager values without performing host conversion while tracing."""
+
+  if isinstance(value, jax.core.Tracer):
+    return None
+  if isinstance(value, jax.Array) and not value.is_fully_addressable:
+    return None
+  return np.asarray(value)
+
+
+@flax.struct.dataclass(frozen=True)
+class DiffusionTokenBatch:
+  """Canonical target-aligned batch for diffusion training.
+
+  Every array in ``model_inputs`` must be batch-major. Model-static values and
+  non-batch tensors belong in the scoring callable so that Tunix can shard the
+  complete batch pytree consistently along its leading dimension.
+
+  Attributes:
+    model_inputs: Model-specific, batch-major array pytree consumed by a
+      ``DiffusionLogitsFn``.
+    target_ids: Target token IDs with shape ``[batch, length]``.
+    loss_weights: Per-target weights with the same shape as ``target_ids``.
+  """
+
+  model_inputs: ModelInputs
+  target_ids: Array
+  loss_weights: Array
+
+  @classmethod
+  def create(
+      cls,
+      *,
+      model_inputs: ModelInputs,
+      target_ids: Array,
+      loss_weights: Array,
+  ) -> "DiffusionTokenBatch":
+    """Constructs and validates a diffusion batch."""
+
+    return cls(
+        model_inputs=model_inputs,
+        target_ids=target_ids,
+        loss_weights=loss_weights,
+    ).validate()
+
+  def validate(self) -> "DiffusionTokenBatch":
+    """Validates the batch's static shape and dtype contract."""
+
+    if not isinstance(self.model_inputs, Mapping):
+      raise TypeError("model_inputs must be a mapping")
+
+    target_shape, target_dtype = _shape_and_dtype("target_ids", self.target_ids)
+    if len(target_shape) != 2:
+      raise ValueError(
+          f"target_ids must have shape [batch, length]; received {target_shape}"
+      )
+    if not jnp.issubdtype(target_dtype, jnp.integer):
+      raise TypeError(
+          f"target_ids must have an integer dtype; received {target_dtype}"
+      )
+
+    weight_shape, weight_dtype = _shape_and_dtype(
+        "loss_weights", self.loss_weights
+    )
+    if weight_shape != target_shape:
+      raise ValueError(
+          "loss_weights must match target_ids shape; "
+          f"received {weight_shape} and {target_shape}"
+      )
+    if not _is_loss_weight_dtype(weight_dtype):
+      raise TypeError(
+          "loss_weights must have a real numeric or boolean dtype; "
+          f"received {weight_dtype}"
+      )
+    concrete_weights = _concrete_numpy(self.loss_weights)
+    if concrete_weights is not None:
+      if not np.all(np.isfinite(concrete_weights)):
+        raise ValueError("loss_weights must contain only finite values")
+      if np.any(concrete_weights < 0):
+        raise ValueError("loss_weights must be nonnegative")
+      concrete_targets = _concrete_numpy(self.target_ids)
+      if concrete_targets is not None and np.any(
+          concrete_targets[concrete_weights > 0] < 0
+      ):
+        raise ValueError("active target_ids must be nonnegative")
+
+    model_input_leaves = jax.tree.leaves(self.model_inputs)
+    if not model_input_leaves:
+      raise ValueError("model_inputs must contain at least one array")
+    batch_size = target_shape[0]
+    for index, leaf in enumerate(model_input_leaves):
+      leaf_shape, leaf_dtype = _shape_and_dtype(
+          f"model_inputs leaf {index}", leaf
+      )
+      if not leaf_shape:
+        raise ValueError(
+            f"model_inputs leaf {index} must be batch-major, not scalar"
+        )
+      if leaf_shape[0] != batch_size:
+        raise ValueError(
+            f"model_inputs leaf {index} has batch size {leaf_shape[0]}; "
+            f"expected {batch_size}"
+        )
+      if not _is_loss_weight_dtype(leaf_dtype):
+        raise TypeError(
+            f"model_inputs leaf {index} must have a real numeric or boolean "
+            f"dtype; received {leaf_dtype}"
+        )
+    return self
+
+
+def validate_diffusion_logits(
+    batch: DiffusionTokenBatch, logits: Array
+) -> Array:
+  """Validates and returns target-aligned token logits.
+
+  The checks use static shape and dtype metadata, so this function is safe to
+  invoke while tracing a JAX computation.
+
+  Args:
+    batch: The batch whose targets the scores must align with.
+    logits: Floating-point token logits with shape ``[batch, length, vocab]``.
+
+  Returns:
+    ``logits`` unchanged.
+
+  Raises:
+    TypeError: If ``logits`` is not an array or has a non-floating dtype.
+    ValueError: If ``logits`` is not target-aligned, has an empty vocabulary,
+      or an active target ID falls outside that vocabulary.
+  """
+
+  logit_shape, logit_dtype = _shape_and_dtype("logits", logits)
+  if len(logit_shape) != 3:
+    raise ValueError(
+        f"logits must have shape [batch, length, vocab]; received {logit_shape}"
+    )
+  if logit_shape[:2] != tuple(batch.target_ids.shape):
+    raise ValueError(
+        "logits must align with target_ids on [batch, length]; "
+        f"received {logit_shape[:2]} and {tuple(batch.target_ids.shape)}"
+    )
+  if logit_shape[2] < 1:
+    raise ValueError("logits must have a non-empty vocabulary dimension")
+  if not jnp.issubdtype(logit_dtype, jnp.floating):
+    raise TypeError(
+        f"logits must have a floating-point dtype; received {logit_dtype}"
+    )
+  concrete_targets = _concrete_numpy(batch.target_ids)
+  concrete_weights = _concrete_numpy(batch.loss_weights)
+  if concrete_targets is not None and concrete_weights is not None:
+    active_targets = concrete_targets[concrete_weights > 0]
+    if np.any(active_targets >= logit_shape[2]):
+      raise ValueError(
+          "active target_ids must be smaller than vocabulary size"
+          f" {logit_shape[2]}"
+      )
+  return logits


### PR DESCRIPTION
## Motivation

Diffusion training integrations need a stable batch and scoring boundary that does not depend on MaxText, a specific model, or one training algorithm.

## Scope

- Add a canonical batch-major `DiffusionTokenBatch` with target-aligned targets and explicit loss weights.
- Define typed raw-batch adapter and logits-function protocols.
- Validate shapes, dtypes, eager values, and scorer outputs while preserving JAX pytree behavior.

## Design

Every model-input leaf has the same leading batch axis. Model-specific static configuration lives in the logits-function closure rather than the batch. Targets refer to physical target positions, so same-position and shifted models resolve alignment before constructing the contract.

Construction and scoring boundaries validate array structure and active values. Validation remains trace safe under JIT and sharding; additional finite/range checks run when arrays are eagerly addressable.

## Compatibility

These are new model-agnostic JAX modules. Existing SFT, distillation, RL, and autoregressive paths do not construct them and remain unchanged.

## Extensibility

MaxText and other integrations can provide different corruption, tokenizer, model, and alignment policies while sharing the same Tunix loss and learner interfaces.

## Tests

- 10 focused diffusion contract tests at this stack point.
- Coverage includes invalid shapes/dtypes/values, target-aligned logits, pytrees, JIT, and sharding-safe validation.
- Pyink, isort, Pylint, Pyrefly, and Python compilation passed.

## Known limitations

The contract intentionally does not create corruption, execute a model rollout, choose stop tokens, or prove that a prepared batch is fresh.

## Stack

First PR in this repository stack; no preceding PR dependency.

[Tunix block-diffusion design document](https://docs.google.com/document/d/1Xe-98ScS2RSH29AdhTdc9tO4WHQG5wCbFkJA3gmIUZQ/edit)
