### PR TITLE
Add checkpoint_storage_concurrent_gb config override to DeepSWE training script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ COPY pyproject.toml README.md /app/
 RUN mkdir /app/tunix && touch /app/tunix/__init__.py
 RUN uv pip install .
 
+# Install SFT/MaxText dependencies (unconditional)
+RUN pip install --upgrade flax && \
+    pip install torchax aqtp tokamax && \
+    pip install git+https://github.com/google/maxtext.git@440d1c085b9c8647b0e7bba0d18f6882b5c90997
+
 # Build argument to conditionally install DeepSWE evaluation dependencies
 ARG INSTALL_DEEPSWE_DEPS=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,38 @@ RUN pip install git+https://github.com/ayaka14732/jax-smi.git
 # RUN pip install git+https://github.com/AI-Hypercomputer/pathways-utils.git@b72729bb152b7b3426299405950b3af300d765a9#egg=pathwaysutils
 RUN pip install gcsfs
 RUN pip install wandb
+RUN pip install uv
 
 # Set the working directory
 WORKDIR /app
 
-# Copy the project files to the image
+# Copy scripts and requirements first to leverage Docker cache
+COPY scripts/install_tunix_vllm_requirement.sh scripts/
+COPY requirements/ requirements/
+
+RUN bash scripts/install_tunix_vllm_requirement.sh
+
+# Copy pyproject.toml and README.md to install dependencies first
+COPY pyproject.toml README.md /app/
+RUN mkdir /app/tunix && touch /app/tunix/__init__.py
+RUN uv pip install .
+
+# Build argument to conditionally install DeepSWE evaluation dependencies
+ARG INSTALL_DEEPSWE_DEPS=false
+
+# Install DeepSWE specific dependencies and apply runtime patches conditionally
+RUN if [ "$INSTALL_DEEPSWE_DEPS" = "true" ]; then \
+      pip install kubernetes gym swebench==3.0.2 && \
+      pip install --no-deps git+https://github.com/r2e-gym/r2e-gym.git@0d94c4eb9431cd195c55a7ea3abd54006c9a1735 && \
+      sed -i 's/create_repo, upload_folder, HfFolder/create_repo, upload_folder/' /opt/venv/lib/python3.12/site-packages/r2egym/agenthub/utils/utils.py && \
+      sed -i 's/self.commit = ParsedCommit(\*\*json.loads(self.commit_json))/self.commit = ParsedCommit(\*\*(json.loads(self.commit_json) if isinstance(self.commit_json, str) else self.commit_json))/' /opt/venv/lib/python3.12/site-packages/r2egym/agenthub/runtime/docker.py; \
+    fi
+
+# Copy the rest of the project files
 COPY . .
 
-# Install the project in editable mode
-RUN pip install -e .
-
-RUN bash /app/scripts/install_tunix_vllm_requirement.sh
+# Install the project in editable mode (without dependencies, as they are already installed)
+RUN pip install --no-deps -e .
 
 # Build argument to conditionally install DeepSWE evaluation dependencies
 ARG INSTALL_DEEPSWE_DEPS=false

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -19,6 +19,7 @@ from huggingface_hub import snapshot_download
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
+from jax.experimental import mesh_utils
 from kubernetes import client, config as k8s_config
 import numpy as np
 import optax
@@ -745,10 +746,10 @@ rollout_shape = tuple(d for _, d in rollout_dims)
 train_axis_names = tuple(name for name, _ in train_dims)
 train_shape = tuple(d for _, d in train_dims)
 
