### PR TITLE
Add Qwen3.5-397B-A17B config, tests for 35B and 397B, and docs

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -17,6 +17,7 @@ Tunix supports the following models:
 | Llama 3.2 | 1B, 3B |
 | Qwen 2.5 | 0.5B, 1.5B, 3B, 7B |
 | Qwen 3 | 0.6B, 1.7B, 4B, 8B, 14B, 30B, 32B |
+| Qwen 3.5 | 35B, 397B |
 
 ### Model Sources
 

--- a/tests/models/automodel_test.py
+++ b/tests/models/automodel_test.py
@@ -106,6 +106,14 @@ def _get_all_models_test_parameters():
       dict(testcase_name="qwen3-30b-a3b", model_name="qwen3-30b-a3b"),
       dict(testcase_name="qwen3-32b", model_name="qwen3-32b"),
       dict(testcase_name="Qwen3-32B", model_name="Qwen3-32B"),
+      dict(
+          testcase_name="qwen3.5-35b-a3b",
+          model_name="qwen3.5-35b-a3b",
+      ),
+      dict(
+          testcase_name="qwen3.5-397b-a17b",
+          model_name="qwen3.5-397b-a17b",
+      ),
   )
 
 
@@ -432,6 +440,7 @@ class AutoModelTest(parameterized.TestCase):
     self.assertTrue(called_config.use_flash_attention)
     self.assertEqual(called_config.flash_attention_block_size, 512)
     self.assertFalse(hasattr(called_config, "invalid_param"))
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/models/qwen3/qwen_params_test.py
+++ b/tests/models/qwen3/qwen_params_test.py
@@ -183,7 +183,6 @@ class Qwen3ParamsTest(lora_params_test_base.LoraParamsTestBase):
     return self.base_checkpoint_dir
 
 
-
 class Qwen3ModelConfigTest(absltest.TestCase):
   """Tests specific to Qwen3 configurations and architectural flags."""
 
@@ -193,22 +192,52 @@ class Qwen3ModelConfigTest(absltest.TestCase):
     config_0p6b = qwen3_model.ModelConfig.qwen3_0p6b()
     self.assertTrue(
         config_0p6b.use_tied_embedding,
-        "qwen3_0p6b config should have use_tied_embedding=True"
+        "qwen3_0p6b config should have use_tied_embedding=True",
     )
 
     # 1.5B / 1.7B model should use tied embeddings
     config_1p7b = qwen3_model.ModelConfig.qwen3_1p7b()
     self.assertTrue(
         config_1p7b.use_tied_embedding,
-        "qwen3_1p7b config should have use_tied_embedding=True"
+        "qwen3_1p7b config should have use_tied_embedding=True",
     )
 
     # 8B model typically does not use tied embeddings
     config_8b = qwen3_model.ModelConfig.qwen3_8b()
     self.assertFalse(
         config_8b.use_tied_embedding,
-        "qwen3_8b config should have use_tied_embedding=False"
+        "qwen3_8b config should have use_tied_embedding=False",
     )
+
+  def test_qwen3p5_35b_a3b_config(self):
+    """Verify that qwen3p5_35b_a3b config is correctly instantiated."""
+    config = qwen3_model.ModelConfig.qwen3p5_35b_a3b()
+    self.assertEqual(config.num_layers, 40)
+    self.assertEqual(config.vocab_size, 248320)
+    self.assertEqual(config.embed_dim, 2048)
+    self.assertEqual(config.hidden_dim, 512)
+    self.assertEqual(config.num_heads, 16)
+    self.assertEqual(config.head_dim, 256)
+    self.assertEqual(config.num_kv_heads, 2)
+    self.assertEqual(config.norm_eps, 1e-06)
+    self.assertEqual(config.rope_theta, 10_000_000)
+    self.assertEqual(config.num_experts, 256)
+    self.assertEqual(config.num_experts_per_tok, 8)
+
+  def test_qwen3p5_397b_a17b_config(self):
+    """Verify that qwen3p5_397b_a17b config is correctly instantiated."""
+    config = qwen3_model.ModelConfig.qwen3p5_397b_a17b()
+    self.assertEqual(config.num_layers, 60)
+    self.assertEqual(config.vocab_size, 248320)
+    self.assertEqual(config.embed_dim, 4096)
+    self.assertEqual(config.hidden_dim, 1024)
+    self.assertEqual(config.num_heads, 32)
+    self.assertEqual(config.head_dim, 256)
+    self.assertEqual(config.num_kv_heads, 2)
+    self.assertEqual(config.norm_eps, 1e-06)
+    self.assertEqual(config.rope_theta, 10_000_000)
+    self.assertEqual(config.num_experts, 512)
+    self.assertEqual(config.num_experts_per_tok, 10)
 
   def test_model_instantiation_with_tied_embeddings(self):
     """Verify that the Qwen3 model omits the lm_head when embeddings are tied."""
