### PR TITLE
Support conditional installation of DeepSWE dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,16 @@ RUN pip install -e .
 
 RUN bash /app/scripts/install_tunix_vllm_requirement.sh
 
+# Build argument to conditionally install DeepSWE evaluation dependencies
+ARG INSTALL_DEEPSWE_DEPS=false
+
+# Install DeepSWE specific dependencies and apply runtime patches conditionally
+RUN if [ "$INSTALL_DEEPSWE_DEPS" = "true" ]; then \
+      pip install kubernetes gym swebench==3.0.2 && \
+      pip install --no-deps git+https://github.com/r2e-gym/r2e-gym.git@0d94c4eb9431cd195c55a7ea3abd54006c9a1735 && \
+      sed -i 's/create_repo, upload_folder, HfFolder/create_repo, upload_folder/' /opt/venv/lib/python3.12/site-packages/r2egym/agenthub/utils/utils.py && \
+      sed -i 's/self.commit = ParsedCommit(\*\*json.loads(self.commit_json))/self.commit = ParsedCommit(\*\*(json.loads(self.commit_json) if isinstance(self.commit_json, str) else self.commit_json))/' /opt/venv/lib/python3.12/site-packages/r2egym/agenthub/runtime/docker.py; \
+    fi
+
 # Set the default command to bash
 CMD ["bash"]

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -9,6 +9,15 @@
 
 set -e
 
+INSTALL_DEEPSWE_DEPS=false
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --deepswe) INSTALL_DEEPSWE_DEPS=true; shift ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+done
+
 DOCKERFILE=./Dockerfile
 
 if [ ! -f "$DOCKERFILE" ]; then
@@ -53,6 +62,7 @@ MSG
 
     $DOCKER_COMMAND build \
         --network=host \
+        --build-arg INSTALL_DEEPSWE_DEPS=${INSTALL_DEEPSWE_DEPS} \
         -t ${LOCAL_IMAGE_NAME} \
         -f ${DOCKERFILE} .
 }


### PR DESCRIPTION
This PR adds support for conditionally installing heavy evaluation dependencies in the Tunix Docker image.

- Introduces an `INSTALL_DEEPSWE_DEPS` build argument in the Dockerfile (default: `false`).
- Wraps the installation of `kubernetes`, `gym`, `swebench`, and `r2e-gym` (along with its related runtime patches) inside a conditional block.
- Updates `build_docker.sh` to accept a `--deepswe` parameter, which passes `--build-arg INSTALL_DEEPSWE_DEPS=true` to the `docker build` command.