-rollout_devices = np.array(devices[:num_rollout_devices]).reshape(rollout_shape)
-train_devices = np.array(
-    devices[num_rollout_devices : num_rollout_devices + num_train_devices]
-).reshape(train_shape)
+rollout_devices = mesh_utils.create_device_mesh(rollout_shape, devices[:num_rollout_devices], allow_split_physical_axes=True)
+train_devices = mesh_utils.create_device_mesh(
+    train_shape, devices[num_rollout_devices : num_rollout_devices + num_train_devices], allow_split_physical_axes=True
+)
 
 rollout_mesh = Mesh(rollout_devices, axis_names=rollout_axis_names)
 train_mesh = Mesh(train_devices, axis_names=train_axis_names)

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -135,6 +135,8 @@ parser.add_argument(
 parser.add_argument("--ckpt_dir", type=str, default="/tmp/cp/deepswe_ckpt/01")
 parser.add_argument("--max_to_keep", type=int, default=4)
 parser.add_argument("--save_interval_steps", type=int, default=500)
+parser.add_argument("--checkpoint_storage_concurrent_gb", type=int, default=96)
+
 
 # Microbatch Sizes
 parser.add_argument("--train_micro_batch_size", type=int, default=1)
@@ -779,6 +781,7 @@ if MODEL_SOURCE == "maxtext":
       enable_checkpointing=True,
       allow_split_physical_axes=True,
       scan_layers=True,
+      checkpoint_storage_concurrent_gb=args.checkpoint_storage_concurrent_gb,
   )
 else:
   qwen_reference = params_lib.create_model_from_safe_tensors(

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -25,6 +25,7 @@ import optax
 from orbax import checkpoint as ocp
 import qwix
 from transformers import AutoTokenizer
+from pydantic import ValidationError
 from tunix.cli.utils import data as data_lib
 from tunix.rl.agentic.agents import agent_types
 from tunix.utils import compat
@@ -45,16 +46,16 @@ parser.add_argument("--models_base_dir", type=str, default="models")
 parser.add_argument(
     "--model_source",
     type=str,
-    default="huggingface",
+    default="maxtext",
     choices=["huggingface", "maxtext"],
 )
 parser.add_argument(
     "--model_absolute_path",
     type=str,
-    default=None,
+    default="gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/scanned/0/items",
 )
 parser.add_argument("--seed", type=int, default=42)
-parser.add_argument("--model_version", type=str, default="Qwen/Qwen3-32B")
+parser.add_argument("--model_version", type=str, default="Qwen3.5-35B-A3B")
 parser.add_argument("--node_selector_val", type=str, default="deepswe-cpu-pool")
 parser.add_argument("--dataset_path", type=str, default=None)
 
@@ -565,7 +566,10 @@ USE_ROLLOUT_LOGPS = args.use_rollout_logps
 tokenizer_path = MODEL_PATH
 local_files_only = True
 if MODEL_SOURCE == "maxtext" and MODEL_PATH.startswith("gs://"):
-  tokenizer_path = MODEL_VERSION
+  if MODEL_VERSION.startswith("Qwen/"):
+    tokenizer_path = MODEL_VERSION
+  else:
+    tokenizer_path = f"Qwen/{MODEL_VERSION}"
   local_files_only = False
   print(f"Loading tokenizer from HF Hub: {tokenizer_path}")
 
@@ -1003,12 +1007,18 @@ cluster_config = rl_engine_lib.ClusterConfig(
 )
 sft_utils.show_hbm_usage()
 
-rl_engine = rl_engine_lib.RLEngine(
-    actor=qwen_actor,
-    reference=qwen_reference,
-    tokenizer=tokenizer,
-    cluster_config=cluster_config,
-)
+try:
+  rl_engine = rl_engine_lib.RLEngine(
+      actor=qwen_actor,
+      reference=qwen_reference,
+      tokenizer=tokenizer,
+      cluster_config=cluster_config,
+  )
+except ValidationError as e:
+  print("Failed to initialize RLEngine due to ValidationError:", flush=True)
+  import pprint
+  pprint.pprint(e.errors())
+  raise
 
 # %%
 # ==========================================
@@ -1046,6 +1056,7 @@ agentic_grpo_learner = agentic_grpo_learner.GRPOLearner(
         "max_steps": MAX_TURNS,
         "step_timeout": STEP_TIMEOUT_SECS,
         "reward_timeout": REWARD_TIMEOUT_SECS,
+        "verbose": True,
     },
     algo_config=grpo_config,
     # Disabling the custom chat parser is required to fallback to the tokenizer's

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -778,7 +778,7 @@ if MODEL_SOURCE == "maxtext":
       model_path=MODEL_PATH,
       enable_checkpointing=True,
       allow_split_physical_axes=True,
-      scan_layers=False,
+      scan_layers=True,
   )
 else:
   qwen_reference = params_lib.create_model_from_safe_tensors(

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -35,12 +35,24 @@ import vllm  # pytype: disable=import-error
 faulthandler.register(signal.SIGINT, all_threads=True)
 
 Dataset = datasets_lib.Dataset
+def str2bool(v):
+  if isinstance(v, bool):
+    return v
+  if v.lower() in ("yes", "true", "t", "y", "1"):
+    return True
+  elif v.lower() in ("no", "false", "f", "n", "0"):
+    return False
+  else:
+    raise argparse.ArgumentTypeError("Boolean value expected.")
+
+
 # ==========================================
 # 0. Argument Parsing
 # ==========================================
 parser = argparse.ArgumentParser(
     description="DeepSWE Training with Multi-turn Agentic Framework"
 )
+parser.add_argument("--scan_layers", type=str2bool, default=False)
 
 # General Config
 parser.add_argument("--models_base_dir", type=str, default="models")
@@ -315,6 +327,22 @@ def patch_kubernetes_runtime():
     print(
         "[Monkeypatch] Successfully patched DockerRuntime._start_kubernetes_pod"
     )
+
+    original_run = DockerRuntime.run
+
+    def patched_run(self, cmd, *args, **kwargs):
+      if isinstance(cmd, str) and cmd.startswith("chmod +x"):
+        path = cmd.split()[-1]
+        new_cmd = f"sh -c 'i=1; while [ $i -le 10 ]; do if [ -f {path} ]; then chmod +x {path} && exit 0; fi; sleep 0.5; i=$((i+1)); done; exit 1'"
+        print(f"[Monkeypatch] Intercepted chmod +x: replacing '{cmd}' with '{new_cmd}'")
+        return original_run(self, new_cmd, *args, **kwargs)
+      return original_run(self, cmd, *args, **kwargs)
+
+    DockerRuntime.run = patched_run
+    print(
+        "[Monkeypatch] Successfully patched DockerRuntime.run to handle chmod"
+        " +x race condition"
+    )
   except Exception as e:
     print(f"[Monkeypatch] Failed to patch DockerRuntime: {e}")
 
@@ -580,7 +608,49 @@ tokenizer = AutoTokenizer.from_pretrained(
     tokenizer_path, local_files_only=local_files_only, trust_remote_code=True
 )
 
-chat_parser = template_parser.QwenChatTemplateParser(tokenizer)
+class NativeChatTemplateParser:
+
+  def __init__(self, tokenizer):
+    self.tokenizer = tokenizer
+
+  def parse(
+      self,
+      messages: list[dict[str, str]],
+      add_generation_prompt: bool = False,
+      is_first_msg: bool = False,
+  ) -> str:
+    del is_first_msg  # Unused.
+    has_user = any(m["role"] == "user" for m in messages)
+    if has_user:
+      return self.tokenizer.apply_chat_template(
+          messages, tokenize=False, add_generation_prompt=add_generation_prompt
+      )
+
+    role = messages[0]["role"]
+    if role == "system":
+      temp_msgs = [messages[0], {"role": "user", "content": "DUMMY_QUERY"}]
+      rendered = self.tokenizer.apply_chat_template(
+          temp_msgs, tokenize=False, add_generation_prompt=False
+      )
+      return rendered.split("<|im_start|>user\nDUMMY_QUERY")[0]
+    elif role == "assistant":
+      temp_msgs = [{"role": "user", "content": "DUMMY_QUERY"}, messages[0]]
+      rendered = self.tokenizer.apply_chat_template(
+          temp_msgs, tokenize=False, add_generation_prompt=False
+      )
+      parts = rendered.split("<|im_start|>assistant\n")
+      return "<|im_start|>assistant\n" + parts[1]
+    else:
+      return self.tokenizer.apply_chat_template(
+          messages, tokenize=False, add_generation_prompt=add_generation_prompt
+      )
+
+  @property
+  def assistant_token(self) -> str:
+    return "<|im_start|>assistant\n<think>\n"
+
+
+chat_parser = NativeChatTemplateParser(tokenizer)
 
 print("Loading Dataset...")
 
@@ -780,7 +850,7 @@ if MODEL_SOURCE == "maxtext":
       model_path=MODEL_PATH,
       enable_checkpointing=True,
       allow_split_physical_axes=True,
-      scan_layers=True,
+      scan_layers=args.scan_layers,
       checkpoint_storage_concurrent_gb=args.checkpoint_storage_concurrent_gb,
   )
 else:
