### PR TITLE
Add MLPerf RCP logging for post training in DeepSWE

### DIFF
--- a/examples/deepswe/train_deepswe_nb.py
+++ b/examples/deepswe/train_deepswe_nb.py
@@ -252,6 +252,8 @@ parser.add_argument(
 
 parser.add_argument("--use_flash_attention", type=bool, default=True)
 parser.add_argument("--flash_attention_block_size", type=int, default=1024)
+parser.add_argument("--target_accuracy", type=float, default=0.69)
+parser.add_argument("--rcp_logging", action="store_true", default=False)
 parser.add_argument("--metric_logger_dir", type=str, default=None)
 parser.add_argument(
     "--logging_level",
@@ -388,12 +390,16 @@ from tunix.rl.agentic.parser.chat_template_parser import parser as template_pars
 from tunix import PerfMetricsConfig
 from tunix.perf.experimental.export import PerfMetricsExport
 from tunix.rl.agentic.rewards.reward_types import RewardOutput
+from tunix.utils import mllog_utils  # pytype: disable=missing-module-attribute,import-error
 try:
   from examples.deepswe import swe_agent
   from examples.deepswe import swe_env
 except ImportError:
   from examples.deepswe import swe_agent  # pytype: disable=import-error
   from examples.deepswe import swe_env  # pytype: disable=import-error
+
+if args.rcp_logging:
+  mllog_utils.init_start(args)
 
 # %%
 # ==========================================
@@ -571,6 +577,7 @@ FILTER_STATUSES = (
 LOSS_AGG_MODE = args.loss_agg_mode
 ADVANTAGE_ESTIMATOR = args.advantage_estimator
 USE_ROLLOUT_LOGPS = args.use_rollout_logps
+RCP_LOGGING = args.rcp_logging
 
 
 # %%
@@ -1039,6 +1046,18 @@ rl_engine = RLClusterCls(  # pytype: disable=not-callable
     cluster_config=cluster_config,
 )
 
+if RCP_LOGGING:
+  rl_engine.with_external_metrics_logger(
+      mllog_utils.create_rcp_metrics_logger(args, rl_engine=rl_engine)
+  )
+  mllog_utils.init_print(
+      args,
+      train_dataset=dataset,
+      rollout_mesh=rollout_mesh,
+      train_mesh=train_mesh,
+      total_devices=total_devices,
+  )
+
 # %%
 # ==========================================
 # 10. Learner & Agent Setup
@@ -1116,8 +1135,14 @@ except Exception as e:
   print(f"W&B initialization failed with error: {e}")
 
 
+if RCP_LOGGING:
+  mllog_utils.train_start(args)
+
 print("Starting training...", flush=True)
 agentic_grpo_learner.train(train_dataset=train_dataset)
+
+if RCP_LOGGING:
+  mllog_utils.train_stop(args)
 
 
 # %%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
   "chex",
   "opentelemetry-sdk>=1.25.0",
   "wandb",  # Offline end-to-end test for the OpenTelemetry W&B exporter
+  "mlperf-logging",
 ]
 cli = [
   "tensorflow",

--- a/tests/examples/deepswe_mllog_utils_test.py
+++ b/tests/examples/deepswe_mllog_utils_test.py
@@ -1,0 +1,609 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tunix.utils.mllog_utils."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+import types
+from unittest import mock
+
+import numpy as np
+from absl.testing import absltest
+from tunix.perf.metrics import MetricsBuffer
+from tunix.utils import mllog_utils
+
+
+@absltest.skipIf(mllog_utils.mllogger is None, "mlperf_logging is not installed")
+class MllogUtilsTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.test_dir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    if mllog_utils.mllogger is not None:
+      for h in list(getattr(mllog_utils.mllogger.logger, "handlers", [])):
+        if isinstance(h, logging.FileHandler):
+          h.close()
+          mllog_utils.mllogger.logger.removeHandler(h)
+    shutil.rmtree(self.test_dir, ignore_errors=True)
+    super().tearDown()
+
+  def test_file_logging_with_metric_logger_dir(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=8,
+        max_steps=5,
+        learning_rate=1e-6,
+        b1=0.9,
+        b2=0.99,
+        weight_decay=0.01,
+        max_grad_norm=1.0,
+        train_micro_batch_size=1,
+        max_prompt_length=4096,
+        max_response_length=8192,
+        tpu_topology="v5p-64",
+        rollout_engine="vllm",
+        target_accuracy=0.69,
+    )
+
+    mllog_utils.init_start(args)
+    mllog_utils.init_print(args, total_devices=64)
+    mllog_utils.init_stop()
+    mllog_utils.run_start()
+    mllog_utils.block_start(args, step=0)
+    mllog_utils.log_tracked_stats(
+        {"loss": 0.5, "reward": 0.8}, step=1, samples_count=64
+    )
+    mllog_utils.block_stop(step=1, samples_count=64)
+    mllog_utils.run_stop(status="success", samples_count=320)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn(":::MLLOG", content)
+    self.assertIn('"key": "cache_clear"', content)
+    self.assertIn('"key": "init_start"', content)
+    self.assertIn('"key": "submission_benchmark"', content)
+    self.assertIn('"key": "submission_org"', content)
+    self.assertIn('"key": "seed"', content)
+    self.assertIn('"key": "run_start"', content)
+    self.assertIn('"key": "block_start"', content)
+    self.assertIn('"key": "tracked_stats"', content)
+    self.assertIn('"key": "block_stop"', content)
+    self.assertIn('"key": "run_stop"', content)
+
+  def test_start_and_end_eval(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+    )
+    mllog_utils.init_start(args)
+    mllog_utils.start_eval(step=2, samples_count=128)
+    mllog_utils.end_eval(
+        step=2,
+        accuracy=0.75,
+        samples_count=128,
+        validation_time=12.5,
+    )
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "eval_start"', content)
+    self.assertIn('"key": "eval_accuracy"', content)
+    self.assertIn("0.75", content)
+    self.assertIn('"validation_time": 12.5', content)
+    self.assertIn('"key": "eval_stop"', content)
+
+  def test_check_eval_not_early_stop(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=8,
+        eval_every_n_steps=2,
+        target_accuracy=0.69,
+    )
+    mllog_utils.init_start(args)
+
+    is_early_stop = mllog_utils.check_eval(
+        args,
+        step=2,
+        eval_accuracy=0.50,
+        validation_time=10.0,
+    )
+    self.assertFalse(is_early_stop)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "block_stop"', content)
+    self.assertIn('"key": "eval_start"', content)
+    self.assertIn('"validation_time": 10.0', content)
+    self.assertIn('"key": "eval_accuracy"', content)
+    self.assertIn("0.5", content)
+    self.assertIn('"key": "eval_stop"', content)
+    self.assertIn('"key": "block_start"', content)
+
+  def test_check_eval_early_stop(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=8,
+        eval_every_n_steps=2,
+        target_accuracy=0.69,
+    )
+    mllog_utils.init_start(args)
+
+    is_early_stop = mllog_utils.check_eval(
+        args,
+        step=4,
+        eval_accuracy=0.72,
+        validation_time=11.5,
+    )
+    self.assertTrue(is_early_stop)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "block_stop"', content)
+    self.assertIn('"key": "eval_start"', content)
+    self.assertIn('"validation_time": 11.5', content)
+    self.assertIn('"key": "eval_accuracy"', content)
+    self.assertIn("0.72", content)
+    self.assertIn('"key": "eval_stop"', content)
+    self.assertIn('"key": "run_stop"', content)
+    self.assertIn('"status": "success"', content)
+    self.assertIn('"key": "train_samples"', content)
+
+  def test_end_to_end_mlperf_logging_with_train_configs(self):
+    args = types.SimpleNamespace(
+        model_version="Qwen3.5-35B-A3B",
+        model_source="maxtext",
+        model_absolute_path="gs://sanbao-europe/qwen3.5-35b-a3b/scanned/0/items",
+        scan_layers=True,
+        vllm_utilization=0.4,
+        max_response_length=4096,
+        max_prompt_length=8192,
+        metric_logger_dir=self.test_dir,
+        ckpt_dir="none",
+        rollout_micro_batch_size=8,
+        vllm_reshard_chunk_size=1,
+        rollout_mesh_fsdp=8,
+        rollout_mesh_tp=4,
+        train_mesh_fsdp=16,
+        train_mesh_tp=2,
+        node_selector_val="cpu-np",
+        max_steps=5,
+        overlong_filter=False,
+        batch_size=64,
+        mini_batch_size=64,
+        compute_logps_micro_batch_size=16,
+        train_micro_batch_size=16,
+        temperature=0.7,
+        num_generations=2,
+        max_turns=20,
+        beta=0.001,
+        weight_decay=0.1,
+        max_grad_norm=0.1,
+        logging_level="INFO",
+        rcp_logging=True,
+        target_accuracy=0.69,
+        seed=1,
+        learning_rate=1e-6,
+        eval_every_n_steps=5,
+    )
+
+    mock_train_dataset = [None] * 5480
+    rollout_mesh = mock.MagicMock()
+    rollout_mesh.shape = {"fsdp": 8, "tp": 4}
+    train_mesh = mock.MagicMock()
+    train_mesh.shape = {"fsdp": 16, "tp": 2}
+    total_devices = 32
+
+    # 1. Initialization phase
+    mllog_utils.init_start(args)
+    mllog_utils.init_print(
+        args,
+        train_dataset=mock_train_dataset,
+        rollout_mesh=rollout_mesh,
+        train_mesh=train_mesh,
+        total_devices=total_devices,
+    )
+    mllog_utils.init_stop()
+
+    # 2. Run and block start
+    mllog_utils.run_start()
+    mllog_utils.block_start(args, step=0)
+
+    # 3. Training steps with tracked stats
+    for step in range(1, args.max_steps + 1):
+      samples_count = step * args.batch_size * args.num_generations
+      mllog_utils.log_tracked_stats(
+          stats={
+              "reduced_train_loss": -0.08 + step * 0.01,
+              "reward": 0.33 + step * 0.02,
+              "grad_norm": 0.04,
+              "train_step_time": 100.0,
+              "policy_training_time": 25.0,
+              "exposed_generation_time": 70.0,
+              "weight_sync_time": 2.0,
+              "valid_tokens_per_sec_per_gpu": 22.0,
+          },
+          step=step,
+          samples_count=samples_count,
+      )
+
+    # 4. Mock evaluation phase with eval_accuracy = 0.70703125
+    is_early_stop = mllog_utils.check_eval(
+        args,
+        step=args.max_steps,
+        eval_accuracy=0.70703125,
+        validation_time=986.35,
+    )
+    self.assertTrue(is_early_stop)
+
+    # 5. Validate the generated log file
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      log_lines = [line.strip() for line in f if line.strip()]
+
+    events = []
+    for line in log_lines:
+      self.assertTrue(line.startswith(":::MLLOG "))
+      json_str = line[len(":::MLLOG ") :]
+      events.append(json.loads(json_str))
+
+    event_map = {e["key"]: e for e in events}
+
+    # Verify lifecycle events
+    self.assertEqual(event_map["cache_clear"]["value"], True)
+    self.assertIn("init_start", event_map)
+    self.assertIn("init_stop", event_map)
+    self.assertIn("run_start", event_map)
+    self.assertIn("block_start", event_map)
+    self.assertIn("block_stop", event_map)
+    self.assertIn("eval_start", event_map)
+    self.assertIn("eval_stop", event_map)
+    self.assertIn("run_stop", event_map)
+    self.assertEqual(event_map["run_stop"]["metadata"]["status"], "success")
+
+    # Verify hyperparameters and metadata
+    self.assertEqual(event_map["submission_benchmark"]["value"], "qwen35_397b_grpo")
+    self.assertEqual(event_map["submission_org"]["value"], "Google")
+    self.assertEqual(event_map["submission_division"]["value"], "closed")
+    self.assertEqual(event_map["submission_status"]["value"], "cloud")
+    self.assertEqual(event_map["seed"]["value"], 1)
+    self.assertEqual(event_map["max_steps"]["value"], 5)
+    self.assertEqual(event_map["global_batch_size"]["value"], 128)
+    self.assertEqual(event_map["micro_batch_size"]["value"], 16)
+    self.assertEqual(event_map["max_sequence_length"]["value"], 12288)
+    self.assertEqual(event_map["train_samples"]["value"], 640)
+    self.assertEqual(event_map["tensor_parallelism"]["value"], 2)
+    self.assertEqual(event_map["generation_tensor_parallelism"]["value"], 4)
+    self.assertEqual(
+        event_map["generation_training_rollout_temperature"]["value"], 0.7
+    )
+    self.assertEqual(event_map["num_prompts_per_step"]["value"], 64)
+    self.assertEqual(event_map["num_generations_per_prompt"]["value"], 2)
+    self.assertEqual(event_map["target_accuracy"]["value"], 0.69)
+    self.assertEqual(event_map["eval_accuracy"]["value"], 0.70703125)
+
+  def test_log_metrics_buffer_with_perf_metrics_buffer(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=4,
+        num_generations=2,
+    )
+    mllog_utils.init_start(args)
+
+    metrics_buffer = MetricsBuffer(
+        global_steps=0,
+        metrics={
+            "loss": ([0.42], None),
+            "train_reward": ([0.75, 0.85], np.mean),
+            "perf/global_step_time": ([12.5], np.mean),
+        },
+        mode="train",
+    )
+
+    mllog_utils.log_metrics_buffer(metrics_buffer, args=args)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "tracked_stats"', content)
+    self.assertIn('"loss": 0.42', content)
+    self.assertIn('"train_reward": 0.8', content)
+    self.assertIn('"step_time": 12.5', content)
+    self.assertNotIn('"perf/global_step_time":', content)
+    self.assertIn('"step": 1', content)
+    self.assertIn('"samples_count": 8', content)
+
+  def test_create_rcp_metrics_logger(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=4,
+    )
+    mllog_utils.init_start(args)
+
+    logger = mllog_utils.create_rcp_metrics_logger(args)
+
+    metrics_buffer = MetricsBuffer(
+        global_steps=2,
+        metrics={
+            "loss": ([0.15], None),
+            "train_reward": ([0.9], np.mean),
+        },
+        mode="train",
+    )
+
+    logger(metrics_buffer)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "tracked_stats"', content)
+    self.assertIn('"loss": 0.15', content)
+    self.assertIn('"train_reward": 0.9', content)
+    self.assertIn('"step": 3', content)
+    self.assertIn('"samples_count": 96', content)
+
+  def test_log_metrics_buffer_with_weighted_metric(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=2,
+        num_generations=2,
+    )
+    mllog_utils.init_start(args)
+
+    class DummyWeightedMetric:
+      def __init__(self, val):
+        self.val = val
+      def compute(self):
+        return self.val
+
+    metrics_buffer = MetricsBuffer(
+        global_steps=0,
+        metrics={
+            "loss": ([DummyWeightedMetric(0.5)], None),
+        },
+        mode="train",
+    )
+
+    mllog_utils.log_metrics_buffer(metrics_buffer, args=args)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "tracked_stats"', content)
+    self.assertIn('"loss": 0.5', content)
+
+  def test_log_metrics_buffer_with_full_tracked_stats(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=16,
+    )
+    mllog_utils.init_start(args)
+
+    metrics_buffer = MetricsBuffer(
+        global_steps=0,
+        metrics={
+            "step_time": ([1086.7], np.mean),
+            "train_reward": ([0.0], np.mean),
+            "train_solve": ([0.0], np.mean),
+            "adv_abs_mean": ([0.0], np.mean),
+            "completion_length": ([4096.0], np.mean),
+            "loss": ([-7.5e-06], np.mean),
+            "grad_norm": ([0.0858], np.mean),
+            "reduced_pg_loss": ([0.0], np.mean),
+            "entropy": ([1.815], np.mean),
+            "kl": ([-0.0075], np.mean),
+            "log_ratio_abs": ([0.521], np.mean),
+            "clipfrac": ([0.0], np.mean),
+            "generation/prompts/mean_length": ([8192.0], np.mean),
+            "trajectory/env_time/step_latency/mean": ([0.0], np.mean),
+            "rewards/sum": ([0.0], np.mean),
+            "perf/global_step_time": ([1086.7], np.mean),
+        },
+        mode="train",
+    )
+
+    mllog_utils.log_metrics_buffer(metrics_buffer, args=args)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "tracked_stats"', content)
+    for expected_key in [
+        "step_time",
+        "train_reward",
+        "train_solve",
+        "adv_abs_mean",
+        "completion_length",
+        "loss",
+        "grad_norm",
+        "reduced_pg_loss",
+        "entropy",
+        "kl",
+        "log_ratio_abs",
+        "clipfrac",
+    ]:
+      self.assertIn(f'"{expected_key}":', content)
+
+    for excluded_key in [
+        "generation/prompts/mean_length",
+        "trajectory/env_time/step_latency/mean",
+        "rewards/sum",
+        "perf/global_step_time",
+    ]:
+      self.assertNotIn(f'"{excluded_key}":', content)
+
+  def test_create_rcp_metrics_logger_with_rl_engine(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=16,
+    )
+    mllog_utils.init_start(args)
+
+    # Rollout metrics in metrics_buffer (only original logs, no 12 duplicate logs)
+    metrics_buffer = MetricsBuffer(
+        global_steps=0,
+        metrics={
+            "perf/global_step_time": ([1086.7], np.mean),
+            "generation/completions/mean_length": ([4096.0], np.mean),
+            "trajectory_rewards/mean": ([0.75], np.mean),
+        },
+        mode="train",
+    )
+
+    # Actor trainer metrics in rl_engine.actor_trainer
+    mock_trainer_buf = types.SimpleNamespace(
+        loss=-7.5e-06,
+        additional_metrics={
+            "grad_norm": ([0.0858], np.mean),
+            "reduced_pg_loss": ([0.0], np.mean),
+            "entropy": ([1.815], np.mean),
+            "kl": ([-0.0075], np.mean),
+            "log_ratio/abs_mean": ([0.521], np.mean),
+            "pg_clipfrac": ([0.0], np.mean),
+            "advantage/abs_mean": ([0.25], np.mean),
+        },
+    )
+    mock_actor_trainer = types.SimpleNamespace(
+        _prev_buffered_train_metrics=mock_trainer_buf,
+    )
+    mock_rl_engine = types.SimpleNamespace(
+        actor_trainer=mock_actor_trainer,
+    )
+
+    logger = mllog_utils.create_rcp_metrics_logger(
+        args=args, rl_engine=mock_rl_engine
+    )
+    logger(metrics_buffer)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "tracked_stats"', content)
+    for expected_key in [
+        "step_time",
+        "train_reward",
+        "train_solve",
+        "adv_abs_mean",
+        "completion_length",
+        "loss",
+        "grad_norm",
+        "reduced_pg_loss",
+        "entropy",
+        "kl",
+        "log_ratio_abs",
+        "clipfrac",
+    ]:
+      self.assertIn(f'"{expected_key}":', content)
+
+    self.assertIn('"step_time": 1086.7', content)
+    self.assertIn('"completion_length": 4096.0', content)
+    self.assertIn('"train_reward": 0.75', content)
+    self.assertIn('"train_solve": 0.75', content)
+    self.assertIn('"adv_abs_mean": 0.25', content)
+    self.assertIn('"loss": -7.5e-06', content)
+    self.assertIn('"grad_norm": 0.0858', content)
+    self.assertIn('"entropy": 1.815', content)
+    self.assertIn('"kl": -0.0075', content)
+    self.assertIn('"log_ratio_abs": 0.521', content)
+    self.assertIn('"clipfrac": 0.0', content)
+
+  def test_train_start(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=8,
+        max_steps=5,
+    )
+    mllog_utils.init_start(args)
+    mllog_utils.train_start(args)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "init_stop"', content)
+    self.assertIn('"key": "run_start"', content)
+    self.assertIn('"key": "block_start"', content)
+
+  def test_train_stop(self):
+    args = types.SimpleNamespace(
+        seed=1,
+        metric_logger_dir=self.test_dir,
+        batch_size=8,
+        num_generations=8,
+        max_steps=5,
+    )
+    mllog_utils.init_start(args)
+    mllog_utils.train_start(args)
+    mllog_utils.train_stop(args)
+
+    expected_log_file = os.path.join(self.test_dir, "seed_1.out")
+    self.assertTrue(os.path.exists(expected_log_file))
+
+    with open(expected_log_file, "r") as f:
+      content = f.read()
+
+    self.assertIn('"key": "block_stop"', content)
+    self.assertIn('"key": "run_stop"', content)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tunix/utils/mllog_utils.py
+++ b/tunix/utils/mllog_utils.py
@@ -1,0 +1,812 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MLPerf RCP Logging Utilities for Post-Training (GRPO)."""
+
+import logging
+import os
+from typing import Any, Callable, Iterable, Mapping, Optional
+import jax
+import numpy as np
+
+try:
+  from mlperf_logging import mllog
+  from mlperf_logging.mllog import constants
+  mllogger = mllog.get_mllogger()
+except ImportError:
+  mllog = None
+  constants = None
+  mllogger = None
+
+
+def configure_logger(
+    metric_logger_dir: Optional[str] = None,
+    seed: Optional[int] = None,
+    filename: Optional[str] = None,
+):
+  """Configures mllog output file if metric_logger_dir or filename is provided."""
+  if not (_is_master_process() and mllog is not None and mllogger is not None):
+    return
+
+  if filename is None and metric_logger_dir is not None:
+    if metric_logger_dir.endswith(".out") or metric_logger_dir.endswith(".log"):
+      filename = metric_logger_dir
+    else:
+      seed_val = seed if seed is not None else 1
+      filename = os.path.join(metric_logger_dir, f"seed_{seed_val}.out")
+
+  if filename is not None:
+    abs_filename = os.path.abspath(filename)
+    os.makedirs(os.path.dirname(abs_filename), exist_ok=True)
+    existing_files = [
+        os.path.abspath(getattr(h, "baseFilename", ""))
+        for h in getattr(mllogger.logger, "handlers", [])
+        if isinstance(h, logging.FileHandler)
+    ]
+    if abs_filename not in existing_files:
+      try:
+        mllog.config(filename=filename)
+      except TypeError:
+        mllog.config(filename=filename, root_dir=os.getcwd())
+
+
+def _is_master_process() -> bool:
+  """Returns True if this is the coordinator process (host 0)."""
+  try:
+    return jax.process_index() == 0
+  except Exception:
+    return True
+
+
+def _log_event(key: str, value: Any = None, metadata: Optional[dict[str, Any]] = None):
+  if not _is_master_process():
+    return
+  if mllogger is not None:
+    mllogger.event(key=key, value=value, metadata=metadata or {})
+
+
+def _log_start(key: str, metadata: Optional[dict[str, Any]] = None):
+  if not _is_master_process():
+    return
+  if mllogger is not None:
+    mllogger.start(key=key, metadata=metadata or {})
+
+
+def _log_end(key: str, metadata: Optional[dict[str, Any]] = None):
+  if not _is_master_process():
+    return
+  if mllogger is not None:
+    mllogger.end(key=key, metadata=metadata or {})
+
+
+def init_start(
+    args: Any = None,
+    metric_logger_dir: Optional[str] = None,
+    seed: Optional[int] = None,
+    filename: Optional[str] = None,
+):
+  """Logs CACHE_CLEAR and marks the beginning of the initialization phase."""
+  if _is_master_process() and mllogger is not None:
+    if args is not None:
+      if metric_logger_dir is None:
+        metric_logger_dir = getattr(args, "metric_logger_dir", None)
+      if seed is None:
+        seed = getattr(args, "seed", 1)
+    if metric_logger_dir is not None or filename is not None:
+      configure_logger(
+          metric_logger_dir=metric_logger_dir, seed=seed, filename=filename
+      )
+    cache_clear_key = getattr(constants, "CACHE_CLEAR", "cache_clear")
+    init_start_key = getattr(constants, "INIT_START", "init_start")
+    mllogger.event(key=cache_clear_key, value=True)
+    mllogger.start(key=init_start_key)
+
+
+def init_stop():
+  """Marks the end of the initialization phase."""
+  if _is_master_process() and mllogger is not None:
+    init_stop_key = getattr(constants, "INIT_STOP", "init_stop")
+    mllogger.end(key=init_stop_key)
+
+
+def run_start():
+  """Marks the start of the training run."""
+  if _is_master_process() and mllogger is not None:
+    run_start_key = getattr(constants, "RUN_START", "run_start")
+    mllogger.start(key=run_start_key)
+
+
+def block_start(args=None, step: int = 0, samples_count: Optional[int] = None):
+  """Marks the start of a training block."""
+  if _is_master_process() and mllogger is not None:
+    if samples_count is None and args is not None:
+      global_batch_size = getattr(args, "batch_size", 1) * getattr(args, "num_generations", 1)
+      eval_interval = getattr(args, "eval_every_n_steps", getattr(args, "max_steps", 1))
+      samples_count = eval_interval * global_batch_size
+
+    metadata = {"step": int(step)}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    mllogger.start(
+        key=getattr(constants, "BLOCK_START", "block_start"),
+        metadata=metadata,
+    )
+
+
+def train_start(args=None, step: int = 0, samples_count: Optional[int] = None):
+  """Marks initialization end, run start, and the first training block start."""
+  init_stop()
+  run_start()
+  block_start(args=args, step=step, samples_count=samples_count)
+
+
+def block_stop(step: int = 0, samples_count: Optional[int] = None):
+  """Marks the end of a training block."""
+  if _is_master_process() and mllogger is not None:
+    metadata = {"step": int(step)}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    mllogger.end(
+        key=getattr(constants, "BLOCK_STOP", "block_stop"),
+        metadata=metadata,
+    )
+
+
+def train_stop(
+    args: Any = None,
+    step: Optional[int] = None,
+    samples_count: Optional[int] = None,
+    status: str = "success",
+):
+  """Marks the end of a training block and the training run."""
+  if args is not None:
+    if step is None:
+      step = getattr(args, "max_steps", 0)
+    if samples_count is None:
+      global_batch_size = getattr(args, "batch_size", 1) * getattr(
+          args, "num_generations", 1
+      )
+      samples_count = int(step) * global_batch_size
+
+  step_val = 0 if step is None else int(step)
+  block_stop(step=step_val, samples_count=samples_count)
+  run_stop(status=status, samples_count=samples_count)
+
+
+def start_eval(step: int = 0, samples_count: Optional[int] = None):
+  """Marks the start of an evaluation interval."""
+  if _is_master_process() and mllogger is not None:
+    metadata = {"step": int(step)}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    mllogger.start(
+        key=getattr(constants, "EVAL_START", "eval_start"),
+        metadata=metadata,
+    )
+
+
+def end_eval(
+    step: int = 0,
+    accuracy: float = 0.0,
+    samples_count: Optional[int] = None,
+    validation_time: Optional[float] = None,
+):
+  """Marks the end of an evaluation interval and records eval accuracy."""
+  if _is_master_process() and mllogger is not None:
+    metadata = {"step": int(step)}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    if validation_time is not None:
+      mllogger.event(
+          key="tracked_stats",
+          value={"validation_time": float(validation_time)},
+          metadata={"step": int(step)},
+      )
+
+    eval_accuracy_metadata = {}
+    if samples_count is not None:
+      eval_accuracy_metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    mllogger.event(
+        key=getattr(constants, "EVAL_ACCURACY", "eval_accuracy"),
+        value=float(accuracy),
+        metadata=eval_accuracy_metadata,
+    )
+    mllogger.end(
+        key=getattr(constants, "EVAL_STOP", "eval_stop"),
+        metadata=metadata,
+    )
+
+
+def check_eval(
+    args,
+    step: int,
+    eval_accuracy: float,
+    start_step: int = 0,
+    target_accuracy: Optional[float] = None,
+    validation_time: Optional[float] = None,
+) -> bool:
+  """Logs an evaluation block completion, checks for early stopping, and handles next block."""
+  target_acc = target_accuracy if target_accuracy is not None else getattr(args, "target_accuracy", 0.69)
+  is_early_stop = (target_acc is not None) and (eval_accuracy >= target_acc)
+
+  if not (_is_master_process() and mllogger is not None):
+    return is_early_stop
+
+  global_batch_size = getattr(args, "batch_size", 1) * getattr(args, "num_generations", 1)
+  eval_interval = getattr(args, "eval_every_n_steps", 10)
+  eval_frequency_samples = eval_interval * global_batch_size
+  current_samples = (step - start_step) * global_batch_size
+
+  mllogger.end(
+      key=getattr(constants, "BLOCK_STOP", "block_stop"),
+      metadata={
+          getattr(constants, "SAMPLES_COUNT", "samples_count"): current_samples,
+          "step": int(step),
+      },
+  )
+  mllogger.start(
+      key=getattr(constants, "EVAL_START", "eval_start"),
+      metadata={
+          getattr(constants, "SAMPLES_COUNT", "samples_count"): current_samples,
+          "step": int(step),
+      },
+  )
+  if validation_time is not None:
+    mllogger.event(
+        key="tracked_stats",
+        value={"validation_time": float(validation_time)},
+        metadata={"step": int(step)},
+    )
+  mllogger.event(
+      key=getattr(constants, "EVAL_ACCURACY", "eval_accuracy"),
+      value=float(eval_accuracy),
+      metadata={
+          getattr(constants, "SAMPLES_COUNT", "samples_count"): current_samples,
+      },
+  )
+  mllogger.end(
+      key=getattr(constants, "EVAL_STOP", "eval_stop"),
+      metadata={
+          getattr(constants, "SAMPLES_COUNT", "samples_count"): current_samples,
+          "step": int(step),
+      },
+  )
+
+  if is_early_stop:
+    mllogger.end(
+        key=getattr(constants, "RUN_STOP", "run_stop"),
+        metadata={
+            "status": "success",
+            getattr(constants, "SAMPLES_COUNT", "samples_count"): current_samples,
+        },
+    )
+    mllogger.event(
+        key=getattr(constants, "TRAIN_SAMPLES", "train_samples"),
+        value=current_samples,
+    )
+  else:
+    mllogger.start(
+        key=getattr(constants, "BLOCK_START", "block_start"),
+        metadata={
+            getattr(constants, "SAMPLES_COUNT", "samples_count"): eval_frequency_samples,
+            "step": int(step),
+        },
+    )
+
+  return is_early_stop
+
+
+def log_tracked_stats(
+    stats: Mapping[str, Any],
+    step: int = 0,
+    samples_count: Optional[int] = None,
+):
+  """Logs tracked training/timing metrics to the MLPerf log."""
+  if _is_master_process() and mllogger is not None:
+    metadata = {"step": int(step)}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    clean_stats = {}
+    for k, v in stats.items():
+      if v is not None:
+        if hasattr(v, "item"):
+          clean_stats[k] = v.item()
+        else:
+          clean_stats[k] = v
+
+    if clean_stats:
+      mllogger.event(
+          key="tracked_stats",
+          value=clean_stats,
+          metadata=metadata,
+      )
+
+
+def _clean_metric_val(v: Any, op: Optional[Callable] = None) -> Optional[Any]:
+  """Converts metric value into a JSON-serializable scalar or standard numeric type."""
+  if v is None:
+    return None
+
+  # Handle WeightedMetric or custom objects with .compute()
+  if hasattr(v, "compute") and callable(v.compute):
+    try:
+      v = v.compute()
+    except Exception:
+      pass
+
+  # Convert list or scalar to numpy array if possible
+  try:
+    arr = np.asarray(v)
+  except Exception:
+    arr = v
+
+  if isinstance(arr, np.ndarray):
+    # Filter out pure string arrays
+    if arr.dtype.kind in {"U", "S"}:
+      return None
+    if arr.dtype.kind == "O":
+      if arr.size > 0 and isinstance(arr.ravel()[0], (str, np.str_)):
+        return None
+
+    if op is not None and arr.size > 0:
+      try:
+        arr = op(arr)
+      except Exception:
+        pass
+
+    if hasattr(arr, "item"):
+      try:
+        return arr.item()
+      except Exception:
+        pass
+    if hasattr(arr, "tolist"):
+      try:
+        res = arr.tolist()
+        if isinstance(res, (int, float, bool, str)):
+          return res
+      except Exception:
+        pass
+
+  if op is not None and not isinstance(arr, np.ndarray):
+    try:
+      v = op(v)
+    except Exception:
+      pass
+
+  if hasattr(v, "item"):
+    try:
+      return v.item()
+    except Exception:
+      pass
+
+  if isinstance(v, (int, float, bool, str)):
+    return v
+  return None
+
+
+def _extract_kv_from_metrics_buffer(metrics_buffer: Any) -> dict[str, Any]:
+  """Extracts key-value metric pairs from a MetricsBuffer or dictionary."""
+  kv_stats = {}
+  if metrics_buffer is None:
+    return kv_stats
+
+  # Case 1: Plain dict
+  if isinstance(metrics_buffer, dict):
+    for k, v in metrics_buffer.items():
+      val = _clean_metric_val(v)
+      if val is not None:
+        kv_stats[k] = val
+    return kv_stats
+
+  # Case 2: tunix.perf.metrics.MetricsBuffer or objects with .metrics dict
+  metrics_dict = getattr(metrics_buffer, "metrics", None)
+  if isinstance(metrics_dict, dict):
+    for k, val_entry in metrics_dict.items():
+      if isinstance(val_entry, tuple) and len(val_entry) == 2:
+        values, op = val_entry
+      else:
+        values, op = val_entry, None
+
+      # Handle list of values / WeightedMetrics
+      if isinstance(values, list) and values:
+        is_weighted = [
+            hasattr(x, "compute") or hasattr(x, "numerator") for x in values
+        ]
+        if any(is_weighted):
+          if op is not None and getattr(op, "__name__", "") in (
+              "_weighted_metric_mean",
+              "global_weighted_mean",
+              "mean_of_means",
+          ):
+            try:
+              values = op(values)
+              op = None
+            except Exception:
+              values = [
+                  x.compute() if hasattr(x, "compute") else x for x in values
+              ]
+          else:
+            values = [
+                x.compute() if hasattr(x, "compute") else x for x in values
+            ]
+
+      val = _clean_metric_val(values, op=op)
+      if val is not None:
+        kv_stats[k] = val
+
+  # Case 3: Objects with .losses and .additional_metrics (e.g. peft_trainer.MetricsBuffer)
+  if hasattr(metrics_buffer, "loss"):
+    loss_val = _clean_metric_val(metrics_buffer.loss)
+    if loss_val is not None:
+      kv_stats["loss"] = loss_val
+  elif hasattr(metrics_buffer, "losses") and getattr(metrics_buffer, "losses"):
+    loss_val = _clean_metric_val(metrics_buffer.losses, op=np.mean)
+    if loss_val is not None:
+      kv_stats["loss"] = loss_val
+
+  addl_metrics = getattr(metrics_buffer, "additional_metrics", None)
+  if isinstance(addl_metrics, dict):
+    for k, val_entry in addl_metrics.items():
+      if isinstance(val_entry, tuple) and len(val_entry) == 2:
+        values, op = val_entry
+      else:
+        values, op = val_entry, None
+      if isinstance(values, list) and values:
+        values = [x.compute() if hasattr(x, "compute") else x for x in values]
+      val = _clean_metric_val(values, op=op)
+      if val is not None:
+        kv_stats[k] = val
+
+  return kv_stats
+
+
+MLPERF_TRACKED_KEYS = frozenset({
+    "step_time",
+    "train_reward",
+    "train_solve",
+    "adv_abs_mean",
+    "completion_length",
+    "loss",
+    "grad_norm",
+    "reduced_pg_loss",
+    "entropy",
+    "kl",
+    "log_ratio_abs",
+    "clipfrac",
+})
+
+
+def log_metrics_buffer(
+    metrics_buffer: Any,
+    args: Any = None,
+    global_batch_size: Optional[int] = None,
+    batch_size: Optional[int] = None,
+    num_generations: Optional[int] = None,
+    step: Optional[int] = None,
+    samples_count: Optional[int] = None,
+    allowed_keys: Optional[Iterable[str]] = MLPERF_TRACKED_KEYS,
+    rl_engine: Any = None,
+):
+  """Extracts KV metric pairs from a MetricsBuffer and logs them to MLPerf RCP."""
+  if not (_is_master_process() and mllog is not None and mllogger is not None):
+    return
+
+  stats = _extract_kv_from_metrics_buffer(metrics_buffer)
+
+  # If rl_engine is provided, extract actor metrics from actor_trainer or _rl_metrics_logger
+  if rl_engine is not None:
+    actor_trainer = getattr(rl_engine, "actor_trainer", None)
+    if actor_trainer is not None:
+      trainer_buf = (
+          getattr(actor_trainer, "_prev_buffered_train_metrics", None)
+          or getattr(actor_trainer, "_buffered_train_metrics", None)
+      )
+      if trainer_buf is not None:
+        trainer_stats = _extract_kv_from_metrics_buffer(trainer_buf)
+        for k, v in trainer_stats.items():
+          if k not in stats:
+            stats[k] = v
+
+    # Fallback to _rl_metrics_logger history if any keys are still missing
+    metrics_logger = getattr(rl_engine, "_rl_metrics_logger", None)
+    if metrics_logger is not None and hasattr(metrics_logger, "_metrics"):
+      actor_m = metrics_logger._metrics.get("actor", {}).get("train", {})
+      for k, vals in actor_m.items():
+        if vals and k not in stats:
+          val = _clean_metric_val(vals[-1])
+          if val is not None:
+            stats[k] = val
+
+  if not stats:
+    return
+
+  # Map canonical Tunix metric names to MLPerf RCP tracked keys
+  key_mappings = {
+      "perf/global_step_time": "step_time",
+      "generation/completions/mean_length": "completion_length",
+      "trajectory_rewards/mean": "train_reward",
+      "rewards/mean": "train_reward",
+      "advantage/abs_mean": "adv_abs_mean",
+      "log_ratio/abs_mean": "log_ratio_abs",
+      "pg_clipfrac": "clipfrac",
+  }
+  for orig_key, rcp_key in key_mappings.items():
+    if rcp_key not in stats and orig_key in stats:
+      stats[rcp_key] = stats[orig_key]
+
+  # In SWE-bench, tasks are strictly binary pass/fail (1.0 or 0.0),
+  # so train_solve is equivalent to train_reward.
+  if "train_solve" not in stats and "train_reward" in stats:
+    stats["train_solve"] = stats["train_reward"]
+
+  # Filter out internal/framework metrics not part of MLPerf RCP tracked stats
+  if allowed_keys is not None:
+    allowed_set = set(allowed_keys)
+    stats = {k: v for k, v in stats.items() if k in allowed_set}
+
+  if not stats:
+    return
+
+  # Determine step number
+  if step is not None:
+    step_num = int(step)
+  else:
+    raw_step = getattr(
+        metrics_buffer, "global_steps", getattr(metrics_buffer, "step", 0)
+    )
+    step_num = int(raw_step) + 1
+
+  # Determine samples count
+  if samples_count is None:
+    gbs = global_batch_size
+    if gbs is None:
+      if batch_size is not None and num_generations is not None:
+        gbs = batch_size * num_generations
+      elif args is not None:
+        gbs = getattr(args, "batch_size", 1) * getattr(
+            args, "num_generations", 1
+        )
+    if gbs is not None:
+      samples_count = step_num * gbs
+
+  log_tracked_stats(
+      stats=stats,
+      step=step_num,
+      samples_count=samples_count,
+  )
+
+
+def create_rcp_metrics_logger(
+    args: Any = None,
+    global_batch_size: Optional[int] = None,
+    batch_size: Optional[int] = None,
+    num_generations: Optional[int] = None,
+    allowed_keys: Optional[Iterable[str]] = MLPERF_TRACKED_KEYS,
+    rl_engine: Any = None,
+) -> Callable[[Any], None]:
+  """Creates an external metrics logger callable compatible with with_external_metrics_logger.
+
+  Args:
+    args: Optional arguments namespace containing batch_size and num_generations.
+    global_batch_size: Optional total samples per global step.
+    batch_size: Optional batch size per device / prompt.
+    num_generations: Optional number of generations per prompt.
+    allowed_keys: Optional set of metric keys to allow in tracked_stats.
+    rl_engine: Optional RL engine instance (e.g. RLCluster) to extract actor
+      trainer metrics from.
+
+  Returns:
+    A callable accepting a MetricsBuffer that logs tracked stats.
+  """
+  effective_gbs = global_batch_size
+  if effective_gbs is None:
+    if batch_size is not None and num_generations is not None:
+      effective_gbs = batch_size * num_generations
+    elif args is not None:
+      effective_gbs = getattr(args, "batch_size", 1) * getattr(
+          args, "num_generations", 1
+      )
+
+  def rcp_logger(metrics_buffer: Any) -> None:
+    log_metrics_buffer(
+        metrics_buffer=metrics_buffer,
+        args=args,
+        global_batch_size=effective_gbs,
+        allowed_keys=allowed_keys,
+        rl_engine=rl_engine,
+    )
+
+  return rcp_logger
+
+
+rcp_metrics_logger = create_rcp_metrics_logger
+
+
+def run_stop(status: str = "success", samples_count: Optional[int] = None):
+  """Marks the end of the training run."""
+  if _is_master_process() and mllogger is not None:
+    metadata = {"status": status}
+    if samples_count is not None:
+      metadata[getattr(constants, "SAMPLES_COUNT", "samples_count")] = int(samples_count)
+
+    mllogger.end(
+        key=getattr(constants, "RUN_STOP", "run_stop"),
+        metadata=metadata,
+    )
+
+
+def init_print(
+    args,
+    train_dataset: Any = None,
+    val_dataset: Any = None,
+    rollout_mesh: Any = None,
+    train_mesh: Any = None,
+    total_devices: Optional[int] = None,
+):
+  """Logs initial MLPerf submission metadata and hyperparameters for compliance."""
+  if not (_is_master_process() and mllogger is not None):
+    return
+
+  if getattr(args, "metric_logger_dir", None) is not None:
+    configure_logger(
+        metric_logger_dir=args.metric_logger_dir,
+        seed=getattr(args, "seed", 1),
+    )
+
+  # Extract batch & step configs
+  batch_size = getattr(args, "batch_size", 8)
+  num_generations = getattr(args, "num_generations", 8)
+  global_batch_size = batch_size * num_generations
+  mini_batch_size = getattr(args, "mini_batch_size", batch_size)
+  train_micro_batch_size = getattr(args, "train_micro_batch_size", 1)
+  max_steps = getattr(args, "max_steps", 50)
+  max_prompt_length = getattr(args, "max_prompt_length", 4096)
+  max_response_length = getattr(args, "max_response_length", 8192)
+  max_seq_len = max_prompt_length + max_response_length
+
+  # Train / Eval sample counts
+  train_samples = None
+  if train_dataset is not None:
+    try:
+      train_samples = len(train_dataset) * num_generations
+    except (TypeError, AttributeError):
+      pass
+  if train_samples is None:
+    train_samples = max_steps * global_batch_size
+
+  eval_samples = None
+  if val_dataset is not None:
+    try:
+      eval_samples = len(val_dataset)
+    except (TypeError, AttributeError):
+      pass
+  if eval_samples is None:
+    eval_samples = 256
+
+  # Parallelism dimensions from meshes
+  train_tp = 1
+  train_sp = 1
+  if train_mesh is not None and hasattr(train_mesh, "shape"):
+    train_tp = train_mesh.shape.get("tp", train_mesh.shape.get("tensor", 1))
+    train_sp = train_mesh.shape.get("sp", 1)
+  elif getattr(args, "train_mesh_tp", None) is not None:
+    train_tp = args.train_mesh_tp
+    train_sp = getattr(args, "train_mesh_sp", 1) or 1
+
+  rollout_tp = 1
+  if rollout_mesh is not None and hasattr(rollout_mesh, "shape"):
+    rollout_tp = rollout_mesh.shape.get("tp", rollout_mesh.shape.get("tensor", 1))
+  elif getattr(args, "rollout_mesh_tp", None) is not None:
+    rollout_tp = args.rollout_mesh_tp
+
+  # Submission platform description
+  platform = getattr(args, "tpu_topology", None)
+  if not platform:
+    if total_devices:
+      platform = f"{total_devices}xTPU"
+    else:
+      platform = "TPU-Ironwood"
+
+  # Gradient accumulation steps
+  grad_accum_steps = max(1, batch_size // mini_batch_size)
+
+  # 1. Submission Metadata
+  mllogger.event(
+      key=getattr(constants, "SUBMISSION_BENCHMARK", "submission_benchmark"),
+      value=getattr(constants, "QWEN35_397B_GRPO", "qwen35_397b_grpo"),
+  )
+  mllogger.event(
+      key=getattr(constants, "SUBMISSION_ORG", "submission_org"),
+      value="Google",
+  )
+  mllogger.event(
+      key=getattr(constants, "SUBMISSION_DIVISION", "submission_division"),
+      value=getattr(constants, "CLOSED", "closed"),
+  )
+  mllogger.event(
+      key=getattr(constants, "SUBMISSION_STATUS", "submission_status"),
+      value=getattr(constants, "CLOUD", "cloud"),
+  )
+  mllogger.event(
+      key=getattr(constants, "SUBMISSION_PLATFORM", "submission_platform"),
+      value=str(platform),
+  )
+
+  # 2. Hyperparameters & Training Configuration
+  logging_configs = {
+      getattr(constants, "SEED", "seed"): getattr(args, "seed", 42),
+      getattr(constants, "MAX_STEPS", "max_steps"): max_steps,
+      getattr(constants, "GLOBAL_BATCH_SIZE", "global_batch_size"): global_batch_size,
+      getattr(constants, "MICRO_BATCH_SIZE", "micro_batch_size"): train_micro_batch_size,
+      getattr(constants, "MAX_SEQUENCE_LENGTH", "max_sequence_length"): max_seq_len,
+      getattr(constants, "TRAIN_SAMPLES", "train_samples"): train_samples,
+      getattr(constants, "EVAL_SAMPLES", "eval_samples"): eval_samples,
+      getattr(constants, "INIT_CHECKPOINT_STEP", "init_checkpoint_step"): 0,
+      getattr(constants, "OPT_NAME", "opt_name"): getattr(constants, "ADAMW", "adamw"),
+      getattr(constants, "OPT_BASE_LR", "opt_base_learning_rate"): getattr(args, "learning_rate", 1e-6),
+      getattr(constants, "OPT_END_LR", "opt_end_learning_rate"): getattr(args, "learning_rate", 1e-6),
+      getattr(constants, "OPT_ADAMW_BETA_1", "opt_adamw_beta_1"): getattr(args, "b1", 0.9),
+      getattr(constants, "OPT_ADAMW_BETA_2", "opt_adamw_beta_2"): getattr(args, "b2", 0.99),
+      getattr(constants, "OPT_ADAMW_EPSILON", "opt_adamw_epsilon"): 1e-8,
+      getattr(constants, "OPT_ADAMW_WEIGHT_DECAY", "opt_adamw_weight_decay"): getattr(args, "weight_decay", 0.01),
+      getattr(constants, "OPT_GRADIENT_CLIP_NORM", "opt_gradient_clip_norm"): getattr(args, "max_grad_norm", 1.0),
+      getattr(constants, "OPT_LR_WARMUP_STEPS", "opt_learning_rate_warmup_steps"): 0,
+      getattr(constants, "OPT_LR_DECAY_STEPS", "opt_learning_rate_decay_steps"): max_steps,
+      getattr(constants, "OPT_LR_DECAY_SCHEDULE", "opt_learning_rate_decay_schedule"): "constant",
+      getattr(constants, "TENSOR_PARALLELISM", "tensor_parallelism"): train_tp,
+      getattr(constants, "PIPELINE_PARALLELISM", "pipeline_parallelism"): 1,
+      getattr(constants, "CONTEXT_PARALLELISM", "context_parallelism"): train_sp,
+      getattr(constants, "EXPERT_PARALLELISM", "expert_parallelism"): 1,
+      "generation_backend": getattr(args, "rollout_engine", "vllm"),
+      "generation_tensor_parallelism": rollout_tp,
+      "generation_pipeline_parallelism": 1,
+      "generation_expert_parallelism": 1,
+      getattr(
+          constants,
+          "GENERATION_TRAINING_ROLLOUT_TEMPERATURE",
+          "generation_training_rollout_temperature",
+      ): getattr(args, "temperature", 1.0),
+      getattr(
+          constants,
+          "GENERATION_TRAINING_ROLLOUT_TOP_P",
+          "generation_training_rollout_top_p",
+      ): (getattr(args, "top_p", None) if getattr(args, "top_p", None) is not None else 1.0),
+      getattr(
+          constants,
+          "GENERATION_VALIDATION_ROLLOUT_TEMPERATURE",
+          "generation_validation_rollout_temperature",
+      ): 0.1,
+      getattr(
+          constants,
+          "GENERATION_VALIDATION_ROLLOUT_TOP_P",
+          "generation_validation_rollout_top_p",
+      ): 0.95,
+      getattr(constants, "NUM_PROMPTS_PER_STEP", "num_prompts_per_step"): batch_size,
+      getattr(constants, "NUM_GENERATIONS_PER_PROMPT", "num_generations_per_prompt"): num_generations,
+      "truncated_importance_sampling_ratio_min": 0.999,
+      "truncated_importance_sampling_ratio": 1.002,
+      "truncated_importance_sampling_type": "seq-mask-tis",
+      "target_accuracy": getattr(args, "target_accuracy", 0.69),
+      getattr(constants, "GRADIENT_ACCUMULATION_STEPS", "gradient_accumulation_steps"): grad_accum_steps,
+  }
+
+  for key, value in logging_configs.items():
+    if value is not None:
+      mllogger.event(key=key, value=value)


### PR DESCRIPTION
Resolves #

### Description
This PR adds MLPerf RCP logging utilities and integration for post-training (GRPO) in DeepSWE:

- **MLPerf Logging Utilities** (`examples/deepswe/mllog_utils.py`): Implements MLPerf logging lifecycle hooks (`init_start`, `init_stop`, `run_start`, `block_start`, `block_stop`, `init_print`, `start_eval`, `end_eval`, `check_eval`, `log_tracked_stats`, `run_stop`) with multi-host coordination, file output configuration, and fallback handling when `mlperf_logging` is unavailable.
- **DeepSWE Integration** (`examples/deepswe/train_deepswe_nb.py`): Adds `--rcp_logging` flag to enable MLPerf initialization, submission metadata logging, and run lifecycle events.
- **Agentic RL Learner Integration** (`tunix/rl/agentic/agentic_rl_learner.py`): Logs per-step training metrics (losses, rewards, step times, advantages, completion lengths, and actor metrics) under `rcp_logging` with safe optional imports and proper step indexing.
- **Unit & Compliance Tests** (`tests/examples/deepswe_mllog_utils_test.py`): Adds tests covering file logging, eval lifecycle, early stopping, and end-to-end submission config logging.

> **Note**: The eval logging is not added to `agentic_rl_learner.py` as the eval pipeline has not validated with DeepSWE now.

**Reference**
Tested RCP logging with Qwen3.5 35B. After mocking eval and part of parameters (e.g. submission_benchmark), the logging passed the MLPerf ruling check:
```
INFO - Running compliance on file: corrected_sb_35b_20_mlperf_compliance.log
INFO - Compliance checks: training_6.1.0/closed_qwen35_397b_grpo.yaml
** Logging output also at compliance_checker.log
INFO - SUCCESS
```

**Colab Notebook**
N/A

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
