### PR TITLE
Fix prompt batching structure for agentic rollout generation

### DIFF
--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -451,8 +451,9 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
       if "pair_index" in env.extra_kwargs:
         tags[perf_constants.PAIR_INDEX] = env.extra_kwargs["pair_index"]
 
+    prompts = [chat_lists]
     result = self.rl_engine.generate(
-        prompts=chat_lists,  # pyrefly: ignore[bad-argument-type]
+        prompts=prompts,  # pytype: disable=wrong-arg-types
         apply_chat_template=False if self.chat_parser else True,
         mode=rl_engine_lib.Mode.TRAIN,
         trace_tags=tags,


### PR DESCRIPTION
Ensure that when rollout_micro_batch_size = 1, the input conversation
history (list of dicts) is wrapped in a list to match the expected
batch format (list of list of dicts) of the rollout generation engine.