### PR TITLE
Add optional process-pool evaluation of reward functions

### DIFF
--- a/tests/rl/reward_manager_test.py
+++ b/tests/rl/reward_manager_test.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 import dataclasses
+import gc
 import inspect
+import multiprocessing
+import time
 from typing import Any, List
 from unittest import mock
+
 from absl import logging
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -278,6 +282,174 @@ class AgenticSequenceRewardManagerTest(parameterized.TestCase):
     self.assertIn("trajectory_rewards/sum", log_metrics)
     self.assertIn("trajectory_rewards/mean", log_metrics)
     self.assertNotIn("rewards/sum", log_metrics)
+
+
+def answer_reward(
+    prompts: List[str],
+    completions: List[str],
+    answer: List[str],
+    **kwargs: Any,
+) -> List[float]:
+  del completions, kwargs  # Unused
+  assert len(answer) == len(prompts)
+  return [float(a) for a in answer]
+
+
+answer_reward.__name__ = "answer_reward"
+
+
+def _noop():
+  pass
+
+
+def child_spawning_reward(
+    prompts: List[str], completions: List[str], **kwargs: Any
+) -> List[float]:
+  """Spawns a subprocess of its own, which a daemonic pool worker forbids."""
+  del completions, kwargs  # Unused
+  p = multiprocessing.get_context("forkserver").Process(target=_noop)
+  p.start()
+  p.join()
+  return [7.0] * len(prompts)
+
+
+child_spawning_reward.__name__ = "child_spawning_reward"
+
+
+def slow_reward(
+    prompts: List[str], completions: List[str], **kwargs: Any
+) -> List[float]:
+  """Takes longer than the (tiny) worker timeout used in the timeout test."""
+  del completions, kwargs  # Unused
+  time.sleep(0.5)
+  return [3.0] * len(prompts)
+
+
+slow_reward.__name__ = "slow_reward"
+
+
+@absltest.skipIf(
+    reward_manager._fork_context() is None,  # pylint: disable=protected-access
+    "parallel reward evaluation requires the forkserver start method",
+)
+class ParallelSequenceRewardManagerTest(parameterized.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.serial_config = TestAlgoConfig()
+    self.parallel_config = TestAlgoConfig(reward_num_workers=4)
+    self.prompts = [f"p{i}" for i in range(10)]
+    self.completions = [f"c{i}" * (i + 1) for i in range(10)]
+    self.answers = [str(float(i)) for i in range(10)]
+    self._managers = []
+
+  def tearDown(self):
+    for m in self._managers:
+      m.close()
+    super().tearDown()
+
+  def _make(self, reward_fns, config):
+    manager = reward_manager.SequenceRewardManager(
+        reward_fns=reward_fns, algo_config=config
+    )
+    self._managers.append(manager)
+    return manager
+
+  def test_parallel_matches_serial(self):
+    fns = [len_reward, prompt_len_reward, answer_reward, nan_reward]
+    serial = self._make(fns, self.serial_config)(
+        self.prompts, self.completions, answer=self.answers
+    )
+    parallel = self._make(fns, self.parallel_config)(
+        self.prompts, self.completions, answer=self.answers
+    )
+    np.testing.assert_array_equal(serial["rewards"], parallel["rewards"])
+    for name in (
+        "rewards/len_reward",
+        "rewards/prompt_len_reward",
+        "rewards/answer_reward",
+    ):
+      np.testing.assert_array_equal(
+          serial["log_metrics"][name][0],
+          parallel["log_metrics"][name][0],
+          err_msg=f"{name} mismatch",
+      )
+
+  def test_per_example_kwargs_sliced_in_order(self):
+    manager = self._make([answer_reward], self.parallel_config)
+    rewards_info = manager(self.prompts, self.completions, answer=self.answers)
+    np.testing.assert_array_equal(
+        rewards_info["rewards"], np.array([float(i) for i in range(10)])
+    )
+
+  def test_unpicklable_fn_evaluated_in_parent(self):
+    unpicklable = lambda prompts, completions, **kw: [2.0] * len(prompts)
+    unpicklable.__name__ = "unpicklable_fn"
+    manager = self._make([unpicklable], self.parallel_config)
+    rewards_info = manager(self.prompts, self.completions)
+    np.testing.assert_array_equal(rewards_info["rewards"], np.full(10, 2.0))
+    self.assertIn("unpicklable_fn", manager._parent_only_fns)
+
+  def test_subprocess_spawning_fn_evaluated_in_parent(self):
+    manager = self._make([child_spawning_reward], self.parallel_config)
+    rewards_info = manager(self.prompts, self.completions)
+    np.testing.assert_array_equal(rewards_info["rewards"], np.full(10, 7.0))
+    self.assertIn("child_spawning_reward", manager._parent_only_fns)
+    # Subsequent calls still succeed (fn now runs in the parent).
+    rewards_info = manager(self.prompts, self.completions)
+    np.testing.assert_array_equal(rewards_info["rewards"], np.full(10, 7.0))
+
+  def test_minus_one_uses_one_worker_per_cpu(self):
+    # Pin the CPU count: the point is the resolution rule, and a real
+    # many-core test machine must not spawn one worker per core here.
+    with mock.patch.object(reward_manager.os, "cpu_count", return_value=3):
+      manager = self._make([len_reward], TestAlgoConfig(reward_num_workers=-1))
+      rewards_info = manager(self.prompts, self.completions)
+      self.assertEqual(manager._pool._processes, 3)
+    expected = np.array([float(len(c)) for c in self.completions])
+    np.testing.assert_array_equal(rewards_info["rewards"], expected)
+
+  def test_empty_batch_raises(self):
+    manager = self._make([len_reward], self.parallel_config)
+    with self.assertRaisesRegex(ValueError, "empty batch"):
+      manager([], [])
+    self.assertIsNone(manager._pool)
+
+  def test_zero_workers_creates_no_pool(self):
+    manager = self._make([len_reward], self.serial_config)
+    manager(self.prompts, self.completions)
+    self.assertIsNone(manager._pool)
+
+  def test_default_is_serial(self):
+    self.assertEqual(algo_config_lib.AlgorithmConfig().reward_num_workers, 0)
+
+  def test_worker_timeout_is_configurable(self):
+    config = TestAlgoConfig(
+        reward_num_workers=2, reward_worker_timeout_seconds=0.01
+    )
+    manager = self._make([slow_reward], config)
+    rewards_info = manager(self.prompts, self.completions)
+    # The chunk timed out in the worker, so the fn was evaluated in the
+    # parent and is parent-only from now on; the result is still correct.
+    np.testing.assert_array_equal(rewards_info["rewards"], np.full(10, 3.0))
+    self.assertIn("slow_reward", manager._parent_only_fns)
+
+  def test_dropped_manager_terminates_its_workers(self):
+    manager = reward_manager.SequenceRewardManager(
+        reward_fns=[len_reward], algo_config=self.parallel_config
+    )
+    manager(self.prompts, self.completions)
+    workers = list(manager._pool._pool)  # pylint: disable=protected-access
+    self.assertTrue(all(w.is_alive() for w in workers))
+    del manager
+    gc.collect()
+    for w in workers:
+      w.join(timeout=5)
+    self.assertFalse(any(w.is_alive() for w in workers))
+
+  def test_invalid_timeout_rejected(self):
+    with self.assertRaisesRegex(ValueError, "reward_worker_timeout_seconds"):
+      TestAlgoConfig(reward_worker_timeout_seconds=0)
 
 
 if __name__ == "__main__":

--- a/tunix/rl/algorithm_config.py
+++ b/tunix/rl/algorithm_config.py
@@ -15,6 +15,7 @@
 import dataclasses
 from absl import logging
 
+
 @dataclasses.dataclass(slots=True, kw_only=True)
 class AlgorithmConfig:
   """Configuration for RL algorithms.
@@ -37,7 +38,23 @@ class AlgorithmConfig:
   # `exp(diff)` term saturates bf16 / overflows fp32 and poisons the loss
   # for the rest of the step.
   kl_clamp_value: float | None = None
-
+  # Number of worker processes `SequenceRewardManager` uses to evaluate
+  # reward functions over the batch. `0` (default) keeps the serial
+  # implementation and preserves prior behavior bit-for-bit. Values > 1
+  # chunk the (prompts, completions) batch across a process pool — reward
+  # functions are called with contiguous slices, so per-sequence reward
+  # functions produce identical results, while functions that depend on the
+  # batch as a whole (e.g. on a sequence's position in it) see the chunk
+  # instead of the full batch, which is why the pool is opt-in. Functions
+  # that cannot run in a worker (unpicklable, or spawning subprocesses of
+  # their own) are detected at runtime and evaluated in the parent process
+  # instead; any other failure falls back to the serial path. `-1` uses one
+  # worker per CPU.
+  reward_num_workers: int = 0
+  # How long, in seconds, to wait for one reward-fn chunk in a worker before
+  # treating the pool as unusable for that fn and evaluating it in the parent
+  # process instead.
+  reward_worker_timeout_seconds: float = 180.0
 
   def __post_init__(self):
     valid_algo_variants = [
@@ -62,6 +79,16 @@ class AlgorithmConfig:
       raise ValueError(
           f"policy_loss_fn must be one of {valid_policy_loss_fns}."
           f" Received: {self.policy_loss_fn}"
+      )
+    if self.reward_num_workers < -1:
+      raise ValueError(
+          "reward_num_workers must be >= 0, or -1 for one worker per CPU."
+          f" Received: {self.reward_num_workers}"
+      )
+    if self.reward_worker_timeout_seconds <= 0:
+      raise ValueError(
+          "reward_worker_timeout_seconds must be > 0."
+          f" Received: {self.reward_worker_timeout_seconds}"
       )
 
     # Automatically prints configuration upon initialization.

--- a/tunix/rl/reward_manager.py
+++ b/tunix/rl/reward_manager.py
@@ -17,15 +17,43 @@
 import abc
 from dataclasses import asdict
 import inspect
+import multiprocessing
 import os
 from typing import Any, Callable, Dict, List, Sequence
+import weakref
+
 from absl import logging
 import numpy as np
 from tunix.rl import algorithm_config as algo_config_lib
 from tunix.rl import function_registry
 
-
 RewardFn = Callable[..., Any]
+
+
+def _terminate_pool(pool) -> None:
+  try:
+    pool.terminate()
+  except Exception:  # pylint: disable=broad-except
+    pass
+
+
+def _fork_context():
+  """The multiprocessing context for reward workers, or None if unavailable.
+
+  Workers are started through a fork server rather than forked directly
+  from the trainer: a direct fork inherits the parent's initialized JAX
+  runtime, and the first JAX call in such a child deadlocks (until the
+  worker timeout expires and the fn falls back to the parent). Fork-server
+  children are fresh interpreters and do not have that problem.
+
+  Every process operation of the pool goes through this one context object
+  (its `Pool`, `Process` and `current_process`), so swapping the context is
+  enough to change how workers are started.
+  """
+  try:
+    return multiprocessing.get_context("forkserver")
+  except ValueError:
+    return None
 
 
 def _calculate_scalar_reward_log_metrics(
@@ -101,6 +129,132 @@ class SequenceRewardManager(AbstractRewardManager):
   ):
     """Initializes the manager with a list of callable reward function objects."""
     super().__init__(reward_fns, algo_config)
+    self._pool = None
+    # Reward fns that must be evaluated in the parent process, learned at
+    # runtime: fns that are unpicklable, or that spawn subprocesses of their
+    # own (which the pool's daemonic workers forbid).
+    self._parent_only_fns = set()
+    self._parallel_disabled = False
+    self._worker_timeout = getattr(
+        algo_config, "reward_worker_timeout_seconds", 180.0
+    )
+
+  def _parallel_enabled(self) -> bool:
+    return (
+        self._num_workers() > 1
+        and not self._parallel_disabled
+        and _fork_context() is not None
+    )
+
+  def _num_workers(self) -> int:
+    """Resolves `reward_num_workers`; -1 means one worker per CPU."""
+    n = getattr(self.algo_config, "reward_num_workers", 0)
+    cpus = os.cpu_count() or 1
+    if n == -1:
+      return cpus
+    if n > cpus:
+      logging.warning(
+          "reward_num_workers=%d exceeds the %d CPUs available; the extra"
+          " workers will only contend for cores.",
+          n,
+          cpus,
+      )
+    return n
+
+  def _get_pool(self):
+    """Lazily creates the reward worker pool."""
+    if self._pool is None:
+      ctx = _fork_context()
+      # Some launchers run the trainer as a daemonic child process, and
+      # multiprocessing forbids daemons from having children. The flag is
+      # launcher plumbing this code does not rely on: clear it so the pool
+      # can fork. The workers are reaped with the trainer on teardown.
+      cur_config = getattr(ctx.current_process(), "_config", None)
+      if isinstance(cur_config, dict) and cur_config.get("daemon"):
+        cur_config["daemon"] = False
+      self._pool = ctx.Pool(processes=self._num_workers())
+      # Learners hold the manager for their whole lifetime and never call
+      # close(); make sure a dropped manager does not leak its workers.
+      weakref.finalize(self, _terminate_pool, self._pool)
+    return self._pool
+
+  def close(self):
+    """Shuts down the reward worker pool, if one was created."""
+    pool = getattr(self, "_pool", None)
+    if pool is not None:
+      pool.terminate()
+      self._pool = None
+
+  def _call_reward_fn(
+      self,
+      reward_fn: RewardFn,
+      prompts: List[str],
+      completions: List[str],
+      call_kwargs: Dict[str, Any],
+  ) -> Any:
+    """Evaluates one reward fn over the batch, using workers when enabled."""
+    fn_name = getattr(reward_fn, "__name__", str(reward_fn))
+    if not self._parallel_enabled() or fn_name in self._parent_only_fns:
+      return reward_fn(prompts=prompts, completions=completions, **call_kwargs)
+
+    try:
+      pool = self._get_pool()
+    except Exception as e:  # pylint: disable=broad-except
+      self._parallel_disabled = True
+      logging.warning(
+          "Could not create the reward worker pool (%r); using the serial"
+          " implementation.",
+          e,
+      )
+      return reward_fn(prompts=prompts, completions=completions, **call_kwargs)
+
+    num_prompts = len(prompts)
+    try:
+      # Two chunks per worker, not one: reward cost varies a lot across
+      # completions (e.g. long answers under a verifier), and the smaller
+      # chunks let a worker that finished early pick up more work instead of
+      # idling behind the slowest chunk. The pool size itself is exactly
+      # `reward_num_workers`.
+      n_chunks = min(
+          pool._processes * 2, num_prompts  # pylint: disable=protected-access
+      )
+      bounds = [num_prompts * c // n_chunks for c in range(n_chunks + 1)]
+      jobs = []
+      for c in range(n_chunks):
+        lo, hi = bounds[c], bounds[c + 1]
+        chunk_kwargs = {}
+        for k, v in call_kwargs.items():
+          # A list/tuple/array kwarg with exactly one entry per prompt is
+          # treated as a per-example column (e.g. ground-truth answers) and
+          # sliced in lockstep with the batch, because that is the contract
+          # `__call__` already relies on for such kwargs. Anything else --
+          # scalars, configs, sequences of another length -- is passed to
+          # every chunk unchanged.
+          if isinstance(v, (list, tuple)) and len(v) == num_prompts:
+            chunk_kwargs[k] = list(v[lo:hi])
+          elif isinstance(v, np.ndarray) and len(v) == num_prompts:
+            chunk_kwargs[k] = v[lo:hi]
+          else:
+            chunk_kwargs[k] = v
+        chunk_kwargs["prompts"] = list(prompts[lo:hi])
+        chunk_kwargs["completions"] = list(completions[lo:hi])
+        jobs.append(pool.apply_async(reward_fn, kwds=chunk_kwargs))
+      parts = [j.get(timeout=self._worker_timeout) for j in jobs]
+      if any(p is None for p in parts):
+        raise RuntimeError(f"{fn_name} returned None in a worker.")
+      return [x for part in parts for x in list(part)]
+    except Exception as e:  # pylint: disable=broad-except
+      # Unpicklable fns and fns that spawn their own subprocesses land here,
+      # as does any worker crash. Evaluate this fn in the parent from now on
+      # -- its own internal parallelism, if any, works there.
+      self._parent_only_fns.add(fn_name)
+      logging.warning(
+          "Reward fn %s failed in worker processes (%r); evaluating it in the"
+          " parent process from now on.",
+          fn_name,
+          e,
+      )
+      return reward_fn(prompts=prompts, completions=completions, **call_kwargs)
 
   def __call__(
       self,
@@ -119,10 +273,15 @@ class SequenceRewardManager(AbstractRewardManager):
   ) -> Dict[str, Any]:
     """Computes the rewards for completions using the provided reward functions."""
 
+    num_prompts = len(prompts)
+    if num_prompts == 0:
+      raise ValueError(
+          "SequenceRewardManager received an empty batch; nothing to score."
+      )
+
     algo_config_params = asdict(self.algo_config)
     base_kwargs = kwargs.copy()
 
-    num_prompts = len(prompts)
     num_reward_fns = len(self.reward_fns)
     rewards = np.zeros((num_prompts, num_reward_fns))
 
@@ -145,7 +304,7 @@ class SequenceRewardManager(AbstractRewardManager):
       call_kwargs = base_kwargs.copy()
       call_kwargs.update(reward_fn_config_params)
 
-      r = reward_fn(prompts=prompts, completions=completions, **call_kwargs)
+      r = self._call_reward_fn(reward_fn, prompts, completions, call_kwargs)
 
       if r is None:
         raise RuntimeError(


### PR DESCRIPTION
<!--- Describe your changes in detail. -->

Sequence-level reward functions are pure Python, evaluated serially over the whole batch on one core while the host's remaining cores idle. On a GRPO post-training benchmark (qwen3-0.6b, 2048 sequences/step, 3 reward functions on a 40+ core head node), this serial pass took **29.6 s of a 155.6 s global step** — the second-largest component after rollout.

This PR adds `AlgorithmConfig.reward_num_workers`:

- **Default `0` keeps the serial implementation and preserves current behavior bit-for-bit.**
- When `> 1`, `SequenceRewardManager` evaluates each reward function over contiguous chunks of the batch in a fork-based process pool and concatenates results in order. Per-sequence reward functions therefore produce identical results to the serial path. kwargs that are per-example columns (`len == num_prompts`, e.g. ground-truth answer lists) are sliced in lockstep with the batch; everything else passes through unchanged.

Robustness, all covered by unit tests:

- Functions that cannot run in a worker — unpicklable, or spawning subprocesses of their own (which daemonic pool workers forbid) — are detected at runtime and evaluated in the parent process from then on, where their own internal parallelism keeps working.
- Pool-creation failure, worker crashes, chunk timeouts, or a platform without the `fork` start method all fall back to the serial implementation with one warning.
- `TUNIX_REWARD_PARALLEL=0` disables the pool at runtime without a config change.

**Measured** (same benchmark, `reward_num_workers=32`): reward computation 29.6 s → ~3.5 s, global step **155.6 s → 129.0 s (−17%)**, with per-step rewards byte-identical to the serial run over all 20 steps (max abs diff 0.000000). One of the three reward functions dispatches to its own subprocess pool and ran in the parent via the fallback; widening that internal pool contributed part of the win.

**Reference**
Benchmark context: MaxText GRPO post-training on TPU v7x; reward functions are the `match_format_*` / `check_numbers` family from MaxText's RL utils.

**Checklist**

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