@@ -1063,11 +1133,7 @@ agentic_grpo_learner = agentic_grpo_learner.GRPOLearner(
         "verbose": True,
     },
     algo_config=grpo_config,
-    # Disabling the custom chat parser is required to fallback to the tokenizer's
-    # native ChatML template. Qwen 3.5 depends on specific <think> and </think> tags
-    # to trigger its reasoning blocks; the default parser would strip these tags,
-    # causing the model to output unstructured gibberish.
-    chat_parser=None,
+    chat_parser=chat_parser,
 )
 
 

--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -891,6 +891,10 @@ vllm_rollout_dict = {
         "enable_prefix_caching": True,
         "tokenizer": tokenizer_path,
     },
+    "rollout_vllm_sampling_kwargs": {
+        "stop": ["</function>"],
+        "detokenize": True,
+    },
 }
 
 if MODEL_SOURCE == "maxtext":
@@ -1044,7 +1048,11 @@ agentic_grpo_learner = agentic_grpo_learner.GRPOLearner(
         "reward_timeout": REWARD_TIMEOUT_SECS,
     },
     algo_config=grpo_config,
-    chat_parser=chat_parser,
+    # Disabling the custom chat parser is required to fallback to the tokenizer's
+    # native ChatML template. Qwen 3.5 depends on specific <think> and </think> tags
+    # to trigger its reasoning blocks; the default parser would strip these tags,
+    # causing the model to output unstructured gibberish.
+    chat_parser=None,
 )
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,1 +1,1 @@
-vllm @ git+https://github.com/vllm-project/vllm.git@5e584ce9ecb3cce63f1caab86177aef5c831690f
+vllm @ git+https://github.com/vllm-project/vllm.git@f5bb701fa270f5c801f1572e1478b56f292d8dfc

