### PR TITLE
Configure vLLM rollout to use vllm_rpa attention

### DIFF
--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -906,6 +906,7 @@ if MODEL_SOURCE == "maxtext":
           "log_config": False,
           "weight_dtype": "bfloat16",
           "prefuse_moe_weights": True,
+          "attention": "vllm_rpa",
       }
   }
   # Force no-op mappings for weight sync if both trainer and sampler use MaxText


### PR DESCRIPTION
Set "attention": "vllm_rpa" in the MaxText model configuration for the vLLM rollout engine in train_deepswe_nb.py. 

This enables the use of optimized Paged Attention with RPA (Relaxed Precision Attention) kernels, improving inference throughput during RL policy rollouts.
