### PR TITLE
[tunix] Preserve optimizer-state dtypes across updates

### DIFF
--- a/tests/experimental/train/peft_trainer_v2_test.py
+++ b/tests/experimental/train/peft_trainer_v2_test.py
@@ -765,6 +765,127 @@ class PeftTrainerTest(parameterized.TestCase):
     )
 
 
+class OptimizerMemoryTest(parameterized.TestCase):
+  """Optimizer-state dtype preservation across v2 update paths."""
+
+  def _bf16_model(self):
+    return nnx.Linear(
+        in_features=4,
+        out_features=2,
+        rngs=nnx.Rngs(0),
+        param_dtype=jnp.bfloat16,
+    )
+
+  def _opt_state_dtypes(self, trainer):
+    return jax.tree_util.tree_map(
+        lambda value: value[...].dtype,
+        nnx.state(trainer.optimizer, nnx.optimizer.OptState),
+        is_leaf=lambda value: isinstance(value, nnx.Variable),
+    )
+
+  def _run_update(self, trainer, inputs, gradient_accumulation_steps):
+    if gradient_accumulation_steps == 1:
+      trainer.train_step(inputs)
+      return
+
+    for _ in range(gradient_accumulation_steps):
+      trainer.fwd_bwd(inputs)
+    trainer.update()
+
+  @parameterized.product(
+      optimizer_kind=('direct', 'injected'),
+      gradient_accumulation_steps=(1, 2),
+  )
+  def test_preserves_bf16_optimizer_state_dtypes_under_jit(
+      self, optimizer_kind, gradient_accumulation_steps
+  ):
+    """Jitted fused and split updates preserve optimizer-state dtypes."""
+    model = self._bf16_model()
+    if optimizer_kind == 'direct':
+      tx = optax.adamw(
+          lambda _: jnp.asarray(0.1, dtype=jnp.float32),
+          mu_dtype=jnp.bfloat16,
+      )
+    else:
+      tx = optax.inject_hyperparams(optax.adamw, hyperparam_dtype=jnp.float32)(
+          learning_rate=0.1
+      )
+    config = peft_trainer_v2.TrainingConfig(
+        eval_every_n_steps=100,
+        max_steps=1,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+    trainer = peft_trainer_v2.PeftTrainer(model, tx, config)
+    trainer.with_loss_fn(lambda m, x, y: jnp.sum((m(x) - y) ** 2))
+
+    initial_opt_state_dtypes = self._opt_state_dtypes(trainer)
+    initial_params = jax.tree_util.tree_map(
+        lambda value: jnp.copy(value[...]),
+        nnx.state(model, nnx.Param),
+        is_leaf=lambda value: isinstance(value, nnx.Variable),
+    )
+    inputs = {
+        'x': jnp.ones((2, 4), dtype=jnp.bfloat16),
+        'y': jnp.ones((2, 2), dtype=jnp.bfloat16),
+    }
+
+    self._run_update(trainer, inputs, gradient_accumulation_steps)
+
+    self.assertEqual(self._opt_state_dtypes(trainer), initial_opt_state_dtypes)
+    updated_params = nnx.state(model, nnx.Param)
+    self.assertTrue(
+        any(
+            not np.array_equal(before, after[...])
+            for before, after in zip(
+                jax.tree_util.tree_leaves(initial_params),
+                jax.tree_util.tree_leaves(
+                    updated_params,
+                    is_leaf=lambda value: isinstance(value, nnx.Variable),
+                ),
+            )
+        )
+    )
+    self.assertEqual(
+        trainer._last_update_grad_norm.dtype,  # pylint: disable=protected-access
+        jnp.float32,
+    )
+    self.assertEqual(float(trainer.grad_accumulator.denom[...]), 0.0)
+
+  def test_preserves_default_fp32_optimizer_state_dtypes_under_jit(self):
+    """The default f32 optimizer state remains f32."""
+    model = nnx.Linear(
+        in_features=4,
+        out_features=2,
+        rngs=nnx.Rngs(0),
+        param_dtype=jnp.float32,
+    )
+    config = peft_trainer_v2.TrainingConfig(eval_every_n_steps=100, max_steps=1)
+    trainer = peft_trainer_v2.PeftTrainer(
+        model,
+        optax.adamw(0.1),
+        config,
+    )
+    trainer.with_loss_fn(lambda m, x, y: jnp.sum((m(x) - y) ** 2))
+    initial_opt_state_dtypes = self._opt_state_dtypes(trainer)
+
+    self._run_update(
+        trainer,
+        {
+            'x': jnp.ones((2, 4), dtype=jnp.float32),
+            'y': jnp.ones((2, 2), dtype=jnp.float32),
+        },
+        gradient_accumulation_steps=1,
+    )
+
+    self.assertEqual(self._opt_state_dtypes(trainer), initial_opt_state_dtypes)
+    floating_dtypes = {
+        dtype
+        for dtype in jax.tree_util.tree_leaves(initial_opt_state_dtypes)
+        if jnp.issubdtype(dtype, jnp.floating)
+    }
+    self.assertEqual(floating_dtypes, {jnp.dtype(jnp.float32)})
+
+
 class V1ParityTest(parameterized.TestCase):
   """Parity tests for PeftTrainerV2 against PeftTrainer before the migration to v2 is fully done."""
 

--- a/tests/sft/peft_trainer_test.py
+++ b/tests/sft/peft_trainer_test.py
@@ -2002,6 +2002,88 @@ class OptimizerMemoryTest(parameterized.TestCase):
     # bf16 params -> bf16 moments on the cond path too.
     self.assertEqual(self._moment_float_dtypes(trainer), {'bfloat16'})
 
+  @parameterized.product(
+      optimizer_kind=('direct', 'injected'),
+      gradient_accumulation_steps=(1, 2),
+  )
+  def test_preserves_bf16_optimizer_state_dtypes_under_jit(
+      self, optimizer_kind, gradient_accumulation_steps
+  ):
+    """Jitted direct and conditional updates preserve optimizer-state dtypes."""
+    model = nnx.Linear(
+        in_features=4,
+        out_features=2,
+        rngs=nnx.Rngs(0),
+        param_dtype=jnp.bfloat16,
+    )
+    if optimizer_kind == 'direct':
+      tx = optax.adamw(
+          lambda _: jnp.asarray(0.1, dtype=jnp.float32),
+          mu_dtype=jnp.bfloat16,
+      )
+    else:
+      tx = optax.inject_hyperparams(optax.adamw, hyperparam_dtype=jnp.float32)(
+          learning_rate=0.1
+      )
+    config = peft_trainer.TrainingConfig(
+        eval_every_n_steps=100,
+        max_steps=1,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+    )
+    trainer = peft_trainer.PeftTrainer(model, tx, config)
+    trainer.with_loss_fn(lambda m, x, y: jnp.sum((m(x) - y) ** 2))
+
+    def opt_state_dtypes():
+      return jax.tree_util.tree_map(
+          lambda value: value[...].dtype,
+          nnx.state(trainer.optimizer, nnx.optimizer.OptState),
+          is_leaf=lambda value: isinstance(value, nnx.Variable),
+      )
+
+    initial_opt_state_dtypes = opt_state_dtypes()
+    initial_params = jax.tree_util.tree_map(
+        lambda value: jnp.copy(value[...]),
+        nnx.state(model, nnx.Param),
+        is_leaf=lambda value: isinstance(value, nnx.Variable),
+    )
+    train_step, _ = trainer.jit_train_and_eval_step()
+    inputs = {
+        'x': jnp.ones((2, 4), dtype=jnp.bfloat16),
+        'y': jnp.ones((2, 2), dtype=jnp.bfloat16),
+    }
+
+    for micro_step in range(gradient_accumulation_steps):
+      is_update_step = micro_step == gradient_accumulation_steps - 1
+      _, _, grad_norm = train_step(
+          inputs, is_update_step=jnp.asarray(is_update_step)
+      )
+      self.assertEqual(grad_norm.dtype, jnp.float32)
+      if not is_update_step:
+        for before, after in zip(
+            jax.tree_util.tree_leaves(initial_params),
+            jax.tree_util.tree_leaves(
+                nnx.state(model, nnx.Param),
+                is_leaf=lambda value: isinstance(value, nnx.Variable),
+            ),
+        ):
+          np.testing.assert_array_equal(before, after[...])
+
+    self.assertEqual(opt_state_dtypes(), initial_opt_state_dtypes)
+    updated_params = nnx.state(model, nnx.Param)
+    self.assertTrue(
+        any(
+            not np.array_equal(before, after[...])
+            for before, after in zip(
+                jax.tree_util.tree_leaves(initial_params),
+                jax.tree_util.tree_leaves(
+                    updated_params,
+                    is_leaf=lambda value: isinstance(value, nnx.Variable),
+                ),
+            )
+        )
+    )
+    self.assertEqual(float(trainer.grad_accumulator.denom[...]), 0.0)
+
   def test_accumulator_grads_skipped_at_depth1(self):
     """At depth-1 (non-packing) the accumulator grad tree is not allocated."""
     model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0))