@@ -232,7 +261,8 @@ class Qwen3ModelConfigTest(absltest.TestCase):
     # The model should decode using the embedder, so lm_head shouldn't exist
     self.assertFalse(
         hasattr(tied_model, "lm_head"),
-        "Model should not have a separate lm_head when use_tied_embedding is True"
+        "Model should not have a separate lm_head when use_tied_embedding is"
+        " True",
     )
 
   def test_model_instantiation_without_tied_embeddings(self):
@@ -257,7 +287,7 @@ class Qwen3ModelConfigTest(absltest.TestCase):
     # The model should have a distinct lm_head layer
     self.assertTrue(
         hasattr(untied_model, "lm_head"),
-        "Model must have a separate lm_head when use_tied_embedding is False"
+        "Model must have a separate lm_head when use_tied_embedding is False",
     )
 
 

--- a/tunix/models/qwen3/model.py
+++ b/tunix/models/qwen3/model.py
@@ -122,7 +122,9 @@ class ShardingConfig:
         o_weight_nhd=P('tp', None, fsdp),
         ffw_weight_df=P(fsdp, 'tp'),
         ffw_weight_fd=P('tp', fsdp),
-        rms_norm_weight=P('tp',),
+        rms_norm_weight=P(
+            'tp',
+        ),
         act_btd=P('fsdp', sp, None if is_sampling else 'tp'),
         act_btf=P('fsdp', sp, 'tp'),
         act_btnh=P('fsdp', sp, 'tp', None),
@@ -154,7 +156,6 @@ class ModelConfig:
   param_dtype: jnp.dtype = jnp.float32
   use_flash_attention: bool = False
   flash_attention_block_size: int = 1024
-
 
   @classmethod
   def qwen3_0p6b(cls):  # qwen3-0.6B
@@ -308,6 +309,22 @@ class ModelConfig:
         num_experts_per_tok=8,
     )
 
+  @classmethod
+  def qwen3p5_397b_a17b(cls):  # Qwen3.5-397B-A17B
+    return cls(
+        num_layers=60,
+        vocab_size=248320,
+        embed_dim=4096,
+        hidden_dim=1024,
+        num_heads=32,
+        head_dim=256,
+        num_kv_heads=2,
+        norm_eps=1e-06,
+        rope_theta=10_000_000,
+        num_experts=512,
+        num_experts_per_tok=10,
+    )
+
 
 def shard(x: jnp.ndarray, s: Tuple[str, ...]):
   mesh = pxla.thread_resources.env.physical_mesh
@@ -422,7 +439,9 @@ class RMSNorm(nnx.Module):
       param_dtype: jnp.dtype,
   ):
     self.w = nnx.Param(
-        nnx.initializers.ones_init()(rngs.params(), dim, param_dtype),  # pyrefly: ignore[bad-argument-type]
+        nnx.initializers.ones_init()(
+            rngs.params(), dim, param_dtype
+        ),  # pyrefly: ignore[bad-argument-type]
         sharding=shd_config.rms_norm_weight,
     )
     self.norm_eps = norm_eps
@@ -513,9 +532,15 @@ class Attention(nnx.Module):
     key_proj = self.k_norm(self.k_proj(x))
     value_proj = self.v_proj(x)
 