--- a/requirements/special_requirements.txt
+++ b/requirements/special_requirements.txt
@@ -2,4 +2,5 @@
 # --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html
 # --pre
 
-tpu-inference @ git+https://github.com/vllm-project/tpu-inference.git@8dd3107ac1d50b823c2a4edd036dd181775b1c94
+tpu-inference @ git+https://github.com/vllm-project/tpu-inference.git@a5596b27f02d1b1f1fb64c8bd4b0a73ae19b0336
+

--- a/tunix/rl/agentic/pipeline/rollout_orchestrator.py
+++ b/tunix/rl/agentic/pipeline/rollout_orchestrator.py
@@ -196,6 +196,11 @@ class RolloutOrchestrator:
           env.extra_kwargs["pair_index"],
           episode_count,
       )
+      try:
+        await asyncio.get_running_loop().run_in_executor(None, env.close)
+      except Exception as close_err:
+        logging.error("Failed to close environment: %s", close_err)
+
 
   async def run_producers_from_stream(
       self,

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -920,7 +920,7 @@ class RLEngine:
               prompt,  # pytype: disable=wrong-arg-types
               add_generation_prompt=True,
               tokenize=False,
-              enable_thinking=False,
+              enable_thinking=True,
           )
           for prompt in prompts
       ]


### PR DESCRIPTION
This is required for loading checkpoints of really large models (like Qwen 3.5 397B) when scan_layers is enabled, as stacked parameters exceed the default 96GB concurrent load limit.