--- a/tunix/experimental/train/peft_trainer_v2.py
+++ b/tunix/experimental/train/peft_trainer_v2.py
@@ -176,6 +176,33 @@ def _calculate_global_batch_size(train_example: Any) -> int:
   )
 
 
+def _opt_state_dtypes(optimizer: nnx.Optimizer) -> Any:
+  """Returns the array dtype of every optimizer-state variable."""
+  return jax.tree_util.tree_map(
+      lambda value: value.get_value().dtype,
+      nnx.state(optimizer, nnx.optimizer.OptState),
+      is_leaf=lambda value: isinstance(value, nnx.Variable),
+  )
+
+
+def _restore_opt_state_float_dtypes(
+    optimizer: nnx.Optimizer, dtypes: Any
+) -> None:
+  """Restores floating optimizer-state leaves to their pre-update dtypes."""
+
+  def _restore(value, dtype):
+    array = value.get_value()
+    if jnp.issubdtype(array.dtype, jnp.floating) and array.dtype != dtype:
+      value.set_value(array.astype(dtype))
+
+  jax.tree_util.tree_map(
+      _restore,
+      nnx.state(optimizer, nnx.optimizer.OptState),
+      dtypes,
+      is_leaf=lambda value: isinstance(value, nnx.Variable),
+  )
+
+
 class GradientAccumulator(nnx.Module):
   """Accumulates gradients over multiple micro-steps.
 
@@ -650,7 +677,9 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
     norm = optax.global_norm(
         jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), acc_grads)
     )
+    opt_state_dtypes = _opt_state_dtypes(optimizer)
     optimizer.update(model, acc_grads)
+    _restore_opt_state_float_dtypes(optimizer, opt_state_dtypes)
     grad_accumulator.reset()
     return norm
 

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -171,6 +171,33 @@ def _zero_safe_reciprocal(denom: jax.Array) -> jax.Array:
   return jnp.where(denom == 0, jnp.zeros_like(denom), 1.0 / denom)
 
 
+def _opt_state_dtypes(optimizer: nnx.Optimizer) -> Any:
+  """Returns the array dtype of every optimizer-state variable."""
+  return jax.tree_util.tree_map(
+      lambda value: value.get_value().dtype,
+      nnx.state(optimizer, nnx.optimizer.OptState),
+      is_leaf=lambda value: isinstance(value, nnx.Variable),
+  )
+
+
+def _restore_opt_state_float_dtypes(
+    optimizer: nnx.Optimizer, dtypes: Any
+) -> None:
+  """Restores floating optimizer-state leaves to their pre-update dtypes."""
+
+  def _restore(value, dtype):
+    array = value.get_value()
+    if jnp.issubdtype(array.dtype, jnp.floating) and array.dtype != dtype:
+      value.set_value(array.astype(dtype))
+
+  jax.tree_util.tree_map(
+      _restore,
+      nnx.state(optimizer, nnx.optimizer.OptState),
+      dtypes,
+      is_leaf=lambda value: isinstance(value, nnx.Variable),
+  )
+
+
 class GradientAccumulator(nnx.Module):
   """Accumulates gradients over multiple micro-steps.
 