-    query_proj = shard(query_proj, self.shd_config.act_btnh)  # pyrefly: ignore[bad-argument-type]
-    key_proj = shard(key_proj, self.shd_config.act_btnh)  # pyrefly: ignore[bad-argument-type]
-    value_proj = shard(value_proj, self.shd_config.act_btnh)  # pyrefly: ignore[bad-argument-type]
+    query_proj = shard(
+        query_proj, self.shd_config.act_btnh
+    )  # pyrefly: ignore[bad-argument-type]
+    key_proj = shard(
+        key_proj, self.shd_config.act_btnh
+    )  # pyrefly: ignore[bad-argument-type]
+    value_proj = shard(
+        value_proj, self.shd_config.act_btnh
+    )  # pyrefly: ignore[bad-argument-type]
 
     query_proj = apply_rope(
         query_proj,
@@ -661,7 +686,9 @@ class Attention(nnx.Module):
       qkv = qkv.reshape((b, t, qh, d))
 
     outputs = self.o_proj(qkv)
-    outputs = shard(outputs, self.shd_config.act_btd)  # pyrefly: ignore[bad-argument-type]
+    outputs = shard(
+        outputs, self.shd_config.act_btd
+    )  # pyrefly: ignore[bad-argument-type]
 
     if cache is not None:
       new_cache = {
@@ -697,7 +724,9 @@ class Attention(nnx.Module):
           state, x, segment_pos, cache, attn_mask, segment_ids=segment_ids
       )
     else:
-      return self.block(x, segment_pos, cache, attn_mask, segment_ids=segment_ids)
+      return self.block(
+          x, segment_pos, cache, attn_mask, segment_ids=segment_ids
+      )
 
   @property
   def head_dim(self):
@@ -758,7 +787,8 @@ class MoELayer(nnx.Module):
   def __call__(self, x, use_megablox=True):
     scores = self.router(x).astype(jnp.float32)  # [B,T,E]
     routing_weights, routing_idx = jax.lax.top_k(
-        jax.nn.softmax(scores, axis=-1), self.experts_per_tok  # pyrefly: ignore[bad-argument-type]
+        jax.nn.softmax(scores, axis=-1),
+        self.experts_per_tok,  # pyrefly: ignore[bad-argument-type]
     )
     routing_weights = (
         routing_weights / jnp.sum(routing_weights, axis=-1, keepdims=True)
@@ -773,7 +803,9 @@ class MoELayer(nnx.Module):
     # -------------------------------------------------------------
     if not use_megablox or (mesh.empty or jax.devices()[0].platform == 'cpu'):
       dispatch_mask = jax.nn.one_hot(
-          routing_idx, num_classes=self.num_experts, dtype=self.dtype  # pyrefly: ignore[bad-argument-type]
+          routing_idx,
+          num_classes=self.num_experts,
+          dtype=self.dtype,  # pyrefly: ignore[bad-argument-type]
       )  # [B, T, K, E]
       dispatch_mask = jnp.swapaxes(dispatch_mask, -1, -2)  # [B, T, E, K]
       dispatched_input = jnp.einsum(
@@ -846,10 +878,14 @@ class MoELayer(nnx.Module):
         num_ep = 1
         ep_shard_idx = 0
 
-      num_local_experts = self.num_experts // num_ep  # pyrefly: ignore[unsupported-operation]
+      num_local_experts = (
+          self.num_experts // num_ep
+      )  # pyrefly: ignore[unsupported-operation]
 
       flat_repeated_inputs = jnp.repeat(
-          inputs.reshape(B * T, D_global), self.experts_per_tok, axis=0  # pyrefly: ignore[bad-argument-type]
+          inputs.reshape(B * T, D_global),
+          self.experts_per_tok,
+          axis=0,  # pyrefly: ignore[bad-argument-type]
       )
       flat_selected_indices = indices.reshape(-1)
 
@@ -882,7 +918,10 @@ class MoELayer(nnx.Module):
         local_output_offsets = global_out_offsets[ep_shard_idx]
 
         output_buffer_size = (
-            min(self.experts_per_tok, num_local_experts) * B * T * num_ep  # pyrefly: ignore[bad-specialization]
+            min(self.experts_per_tok, num_local_experts)
+            * B
+            * T
+            * num_ep  # pyrefly: ignore[bad-specialization]
         )
         output_buffer = jax.lax.empty(
             shape=(output_buffer_size, D_global), dtype=inputs.dtype
@@ -1055,7 +1094,9 @@ class MLP(nnx.Module):
       x: jaxtyping.Array,
   ) -> jaxtyping.Array:
     activations = nnx.silu(self.gate_proj(x)) * self.up_proj(x)
-    activations = shard(activations, self.shd_config.act_btf)  # pyrefly: ignore[bad-argument-type]
+    activations = shard(
+        activations, self.shd_config.act_btf
+    )  # pyrefly: ignore[bad-argument-type]
     outputs = self.down_proj(activations)
     return outputs
 
@@ -1219,7 +1260,7 @@ class Qwen3(BackendMappingMixin, nnx.Module):
         f'layer_{i}': {
             'k': jnp.zeros(shape, dtype=config.dtype),
             'v': jnp.zeros(shape, dtype=config.dtype),
-            'end_index': jnp.zeros((batch_size,), dtype=jnp.int32)
+            'end_index': jnp.zeros((batch_size,), dtype=jnp.int32),
         }
         for i in range(config.num_layers)
     }

--- a/tunix/models/registry.py
+++ b/tunix/models/registry.py
@@ -525,4 +525,12 @@ MODEL_CATALOG = (
         model_config_id='qwen3p5_35b_a3b',
         model_config_category='qwen3',
     ),
+    naming.ModelNaming(
+        model_id='Qwen/Qwen3.5-397B-A17B',
+        model_name='qwen3.5-397b-a17b',
+        model_family='qwen3p5',
+        model_version='397b_a17b',
+        model_config_id='qwen3p5_397b_a17b',
+        model_config_category='qwen3',
+    ),
 )


### PR DESCRIPTION
Resolves #

Add Qwen3.5-397B-A17B model configuration to the model registry and define the ModelConfig parameters for it. Additionally, add unit tests for both Qwen3.5-35B-A3B and Qwen3.5-397B-A17B configurations, and update the model support list in the documentation.

**Reference**
- Model configuration details:
  - Qwen3.5-35B-A3B: https://huggingface.co/Qwen/Qwen3.5-35B-A3B
  - Qwen3.5-397B-A17B: https://huggingface.co/Qwen/Qwen3.5-397B-A17B

**Colab Notebook**
N/A

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