@@ -551,7 +578,9 @@ class PeftTrainer:
       norm = optax.global_norm(
           jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), acc_grads)
       )
+      opt_state_dtypes = _opt_state_dtypes(optimizer)
       optimizer.update(model, acc_grads)
+      _restore_opt_state_float_dtypes(optimizer, opt_state_dtypes)
       grad_accumulator.reset()
       return norm
 
@@ -575,7 +604,9 @@ class PeftTrainer:
       grad_norm = optax.global_norm(
           jax.tree_util.tree_map(lambda x: x.astype(jnp.float32), grads)
       )
+      opt_state_dtypes = _opt_state_dtypes(optimizer)
       optimizer.update(model, grads)
+      _restore_opt_state_float_dtypes(optimizer, opt_state_dtypes)
     else:
       if isinstance(aux, utils.LossOutput):
         # Accumulate the UNREDUCED gradients (d/dparam of the sum) weighted by the


### PR DESCRIPTION
## Motivation

Tunix commonly uses float32 optimizer state for accuracy, while also supporting
optimizer configurations that intentionally use lower-precision moments to
reduce memory. In both cases, the dtype tree selected when the optimizer is
initialized or restored must remain stable. An Optax optimizer built with
`inject_hyperparams` can instead promote some floating moment leaves during
`update`. With bfloat16 moments this silently changes the optimizer-state
contract to float32. On the legacy gradient-accumulation path it also makes the
update and skip branches of `nnx.cond` return different dtypes, so tracing
fails.

## Scope

This PR preserves the optimizer-state dtype tree across each trainer update:

- capture optimizer-state dtypes immediately before `optimizer.update`;
- restore only floating leaves whose dtype changed during the update;
- cover the legacy trainer's depth-one and conditional accumulated paths;
- apply the same invariant to the graduating `peft_trainer_v2` fused and split
  update paths; and
- test actual jitted updates for direct and injected AdamW at accumulation
  depths one and two in both trainers.

Integer counters and floating leaves that already use their configured dtype
are unchanged. A dedicated v2 test confirms that the default float32 state
remains float32. This PR does not modify model parameter dtypes, loss or metric
reduction, gradient accumulation math, checkpoint formats, or optimizer
selection.

## Dependency

This follow-up is based on `main` after #1850. The two changes are semantically
independent, but both touch `PeftTrainer` and its tests, so this patch was
rebuilt after #1850 merged rather than replaying the old preparation commit.
The guarded publisher verifies that #1850 is present before preparing or
publishing the branch.

## Tests

```text
python -m pytest -q tests/sft/peft_trainer_test.py \
  tests/experimental/train/peft_trainer_v2_test.py \
  -k optimizer_state_dtypes_under_jit
python -m pytest -q tests/sft/peft_trainer_test.py \
  tests/experimental/train/peft_trainer_v2_test.py
```

The focused matrix has nine passing cases: direct and injected AdamW at
accumulation depths one and two in both trainers, plus the default float32 v2
state. The complete trainer suites have 114 passing tests. The guarded
publisher also runs changed-range Pyink, scoped error/fatal Pylint, Python
compilation, and `git diff --check`.

Design document:
https://docs.google.com/document/d/1Xe-98ScS2RSH29AdhTdc9tO4WHQG5wCbFkJA3gmIUZQ/edit
