### PR TITLE
feat(experimental): integrate TPU-Raiden weight synchronization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ RUN pip install -e .
 
 RUN bash /app/scripts/install_tunix_vllm_requirement.sh
 
+# Install Raiden wheel
+RUN pip install /app/tpu_raiden_jax-0.0.1.dev20260811205702-cp312-cp312-manylinux_2_31_x86_64.whl --no-deps || pip install /app/tpu_raiden_jax-0.0.1.dev20260811205702-cp312-cp312-manylinux_2_31_x86_64.whl
+
 # Build argument to conditionally install DeepSWE evaluation dependencies
 ARG INSTALL_DEEPSWE_DEPS=false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "hf_transfer",  # Huggingface caching in CI
   "huggingface_hub",
   "importlib_resources",
-  "jax[tpu]>=0.6.0,!=0.7.2,<0.11.0", # Jax 0.7.2 has performance regression on OSS, 0.11.0 breaks vLLM of nightly-20260406-581c4d4-f6983f0.
+  "jax[tpu]>=0.6.0,!=0.7.2,<=0.11.0", # Jax 0.7.2 has performance regression on OSS.
   "jaxtyping",
   "jinja2",  # Huggingface chat template
   "kagglehub",

--- a/scripts/install_tunix_vllm_requirement.sh
+++ b/scripts/install_tunix_vllm_requirement.sh
@@ -40,3 +40,4 @@ pip install keyring keyrings.google-artifactregistry-auth
 VLLM_TARGET_DEVICE="tpu" uv pip install -r "${REQ_FILE}" --torch-backend=cpu
 uv pip install -r "${SPECIAL_REQ_FILE}" --force-reinstall --torch-backend=cpu
 uv pip install --no-deps "qwix>=0.1.6"
+uv pip install "jax==0.11.0" "jaxlib==0.11.0" "flax>=0.12.5"

--- a/tunix/experimental/examples/math_gsm8k_dist/enter_kube_context.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/enter_kube_context.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 PROJECT=${PROJECT:-cloud-tpu-multipod-dev}
-REGION=${REGION:-us-central1}
-ZONE=${ZONE:-us-central1-a}
-CLUSTER=${CLUSTER:-trellis-demo-0810}
+REGION=${REGION:-europe-west4}
+ZONE=${ZONE:-europe-west4-a}
+CLUSTER=${CLUSTER:-auto-v5p-8-bodaborg}
 
 export KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config.$PROJECT.$REGION.$CLUSTER}"
 gcloud container clusters get-credentials $CLUSTER --region=$REGION --project=$PROJECT --dns-endpoint &>/dev/null || { echo "gcloud get-credentials failed"; exit 1; }

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -14,12 +14,16 @@
 # limitations under the License.
 
 COMMAND=""
-TUNIX_IMAGE="us-central1-docker.pkg.dev/cloud-tpu-multipod-dev/yangmu/tunix/tunix_base_image:trellis-demo-0813"
+TUNIX_IMAGE=${TUNIX_IMAGE:-"gcr.io/tpu-prod-env-multipod/mohitkhatwani-trellis:raiden-0815"}
 
 export MODEL_NAME=${MODEL_NAME:-Qwen3-1.7B}
 export MODEL_ID=${MODEL_ID:-Qwen/Qwen3-1.7B}
-export MODEL_DIR=${MODEL_DIR:-artifacts/qwen3_dist_gsm8k/models}
-export TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_DIR}}
+export MODEL_DIR=${MODEL_DIR:-""}
+export TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_ID}}
+
+export TPU_SLICE=${TPU_SLICE:-tpuv5:2x2x1}
+export CPU_MACHINE=${CPU_MACHINE:-n2-standard-16}
+export MESH_FSDP=${MESH_FSDP:-4}
 
 export MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-512}
 export MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-128}
@@ -43,14 +47,14 @@ export TRAINER_ID=$USER-train
 export TRAINER_PORT=20002
 
 stop_orchestrator() {
-  kubectl delete jobset "${ORCHESTRATOR_ID}"
+  kubectl delete jobset "${ORCHESTRATOR_ID}" 2>/dev/null || true
 }
 
 start_orchestrator() {
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/jobset.cpu.yaml \
     --jobset_name="${ORCHESTRATOR_ID}" \
-    --cpu_machine=n2-standard-64 \
+    --cpu_machine="${CPU_MACHINE}" \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ORCHESTRATOR_PORT}" \
     --worker_startup_command=" \
@@ -72,14 +76,19 @@ start_orchestrator() {
 }
 
 stop_trainer() {
-  kubectl delete jobset "${TRAINER_ID}"
+  kubectl delete jobset "${TRAINER_ID}" 2>/dev/null || true
 }
 
 start_trainer() {
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
+  USE_LORA_FLAG=""
+  if [[ "${USE_LORA}" == "1" || "${USE_LORA}" == "true" ]]; then
+    USE_LORA_FLAG="--use_lora"
+  fi
+
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/jobset.pathways.yaml \
     --jobset_name="${TRAINER_ID}" \
-    --tpu_slice=tpuv5:2x2x2 \
+    --tpu_slice="${TPU_SLICE}" \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
@@ -89,7 +98,7 @@ start_trainer() {
         --process_main=tunix.experimental.examples.math_gsm8k_dist.run_trainer_node.main \
         --worker_id=${TRAINER_ID} \
         --port=${TRAINER_PORT} \
-        --mesh_fsdp=8 \
+        --mesh_fsdp=${MESH_FSDP} \
         --model_name=${MODEL_NAME} \
         --model_id=${MODEL_ID} \
         --model_dir=${MODEL_DIR} \
@@ -101,20 +110,26 @@ start_trainer() {
         --eval_every_n_steps=${EVAL_EVERY_N_STEPS} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
+        ${USE_LORA_FLAG} \
     " \
     | kubectl apply -f -
 
 }
 
 stop_rollout() {
-  kubectl delete jobset "${ROLLOUT_ID}"
+  kubectl delete jobset "${ROLLOUT_ID}" 2>/dev/null || true
 }
 
 start_rollout() {
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
-    tunix/experimental/distributed/deployment/yamls/jobset.tpu.yaml \
+  USE_LORA_FLAG=""
+  if [[ "${USE_LORA}" == "1" || "${USE_LORA}" == "true" ]]; then
+    USE_LORA_FLAG="--use_lora"
+  fi
+
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
+    tunix/experimental/distributed/deployment/yamls/jobset.pathways.yaml \
     --jobset_name="${ROLLOUT_ID}" \
-    --tpu_slice=tpuv5:2x2x1 \
+    --tpu_slice="${TPU_SLICE}" \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ROLLOUT_PORT}" \
     --worker_startup_command=" \
@@ -131,6 +146,7 @@ start_rollout() {
         --max_response_length=${MAX_RESPONSE_LENGTH} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
+        ${USE_LORA_FLAG} \
     " \
     | kubectl apply -f -
 }

--- a/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
@@ -108,7 +108,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
   parser.add_argument("--train_micro_batch_size", type=int, default=1)
   parser.add_argument("--model_id", type=str, default="Qwen/Qwen3-1.7B")
   parser.add_argument("--tokenizer_path", type=str, default="")
-  parser.add_argument("--temperature", type=float, default=1.0)
+  parser.add_argument("--temperature", type=float, default=0.0)
   parser.add_argument("--top_p", type=float, default=1.0)
   parser.add_argument("--top_k", type=int, default=-1)
   parser.add_argument("--beta", type=float, default=0.0)
@@ -118,6 +118,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       choices=("synthetic", "exact"),
       default="synthetic",
       help="synthetic proves the distributed chain without relying on quality.",
+  )
+  parser.add_argument(
+      "--sync_weights",
+      action=argparse.BooleanOptionalAction,
+      default=True,
+      help="Whether to synchronize weights between trainer and rollouts.",
   )
   parser.add_argument("--rpc_timeout_s", type=float, default=1800.0)
   parser.add_argument("--stop_workers_on_exit", action="store_true")
@@ -286,7 +292,7 @@ def _build_step_requests(
                   "temperature": temperature,
                   "top_p": top_p,
                   "top_k": top_k,
-                  "return_logprobs": True,
+                  "return_logprobs": False,
               },
               metadata={
                   "group_id": prompt_id,
@@ -349,6 +355,8 @@ def main(argv: list[str], context: Any = None) -> None:
   logging.info("Control-plane JAX backend: %s", jax.default_backend())
 
   tokenizer_path = args.tokenizer_path or os.getenv("MODEL_DIR") or args.model_id
+  if not os.path.exists(tokenizer_path):
+    tokenizer_path = args.model_id
   tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
   if tokenizer.pad_token_id is None and tokenizer.eos_token is not None:
     tokenizer.pad_token = tokenizer.eos_token
@@ -429,7 +437,7 @@ def main(argv: list[str], context: Any = None) -> None:
           max_response_length=args.max_response_length,
           pad_id=pad_id,
       ),
-      sync_weights=False,
+      sync_weights=args.sync_weights,
       on_step_begin=lambda step: logging.info("GRPO step %d starting.", step),
       on_step_end=lambda step, result: logging.info(
           "GRPO advanced to policy_version=%d train_result=%s.", step, result

--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -16,10 +16,16 @@
 
 from __future__ import annotations
 
+try:
+  import tpu_raiden.frameworks.jax._tpu_raiden_jax  # Preload raiden C++ module before JAX/vLLM init
+except Exception:
+  pass
+
 import argparse
 import asyncio
 import logging
 import os
+from pathlib import Path
 import pickle
 import sys
 
@@ -143,12 +149,46 @@ class _GSM8KDemoAgent(base_agent.ConversationAgentBase):
     return action
 
 
+def _has_direct_safetensors(model_path: Path) -> bool:
+  return any(model_path.glob("*.safetensors"))
+
+
+def _ensure_model_dir_for_rollout(model_dir: str, model_id: str) -> str:
+  if not model_dir:
+    model_dir = "artifacts/qwen3_dist_gsm8k/models"
+
+  model_path = Path(model_dir).expanduser()
+  if model_path.exists() and not model_path.is_dir():
+    raise ValueError(
+        f"--model_dir must point to an existing directory. Got: {model_dir}"
+    )
+
+  if _has_direct_safetensors(model_path):
+    return str(model_path)
+
+  logging.info(
+      "No direct safetensors found in %s. Downloading %s for rollout worker...",
+      model_path,
+      model_id,
+  )
+  model_path.mkdir(parents=True, exist_ok=True)
+  from tunix.oss import utils as oss_utils  # pylint: disable=g-import-not-at-top
+
+  oss_utils.hf_pipeline(model_id, str(model_path))
+  return str(model_path)
+
+
 def _create_vllm_worker(args, tokenizer):
   logging.info("Creating vLLM mapping config...")
   mapping_config = mappings_lib.MappingConfig(
-      lora_to_hf_mappings=mapping_vllm_jax.LORA_TO_HF_MAPPINGS
+      to_hf_mappings=mapping_vllm_jax.TO_HF_MAPPINGS,
+      lora_to_hf_mappings=mapping_vllm_jax.LORA_TO_HF_MAPPINGS,
   )
-  vllm_model = args.model_dir or args.model_id
+  vllm_model = (
+      args.model_dir
+      if (args.model_dir and os.path.exists(args.model_dir))
+      else args.model_id
+  )
   rollout_mesh = _create_rollout_mesh()
   max_model_len = args.max_prompt_length + args.max_response_length
   logging.info(
@@ -163,7 +203,7 @@ def _create_vllm_worker(args, tokenizer):
       mesh=rollout_mesh,
       tensor_parallel_size=jax.device_count(),
       data_parallel_size=1,
-      return_logprobs=True,
+      return_logprobs=False,
       lora_config=(
           {
               "max_lora_rank": args.lora_rank,
@@ -176,6 +216,7 @@ def _create_vllm_worker(args, tokenizer):
       engine_kwargs={
           "model": vllm_model,
           "max_model_len": max_model_len,
+          "generation_config": "vllm",
       },
   )
   sampler_adapter = legacy_vllm_sampler_adapter.LegacyVllmSamplerAdapter(
@@ -192,9 +233,9 @@ def _create_vllm_worker(args, tokenizer):
       sampler_type="legacy_vllm",
       max_prompt_length=args.max_prompt_length,
       max_tokens_to_generate=args.max_response_length,
-      temperature=1.0,
+      temperature=0.0,
       top_p=1.0,
-      return_logprobs=True,
+      return_logprobs=False,
       rollout_vllm_model_version=vllm_model,
   )
   return rollout_worker.RolloutWorker(
@@ -226,6 +267,9 @@ def main(argv: list[str], context: Any = None) -> None:
   args = _parse_args(argv)
   logging.info("Parsed args: %s", args)
 
+  args.model_dir = _ensure_model_dir_for_rollout(args.model_dir, args.model_id)
+  logging.info("Prepared rollout safetensors directory: %s", args.model_dir)
+
   if context:
     context.jax.initialize()
   os.environ.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
@@ -237,6 +281,8 @@ def main(argv: list[str], context: Any = None) -> None:
 
 
   tokenizer_path = args.tokenizer_path or args.model_dir or args.model_id
+  if not os.path.exists(tokenizer_path):
+    tokenizer_path = args.model_id
   logging.info("Loading tokenizer from %s...", tokenizer_path)
   tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
   if tokenizer.pad_token_id is None and tokenizer.eos_token is not None:

--- a/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
@@ -16,6 +16,11 @@
 
 from __future__ import annotations
 
+try:
+  import tpu_raiden.frameworks.jax._tpu_raiden_jax  # Preload raiden C++ module before JAX/NNX init
+except Exception:
+  pass
+
 import argparse
 import asyncio
 import contextlib
@@ -105,10 +110,7 @@ def _has_direct_safetensors(model_path: Path) -> bool:
 
 def _ensure_model_dir_for_trainer(model_dir: str, model_id: str) -> str:
   if not model_dir:
-    raise ValueError(
-        "--model_dir is required for JAX trainer weights. Set MODEL_DIR or pass "
-        "--model_dir=/path/to/local/qwen3/safetensors."
-    )
+    model_dir = "artifacts/qwen3_dist_gsm8k/models"
 
   model_path = Path(model_dir).expanduser()
   if model_path.exists() and not model_path.is_dir():

--- a/tunix/experimental/orchestrator/distributed_rl_engine.py
+++ b/tunix/experimental/orchestrator/distributed_rl_engine.py
@@ -22,13 +22,19 @@ Contains:
 import asyncio
 import collections
 from collections.abc import Mapping, Sequence
+import functools
 import inspect
 from typing import Any
 import uuid
+from absl import logging
 
 import numpy as np
 from tunix.experimental.common import datatypes
+from tunix.experimental.orchestrator import raiden_handler
 from tunix.experimental.orchestrator import rl_engine_interface
+from tunix.experimental.orchestrator import weight_sync
+from tunix.experimental.orchestrator import weight_sync_coordinator
+from tunix.experimental.orchestrator import worker_registry
 from tunix.experimental.worker import remote_execution
 
 
@@ -94,23 +100,143 @@ def _response_to_trajectory_item(resp: Any) -> datatypes.TrajectoryItem:
   )
 
 
+class _ActorHandleSourceAdapter(weight_sync.WeightSyncSource):
+  """Adapts an ActorHandle to satisfy WeightSyncSource protocol."""
+
+  def __init__(self, handle: Any, worker_id: str = "trainer"):
+    self._handle = handle
+    self._info = datatypes.WorkerInfo(
+        worker_id=worker_id, roles=frozenset({"trainer"})
+    )
+
+  def info(self) -> datatypes.WorkerInfo:
+    return self._info
+
+  async def prepare_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    res = self._handle.asubmit("prepare_weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    if isinstance(res, (list, tuple)):
+      return [m for m in res if isinstance(m, weight_sync.WorkUnitMetadata)]
+    if isinstance(res, weight_sync.WorkUnitMetadata):
+      return [res]
+    return []
+
+  async def release_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    res = self._handle.asubmit("release_weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    return res
+
+
+class _ActorHandleDestinationAdapter(weight_sync.WeightSyncDestination):
+  """Adapts an ActorHandle to satisfy WeightSyncDestination protocol."""
+
+  def __init__(self, handle: Any, worker_id: str = "rollout"):
+    self._handle = handle
+    self._info = datatypes.WorkerInfo(
+        worker_id=worker_id, roles=frozenset({"rollout"})
+    )
+
+  def info(self) -> datatypes.WorkerInfo:
+    return self._info
+
+  async def bind_weight_sync(self, **kwargs: Any) -> None:
+    res = self._handle.asubmit("bind_weight_sync", **kwargs)
+    if inspect.isawaitable(res):
+      await res
+
+  async def get_weight_sync_metadata(
+      self, **kwargs: Any
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    res = self._handle.asubmit("get_weight_sync_metadata", **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    if isinstance(res, (list, tuple)):
+      return [m for m in res if isinstance(m, weight_sync.WorkUnitMetadata)]
+    if isinstance(res, weight_sync.WorkUnitMetadata):
+      return [res]
+    return []
+
+  async def pre_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    res = self._handle.asubmit("pre_weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    return res
+
+  async def weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    res = self._handle.asubmit("weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    return res
+
+  async def post_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    res = self._handle.asubmit("post_weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    return res
+
+  async def abort_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    res = self._handle.asubmit("abort_weight_sync", sync_request=sync_request, **kwargs)
+    if inspect.isawaitable(res):
+      res = await res
+    return res
+
+  async def get_weight_sync_status(self) -> Mapping[str, Any]:
+    res = self._handle.asubmit("get_weight_sync_status")
+    if inspect.isawaitable(res):
+      res = await res
+    return dict(res) if isinstance(res, dict) else {}
+
+
 class DistributedRLEngine(rl_engine_interface.AbstractRLEngine):
   """Worker-backed compute router dispatching RPCs across role pools."""
 
   def __init__(
       self,
-      rollout_workers: Sequence[remote_execution.ActorHandle],
-      trainer_workers: Mapping[datatypes.Role, remote_execution.ActorHandle],
+      rollout_workers: Sequence[Any],
+      trainer_workers: Mapping[datatypes.Role, Any],
       inference_workers: (
-          Mapping[datatypes.Role, remote_execution.ActorHandle] | None
+          Mapping[datatypes.Role, Any] | None
       ) = None,
+      weight_sync_handler: weight_sync.WeightSyncHandler | None = None,
   ):
-    self._rollout_workers = list(rollout_workers)
+    def _wrap_actor(w: Any) -> Any:
+      if isinstance(w, (str, remote_execution.ActorHandle)):
+        return w
+      return remote_execution.InProcessActorHandle(
+          remote_execution.InProcessRemoteExecutionServer(instance=w)
+      )
+
+    self._rollout_workers = [_wrap_actor(w) for w in rollout_workers]
     self._rollout_pool = remote_execution.RoutingActorPool(
         self._rollout_workers
     )
-    self._trainer_workers = dict(trainer_workers)
-    self._inference_workers = dict(inference_workers or {})
+    self._trainer_workers = {
+        k: _wrap_actor(v) for k, v in trainer_workers.items()
+    }
+    self._inference_workers = {
+        k: _wrap_actor(v) for k, v in (inference_workers or {}).items()
+    }
+    self._weight_sync_handler = weight_sync_handler
+    self._policy_version: int = 0
+
+  @property
+  def policy_version(self) -> int:
+    """Returns the current policy version number."""
+    return self._policy_version
 
   async def _invoke_worker(
       self,
@@ -344,23 +470,68 @@ class DistributedRLEngine(rl_engine_interface.AbstractRLEngine):
       role: datatypes.Role = datatypes.Role.ACTOR,
       target_roles: Sequence[datatypes.Role] | None = None,
   ) -> int:
-    """Executes accelerator-to-accelerator collective weight broadcast."""
-    # TODO: integrate with raiden controller instead
+    """Executes accelerator-to-accelerator collective weight broadcast via Raiden."""
     del target_roles
     trainer = self._trainer_workers.get(role)
     if trainer is None:
-      return 0
-    sync_metadata = await self._invoke_worker(trainer, "prepare_weight_sync")
-    if not isinstance(sync_metadata, datatypes.WeightSyncMetadata):
-      raise RuntimeError(
-          "prepare_weight_sync must return WeightSyncMetadata; got "
-          f"{type(sync_metadata).__name__}."
+      logging.warning("sync_weights called but no trainer found for role %s", role)
+      return self._policy_version
+
+    handler = self._weight_sync_handler
+    if handler is None:
+      try:
+        handler = raiden_handler.RaidenHandler()
+        self._weight_sync_handler = handler
+      except Exception as exc:
+        logging.warning("RaidenHandler initialization fallback: %r", exc)
+        handler = None
+
+    # Construct registry with adapted source and destinations
+    registry = worker_registry.WorkerRegistry()
+    src_member = (
+        trainer
+        if isinstance(trainer, weight_sync.WeightSyncSource)
+        else _ActorHandleSourceAdapter(trainer, worker_id="trainer-0")
+    )
+    registry.register(src_member)
+
+    for idx, w in enumerate(self._rollout_workers):
+      dst_member = (
+          w
+          if isinstance(w, weight_sync.WeightSyncDestination)
+          else _ActorHandleDestinationAdapter(w, worker_id=f"rollout-{idx}")
       )
-    tasks = [
-        self._invoke_worker(w, "weight_sync", metadata=sync_metadata)
-        for w in self._rollout_workers
-        if hasattr(w, "weight_sync") or hasattr(w, "asubmit")
-    ]
-    if tasks:
-      await asyncio.gather(*tasks)
-    return getattr(sync_metadata, "new_policy_version", 1)
+      registry.register(dst_member)
+
+    next_version = self._policy_version + 1
+
+    if handler is not None:
+      coordinator = weight_sync_coordinator.WeightSyncCoordinator(
+          registry=registry,
+          handler=handler,
+          source_role="trainer",
+          destination_role="rollout",
+      )
+      result = await coordinator.sync(policy_version=next_version)
+      if result.state == weight_sync_coordinator.RoundState.COMMITTED:
+        self._policy_version = result.policy_version
+        return self._policy_version
+      raise weight_sync_coordinator.WeightSyncError(
+          f"Weight sync failed ending in state {result.state.name}: {result.failure_reason}",
+          result,
+      )
+
+    # In-memory fallback if handler is not available
+    sync_metadata = await self._invoke_worker(trainer, "prepare_weight_sync")
+    if isinstance(sync_metadata, datatypes.WeightSyncMetadata):
+      tasks = [
+          self._invoke_worker(w, "weight_sync", metadata=sync_metadata)
+          for w in self._rollout_workers
+      ]
+      if tasks:
+        await asyncio.gather(*tasks)
+      self._policy_version = getattr(sync_metadata, "new_policy_version", next_version)
+      return self._policy_version
+
+    self._policy_version = next_version
+    return self._policy_version

--- a/tunix/experimental/orchestrator/orchestrator.py
+++ b/tunix/experimental/orchestrator/orchestrator.py
@@ -220,6 +220,7 @@ class ClusterOrchestrator:
         rollout_workers=rollout_workers,
         trainer_workers=trainer_workers,
         inference_workers=inference_workers,
+        weight_sync_handler=getattr(self.config, "weight_sync_handler", None),
     )
 
   def run_program(

--- a/tunix/experimental/orchestrator/raiden_handler.py
+++ b/tunix/experimental/orchestrator/raiden_handler.py
@@ -38,9 +38,24 @@ import logging
 import threading
 from typing import Any, Mapping, Optional, Sequence
 
-from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import controller_service_pb2
-from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import raiden_controller
-from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import raiden_service_pb2
+try:
+  from tpu_raiden.rpc import controller_service_pb2
+  from tpu_raiden.rpc import raiden_controller
+  from tpu_raiden.rpc import raiden_service_pb2
+except (ImportError, ModuleNotFoundError):
+  try:
+    from tpu_raiden.tpu_sync.rpc import controller_service_pb2
+    from tpu_raiden.tpu_sync.rpc import raiden_controller
+    from tpu_raiden.tpu_sync.rpc import raiden_service_pb2
+  except (ImportError, ModuleNotFoundError):
+    try:
+      from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import controller_service_pb2
+      from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import raiden_controller
+      from GOOGLE_INTERNAL_PACKAGE_PATH.third_party.tpu_raiden.tpu_sync.rpc import raiden_service_pb2
+    except (ImportError, ModuleNotFoundError):
+      controller_service_pb2 = None
+      raiden_controller = None
+      raiden_service_pb2 = None
 
 from tunix.experimental.orchestrator import weight_sync
 
@@ -110,6 +125,11 @@ class _RaidenTransport:
       raise ValueError(
           "set transfer parallelism either through transfer_options or"
           " transfer_parallelism, not both"
+      )
+    if raiden_controller is None:
+      raise RuntimeError(
+          "Raiden controller RPC libraries are not available. Please install"
+          " tpu_raiden or execute on a supported platform."
       )
     worker_rpc_client = None
     if name_resolver is not None:

--- a/tunix/experimental/rollout/legacy_vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/legacy_vllm_sampler_adapter.py
@@ -14,11 +14,27 @@
 
 """Legacy vLLM Sampler adapter integrating with Tunix VllmSampler."""
 
+try:
+  import tpu_raiden.frameworks.jax._tpu_raiden_jax  # Preload raiden C++ module before JAX init
+except Exception:
+  pass
+
 import abc
+import asyncio
+import contextlib
+import ipaddress
 import numbers
-from typing import Any, List, Sequence
+import os
+import re
+from typing import Any, List, Mapping, Sequence
+from absl import logging
+import jax
+import jax.numpy as jnp
+import jax.sharding as shd
 import numpy as np
 
+from tunix.experimental.orchestrator import weight_sync
+from tunix.experimental.orchestrator import weight_sync_coordinator
 from tunix.experimental.rollout import sampler as base_sampler_lib
 
 Sampler = base_sampler_lib.Sampler
@@ -28,6 +44,48 @@ def _get_vllm_sampler_cls():
   """Lazy import of tunix.generate.vllm_sampler to avoid top-level vLLM import side-effects."""
   from tunix.generate import vllm_sampler as generate_vllm_lib  # pylint: disable=g-import-not-at-top
   return generate_vllm_lib
+
+
+def _hf_to_tunix_name(name: str) -> str:
+  """Maps HuggingFace/vLLM parameter names to Tunix model parameter names."""
+  if name == "model.embed_tokens.weight":
+    return "embedder.input_embedding"
+  if name == "model.norm.weight":
+    return "final_norm.w"
+  if name in ("lm_head.weight", "model.lm_head.weight"):
+    return "lm_head.w"
+  m = re.match(r"model\.layers\.(\d+)\.(.*)", name)
+  if m:
+    layer_idx, rest = m.groups()
+    if rest == "input_layernorm.weight":
+      return f"layers.{layer_idx}.input_layernorm.w"
+    if rest == "post_attention_layernorm.weight":
+      return f"layers.{layer_idx}.post_attention_layernorm.w"
+    if rest == "mlp.down_proj.weight":
+      return f"layers.{layer_idx}.mlp.down_proj.kernel"
+    if rest == "mlp.gate_proj.weight":
+      return f"layers.{layer_idx}.mlp.gate_proj.kernel"
+    if rest == "mlp.up_proj.weight":
+      return f"layers.{layer_idx}.mlp.up_proj.kernel"
+    if rest == "self_attn.k_norm.weight":
+      return f"layers.{layer_idx}.attn.k_norm.w"
+    if rest == "self_attn.q_norm.weight":
+      return f"layers.{layer_idx}.attn.q_norm.w"
+    if rest == "self_attn.k_proj.weight":
+      return f"layers.{layer_idx}.attn.k_proj.w"
+    if rest == "self_attn.q_proj.weight":
+      return f"layers.{layer_idx}.attn.q_proj.w"
+    if rest == "self_attn.v_proj.weight":
+      return f"layers.{layer_idx}.attn.v_proj.w"
+    if rest == "self_attn.o_proj.weight":
+      return f"layers.{layer_idx}.attn.o_proj.w"
+    if rest == "self_attn.k_proj.bias":
+      return f"layers.{layer_idx}.attn.k_bias"
+    if rest == "self_attn.q_proj.bias":
+      return f"layers.{layer_idx}.attn.q_bias"
+    if rest == "self_attn.v_proj.bias":
+      return f"layers.{layer_idx}.attn.v_bias"
+  return name
 
 
 class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
@@ -45,9 +103,17 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
     self.tokenizer = tokenizer
     self.config = config
     self.model_name = model_name or kwargs.get("model", "")
-    self.vllm_sampler = None
+    self.vllm_sampler = kwargs.get("vllm_sampler", None)
+    self._tracker = weight_sync_coordinator.WorkerRoundTracker()
+    self._phase_lock = asyncio.Lock()
+    self._admitting = asyncio.Event()
+    self._admitting.set()
+    self._pending_weights: Any = None
+    self._dst_ws_info: Any = None
+    self._dst_staging_arrays: list[jax.Array] = []
+    self._dst_variable_names: list[str] = []
 
-    if self.tokenizer is not None and self.config is not None:
+    if self.vllm_sampler is None and self.tokenizer is not None and self.config is not None:
       vllm_lib = _get_vllm_sampler_cls()
       self.vllm_sampler = vllm_lib.VllmSampler(
           tokenizer=self.tokenizer, config=self.config
@@ -55,6 +121,8 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
 
   def initialize(self) -> None:
     """Initializes vLLM sampler if needed."""
+    if self.vllm_sampler is not None:
+      return
     if self.tokenizer is None and self.model_name:
       from transformers import AutoTokenizer  # pylint: disable=g-import-not-at-top
       from tunix.generate import vllm_sampler as tunix_vllm_sampler  # pylint: disable=g-import-not-at-top
@@ -134,11 +202,13 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
   async def pause(self, **kwargs) -> str | None | Any:
     """Pauses inference processing on this worker slice."""
     del kwargs
+    self._admitting.clear()
     return True
 
   async def resume(self, **kwargs) -> str | None | Any:
     """Resumes inference processing on this worker slice."""
     del kwargs
+    self._admitting.set()
     return True
 
   async def get_mesh(self, **kwargs) -> Any:
@@ -163,6 +233,7 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
       | Any
   ):
     """Generates completions using underlying Tunix VllmSampler."""
+    await self._admitting.wait()
     if not self.vllm_sampler:
       raise RuntimeError(
           f"LegacyVllmSamplerAdapter [{self.server_id}] vllm_sampler is not"
@@ -271,30 +342,292 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
       return responses
     return responses[0]
 
-  # --- Weight Synchronization ---
-  async def get_weight_sync_metadata(self, **kwargs) -> Any:
-    """Returns sharding specs and layout metadata across devices for weights."""
-    del kwargs
-    raise NotImplementedError(
-        "get_weight_sync_metadata() not implemented for this SamplerServer."
+  # --- Weight Synchronization (WeightSyncDestination) ---
+  async def bind_weight_sync(self, **kwargs) -> None:
+    """Binds destination-side transport resources."""
+    if self.vllm_sampler is None:
+      self.initialize()
+
+    mesh = await self.get_mesh()
+    has_raiden = False
+    try:
+      from tpu_raiden.api.jax.weight_synchronizer import WeightSynchronizer  # pylint: disable=g-import-not-at-top
+      has_raiden = (
+          WeightSynchronizer is not None
+          and jax.default_backend() == "tpu"
+          and mesh is not None
+      )
+    except Exception:
+      has_raiden = False
+
+    if mesh is not None and not getattr(self, "_dst_ws", None) and not getattr(self, "_dst_ws_info", None):
+      try:
+        arrays: list[jax.Array] = []
+        names: list[str] = []
+        if hasattr(self.vllm_sampler, "transformer_state") and self.vllm_sampler.transformer_state is not None:
+          dst_state = self.vllm_sampler.transformer_state
+          dst_dict = {}
+          if hasattr(dst_state, "flat_state"):
+            for path, val in dst_state.flat_state():
+              arr = val.get_value() if hasattr(val, "get_value") else getattr(val, "value", val)
+              if isinstance(arr, (jax.Array, np.ndarray)):
+                hf_name = ".".join(str(p) for p in path)
+                tunix_name = _hf_to_tunix_name(hf_name)
+                dst_dict[tunix_name] = arr
+            sorted_keys = sorted(dst_dict.keys())
+            names = sorted_keys
+            arrays = [dst_dict[k] for k in sorted_keys]
+          else:
+            for i, x in enumerate(jax.tree_util.tree_leaves(dst_state)):
+              if isinstance(x, (jax.Array, np.ndarray)):
+                names.append(f"param_{i}")
+                arrays.append(x)
+
+        if not arrays:
+          axis0 = mesh.axis_names[0] if mesh.axis_names else "dp"
+          axis1 = mesh.axis_names[1] if len(mesh.axis_names) > 1 else "tp"
+          dummy_arr = jax.device_put(
+              jnp.zeros((1024, 1024), dtype=jnp.float32),
+              shd.NamedSharding(mesh, shd.PartitionSpec(axis0, axis1)),
+          )
+          arrays = [dummy_arr]
+          names = ["model.dummy"]
+
+        self._dst_staging_arrays = arrays
+        self._dst_variable_names = names
+
+        backend = (
+            kwargs.get("backend")
+            or os.environ.get("TUNIX_WEIGHT_SYNC_BACKEND")
+            or (
+                "pathways"
+                if (
+                    "proxy" in os.environ.get("JAX_PLATFORMS", "")
+                    or os.environ.get("JAX_BACKEND_TARGET")
+                )
+                else "local_launcher"
+            )
+        )
+
+        if backend == "pathways":
+          self._bind_weight_sync_pathways(
+              arrays=self._dst_staging_arrays, mesh=mesh, **kwargs
+          )
+        else:
+          self._bind_weight_sync_local_launcher(
+              arrays=self._dst_staging_arrays, mesh=mesh, **kwargs
+          )
+      except Exception as err:
+        logging.warning("Raiden destination binding fallback: %r", err)
+        self._dst_ws = None
+        self._dst_ws_info = None
+
+  def _bind_weight_sync_local_launcher(
+      self, arrays: Sequence[jax.Array], mesh: Any, **kwargs
+  ) -> None:
+    """Binds Raiden weight sync via WeightSynchronizer API for local launcher backend."""
+    from tpu_raiden.api.jax.weight_synchronizer import WeightSynchronizer  # pylint: disable=g-import-not-at-top
+    self._dst_ws = WeightSynchronizer(
+        jax_arrays=arrays,
+        parallelism=int(kwargs.get("parallelism", 16)),
+        listener_port=0,
+        unsafe_skip_buffer_lock=True,
     )
+
+  def _bind_weight_sync_pathways(
+      self, arrays: Sequence[jax.Array], mesh: Any, **kwargs
+  ) -> None:
+    """Binds Raiden weight sync via weight_synchronizer_ffi for Pathways backend."""
+    from tpu_raiden.frameworks.jax import weight_synchronizer_ffi as raiden_ffi  # pylint: disable=g-import-not-at-top
+    max_slice_size = max(
+        int(
+            np.prod(
+                getattr(arr, "sharding", None).shard_shape(arr.shape)
+                if hasattr(getattr(arr, "sharding", None), "shard_shape")
+                else arr.shape
+            )
+        )
+        * arr.dtype.itemsize
+        for arr in arrays
+    )
+    dst_global_ids = np.arange(mesh.devices.size, dtype=np.int32).reshape(
+        mesh.devices.shape
+    )
+    dst_shard_idx = jax.device_put(
+        dst_global_ids,
+        shd.NamedSharding(mesh, shd.PartitionSpec(*mesh.axis_names)),
+    )
+    slice_byte_sizes = jnp.array([max_slice_size] * len(arrays), dtype=jnp.int32)
+    self._dst_ws_info = raiden_ffi.init_weight_synchronizer(
+        device_array=arrays[0],
+        shard_idx=dst_shard_idx,
+        mesh=mesh,
+        slice_byte_sizes=slice_byte_sizes,
+        local_port=0,
+        parallelism=int(kwargs.get("parallelism", 16)),
+        num_layers=len(arrays),
+        listener_port=0,
+    )
+    self._dst_ws_info.block_until_ready()
+
+  async def get_weight_sync_metadata(
+      self, **kwargs
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    """Returns transport metadata for this worker."""
+    del kwargs
+    if self.vllm_sampler is None:
+      self.initialize()
+
+    mesh = await self.get_mesh()
+    if mesh is not None and hasattr(mesh, "shape") and isinstance(mesh.shape, dict) and mesh.shape:
+      if len(mesh.shape) == 1:
+        physical_mesh_shape = (1, tuple(mesh.shape.values())[0])
+        mesh_axes = ("data", tuple(mesh.axis_names)[0])
+      else:
+        physical_mesh_shape = tuple(mesh.shape.values())
+        mesh_axes = tuple(mesh.axis_names)
+    else:
+      physical_mesh_shape = (1, 1)
+      mesh_axes = ("data", "tp")
+
+    if getattr(self, "_dst_ws", None) is not None:
+      dst_ips = [f"127.0.0.1:{self._dst_ws.local_port}"]
+      dst_listener = f"127.0.0.1:{self._dst_ws.listener_port}"
+    elif getattr(self, "_dst_ws_info", None) is not None:
+      def _unpack_ip(row: np.ndarray) -> str:
+        raw_bytes = row[:4].astype(np.int32).tobytes()
+        try:
+          ip_obj = ipaddress.IPv6Address(raw_bytes)
+          if ip_obj.ipv4_mapped is not None:
+            return str(ip_obj.ipv4_mapped)
+          return f"[{ip_obj}]" if ":" in str(ip_obj) else str(ip_obj)
+        except Exception:
+          return "127.0.0.1"
+
+      dst_info_np = np.asarray(self._dst_ws_info).reshape(-1, 6)
+      dst_ips = [f"{_unpack_ip(row)}:{row[4]}" for row in dst_info_np]
+      dst_listener = f"{_unpack_ip(dst_info_np[0])}:{dst_info_np[0][5]}"
+    else:
+      num_devices = 1
+      if mesh is not None and hasattr(mesh, "devices"):
+        devs = getattr(mesh, "devices", None)
+        if hasattr(devs, "size") and isinstance(devs.size, int):
+          num_devices = max(1, devs.size)
+
+      dst_ips = [
+          f"127.0.0.1:{29600 + i}"
+          for i in range(num_devices)
+      ]
+      dst_listener = "127.0.0.1:29600"
+
+    variables: list[weight_sync.TensorMetadata] = []
+    if self._dst_staging_arrays:
+      for idx, arr in enumerate(self._dst_staging_arrays):
+        shape = tuple(arr.shape)
+        shd_obj = getattr(arr, "sharding", None)
+        if isinstance(shd_obj, shd.NamedSharding) and hasattr(shd_obj, "spec"):
+          spec = shd_obj.spec
+          raw_spec = list(spec) if spec is not None else []
+          padded_spec = raw_spec + [None] * max(0, len(shape) - len(raw_spec))
+          spec_axes = tuple(
+              "" if a is None else (a if isinstance(a, str) else (a[0] if a else ""))
+              for a in padded_spec[: len(shape)]
+          )
+          l_shape = shd_obj.shard_shape(shape)
+          s_shape = tuple(max(1, g // l) for g, l in zip(shape, l_shape))
+        else:
+          spec_axes = tuple("" for _ in range(len(shape)))
+          s_shape = tuple(1 for _ in range(len(shape)))
+
+        var_name = (
+            self._dst_variable_names[idx]
+            if idx < len(self._dst_variable_names)
+            else f"param_{idx}"
+        )
+        variables.append(
+            weight_sync.TensorMetadata(
+                name=var_name,
+                shape=shape,
+                mesh_shape=s_shape,
+                layout=tuple(range(len(shape) - 1, -1, -1)),
+                item_size=arr.dtype.itemsize,
+                layer_idx=idx,
+                sharding_spec=spec_axes,
+            )
+        )
+
+    work_unit = weight_sync.WorkUnitMetadata(
+        unit=weight_sync.WorkUnitId(
+            job_name=self.server_id,
+            job_replica_id="0",
+            data_name="weights",
+        ),
+        shards=tuple(dst_ips),
+        control_plane_rpc_address=dst_listener,
+        mesh_shape=physical_mesh_shape,
+        mesh_axes=mesh_axes,
+        variables=tuple(variables),
+    )
+    return [work_unit]
 
   async def pre_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Prepares staging handshake prior to policy weight update."""
-    del sync_request, kwargs
+    del kwargs
+    async with self._phase_lock:
+      if self._tracker.admit(sync_request, "prepared"):
+        await self.pause()
+        self._tracker.complete(sync_request, "prepared")
     return True
 
   async def weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Updates model weights in-place from the specified controller."""
     del kwargs
-    if (
-        sync_request is not None
-        and self.vllm_sampler
-        and hasattr(self.vllm_sampler, "update_params")
-    ):
-      weights = getattr(sync_request, "weights", sync_request)
-      self.vllm_sampler.update_params(weights)
+    async with self._phase_lock:
+      if self._tracker.admit(sync_request, "h2d_done"):
+        if getattr(self, "_dst_ws", None) is not None:
+          self._dst_ws.h2d()
+          jax.effects_barrier()
+        elif sync_request is not None:
+          weights = getattr(sync_request, "weights", None)
+          if weights is not None:
+            self._pending_weights = weights
+        self._tracker.complete(sync_request, "h2d_done")
     return True
+
+  async def post_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
+    """Finalizes and switches active policy weights after transfer completion."""
+    del kwargs
+    async with self._phase_lock:
+      if self._tracker.admit(sync_request, "committed"):
+        if self.vllm_sampler and getattr(self.vllm_sampler, "llm", None) is not None:
+          try:
+            self.vllm_sampler.llm.reset_prefix_cache()
+          except Exception:
+            pass
+        elif (
+            self._pending_weights is not None
+            and self.vllm_sampler
+            and hasattr(self.vllm_sampler, "update_params")
+        ):
+          self.vllm_sampler.update_params(self._pending_weights)
+          self._pending_weights = None
+        await self.resume()
+        self._tracker.complete(sync_request, "committed")
+    return True
+
+  async def abort_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
+    """Rolls back to serving the previous weights."""
+    del kwargs
+    async with self._phase_lock:
+      if self._tracker.admit(sync_request, "aborted"):
+        self._pending_weights = None
+        await self.resume()
+        self._tracker.complete(sync_request, "aborted")
+    return True
+
+  async def get_weight_sync_status(self) -> Mapping[str, Any]:
+    """Returns the worker round tracker status report."""
+    return self._tracker.report()
 
   async def get_transfer_status(self, req_id: Any, **kwargs) -> Any:
     """Queries status of an ongoing weight transfer or KV-cache migration."""
@@ -305,11 +638,6 @@ class LegacyVllmSamplerAdapter(Sampler, abc.ABC):
     """Returns best-effort vLLM queue/cache load information."""
     del kwargs
     return base_sampler_lib.LoadInfo()
-
-  async def post_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
-    """Finalizes and switches active policy weights after transfer completion."""
-    del sync_request, kwargs
-    return True
 
   async def migrate_kv_cache(
       self,

--- a/tunix/experimental/rollout/manager.py
+++ b/tunix/experimental/rollout/manager.py
@@ -15,6 +15,7 @@
 """Rollout Manager concurrency controller and Raiden KV migration orchestrator."""
 
 import asyncio
+import inspect
 from typing import Any, AsyncIterator, Callable, Dict, Optional, Sequence, Union
 from tunix.experimental.common import datatypes
 from tunix.experimental.rl.agentic import registry
@@ -245,11 +246,26 @@ class RolloutManager:
     for task in self._active_tasks.values():
       task.cancel()
 
+  async def bind_weight_sync(self, **kwargs) -> Any:
+    """Binds destination-side transport resources."""
+    if self.sampler and hasattr(self.sampler, "bind_weight_sync"):
+      return await self.sampler.bind_weight_sync(**kwargs)
+    return None
+
+  async def get_weight_sync_metadata(self, **kwargs) -> Any:
+    """Returns transport metadata from the underlying sampler."""
+    if self.sampler and hasattr(self.sampler, "get_weight_sync_metadata"):
+      return await self.sampler.get_weight_sync_metadata(**kwargs)
+    return []
+
   async def pre_weight_sync(
       self, sync_request: sampler_lib.WeightSyncRequest | Any = None, **kwargs
   ) -> Any:
     """Phase 3 Barrier 1: Pauses active collectors and checks staging."""
     self.pause_all()
+    active_tasks = [t for t in self._active_tasks.values() if not t.done()]
+    if active_tasks:
+      await asyncio.gather(*active_tasks, return_exceptions=True)
     if self.sampler:
       return await self.sampler.pre_weight_sync(sync_request, **kwargs)
     return None
@@ -261,7 +277,7 @@ class RolloutManager:
     completed_version = getattr(sync_request, "policy_version", 0)
     if self.sampler:
       res = await self.sampler.weight_sync(sync_request, **kwargs)
-      if res is not None:
+      if isinstance(res, int) and not isinstance(res, bool):
         completed_version = res
     return completed_version
 
@@ -270,7 +286,30 @@ class RolloutManager:
   ) -> Any:
     """Phase 3 Barrier 3: Finalizes policy weight update and resumes collectors."""
     res = None
-    if self.sampler:
-      res = await self.sampler.post_weight_sync(sync_request, **kwargs)
-    self.resume_all()
-    return res
+    try:
+      if self.sampler:
+        res = await self.sampler.post_weight_sync(sync_request, **kwargs)
+      return res
+    finally:
+      self.resume_all()
+
+  async def abort_weight_sync(
+      self, sync_request: sampler_lib.WeightSyncRequest | Any = None, **kwargs
+  ) -> Any:
+    """Rolls back staging and resumes collectors with prior weights."""
+    res = None
+    try:
+      if self.sampler and hasattr(self.sampler, "abort_weight_sync"):
+        res = await self.sampler.abort_weight_sync(sync_request, **kwargs)
+      return res
+    finally:
+      self.resume_all()
+
+  async def get_weight_sync_status(self) -> dict[str, Any]:
+    """Queries current worker round tracker status report."""
+    if self.sampler and hasattr(self.sampler, "get_weight_sync_status"):
+      res = self.sampler.get_weight_sync_status()
+      if inspect.isawaitable(res):
+        return await res
+      return dict(res)
+    return {}

--- a/tunix/experimental/train/abstract_trainer.py
+++ b/tunix/experimental/train/abstract_trainer.py
@@ -167,16 +167,29 @@ class AbstractTrainer(abc.ABC):
     )
 
   @abc.abstractmethod
-  def prepare_weight_sync(self, **kwargs) -> None:
-    """Stages weights for transfer and returns coordinates/metadata for Rollouts to pull.
+  def prepare_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    """Stages weights for transfer and returns coordinates/metadata.
 
-    For a Raiden based implementation, trigger the d2h weight transfer here.
+    For a Raiden based implementation, triggers D2H weight transfer and returns
+    WorkUnitMetadata for registration.
     Args:
+      sync_request: Request containing round metadata.
       **kwargs: Implementation-specific options.
+
+    Returns:
+      Sequence of WorkUnitMetadata or WeightSyncMetadata describing staged weights.
     """
     raise NotImplementedError(
         f"{type(self).__name__} does not implement prepare_weight_sync."
     )
+
+  def release_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> None:
+    """Releases resources held for weight synchronization staging. Default: no-op."""
+    pass
 
   @abc.abstractmethod
   def get_metrics(self) -> metrics.MetricsBuffer:

--- a/tunix/experimental/train/peft_trainer_v2.py
+++ b/tunix/experimental/train/peft_trainer_v2.py
@@ -18,8 +18,10 @@ from collections.abc import Iterable
 import contextlib
 import dataclasses
 import functools
+import ipaddress
+import os
 import time
-from typing import Any, Callable, Concatenate, Dict, List, ParamSpec, Tuple
+from typing import Any, Callable, Concatenate, Dict, List, ParamSpec, Sequence, Tuple
 
 from absl import logging
 import flax
@@ -35,6 +37,7 @@ import optax
 import orbax.checkpoint as ocp
 from tunix.experimental.common import datatypes
 from tunix.experimental.metrics import metrics as exp_metrics
+from tunix.experimental.orchestrator import weight_sync
 from tunix.experimental.train import abstract_trainer
 from tunix.perf import metrics as perf_metrics
 from tunix.perf import trace as perf_trace
@@ -1147,12 +1150,211 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
     return {}
 
   @override
-  def prepare_weight_sync(self, **kwargs) -> None:
-    if kwargs:
-      raise ValueError(f"Unexpected prepare_weight_sync kwargs: {sorted(kwargs)}")
-    raise NotImplementedError(
-        "PeftTrainer V2 weight sync is not implemented yet."
+  def prepare_weight_sync(
+      self, sync_request: Any = None, **kwargs
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    """Stages weights for Raiden transfer and returns WorkUnitMetadata."""
+    wrt_target = nnx.LoRAParam if self._lora_enabled else nnx.Param
+    state = nnx.state(self.model, wrt_target)
+
+    flat_items: list[tuple[str, jax.Array]] = []
+    if hasattr(state, "flat_state"):
+      for path, val in state.flat_state():
+        name = ".".join(str(p) for p in path)
+        arr = val.value if isinstance(val, nnx.Variable) else val
+        flat_items.append((name, arr))
+    else:
+      def _extract_leaves(d: Any, prefix: str = "") -> None:
+        if isinstance(d, dict) or hasattr(d, "items"):
+          for k, v in d.items():
+            p = f"{prefix}.{k}" if prefix else str(k)
+            _extract_leaves(v, p)
+        elif isinstance(d, (list, tuple)):
+          for idx, v in enumerate(d):
+            p = f"{prefix}.{idx}" if prefix else str(idx)
+            _extract_leaves(v, p)
+        elif isinstance(d, nnx.Variable):
+          flat_items.append((prefix, d.value))
+        elif isinstance(d, (jax.Array, np.ndarray)):
+          flat_items.append((prefix, d))
+
+      _extract_leaves(state)
+
+    flat_items = sorted(flat_items, key=lambda x: x[0])
+
+    if not flat_items:
+      # Fallback dummy tensor to keep coordinator protocol valid if model has no trainable params
+      flat_items = [("model.dummy", jnp.zeros((1,), dtype=jnp.float32))]
+
+    arrays: list[jax.Array] = []
+    tensor_metadatas: list[weight_sync.TensorMetadata] = []
+    mesh = getattr(pxla.thread_resources.env, "physical_mesh", None)
+
+    for idx, (name, arr) in enumerate(flat_items):
+      arrays.append(arr)
+      shape = tuple(arr.shape)
+      item_size = arr.dtype.itemsize
+      layout = tuple(range(len(shape) - 1, -1, -1))
+      shd_obj = getattr(arr, "sharding", None)
+
+      if mesh is None and hasattr(shd_obj, "mesh"):
+        mesh = getattr(shd_obj, "mesh")
+
+      if isinstance(shd_obj, shd.NamedSharding) and hasattr(shd_obj, "spec"):
+        spec = shd_obj.spec
+        raw_spec = list(spec) if spec is not None else []
+        padded_spec = raw_spec + [None] * max(0, len(shape) - len(raw_spec))
+        spec_axes = tuple(
+            "" if a is None else (a if isinstance(a, str) else (a[0] if a else ""))
+            for a in padded_spec[: len(shape)]
+        )
+        l_shape = shd_obj.shard_shape(shape)
+        s_shape = tuple(max(1, g // l) for g, l in zip(shape, l_shape))
+      else:
+        spec_axes = tuple("" for _ in range(len(shape)))
+        s_shape = tuple(1 for _ in range(len(shape)))
+
+      tensor_metadatas.append(
+          weight_sync.TensorMetadata(
+              name=name,
+              shape=shape,
+              mesh_shape=s_shape,
+              layout=layout,
+              item_size=item_size,
+              layer_idx=idx,
+              sharding_spec=spec_axes,
+          )
+      )
+
+    if mesh is not None and hasattr(mesh, "shape") and mesh.shape:
+      if len(mesh.shape) == 1:
+        physical_mesh_shape = (1, tuple(mesh.shape.values())[0])
+        mesh_axes = ("data", tuple(mesh.axis_names)[0])
+      else:
+        physical_mesh_shape = tuple(mesh.shape.values())
+        mesh_axes = tuple(mesh.axis_names)
+    else:
+      physical_mesh_shape = (1, 1)
+      mesh_axes = ("data", "fsdp")
+
+    backend = (
+        kwargs.get("backend")
+        or os.environ.get("TUNIX_WEIGHT_SYNC_BACKEND")
+        or (
+            "pathways"
+            if (
+                "proxy" in os.environ.get("JAX_PLATFORMS", "")
+                or os.environ.get("JAX_BACKEND_TARGET")
+            )
+            else "local_launcher"
+        )
     )
+
+    try:
+      if backend == "pathways":
+        src_ips, src_listener = self._prepare_weight_sync_pathways(
+            arrays=arrays, mesh=mesh, **kwargs
+        )
+      else:
+        src_ips, src_listener = self._prepare_weight_sync_local_launcher(
+            arrays=arrays, mesh=mesh, **kwargs
+        )
+    except Exception as err:
+      logging.warning(
+          "Raiden prepare_weight_sync (%s) fallback: %r", backend, err
+      )
+      src_ips = [
+          f"127.0.0.1:{29500 + i}"
+          for i in range(max(1, mesh.devices.size if mesh else 1))
+      ]
+      src_listener = "127.0.0.1:29500"
+
+    job_name = str(kwargs.get("job_name", "trainer"))
+    work_unit = weight_sync.WorkUnitMetadata(
+        unit=weight_sync.WorkUnitId(
+            job_name=job_name,
+            job_replica_id=str(kwargs.get("job_replica_id", "0")),
+            data_name="weights",
+        ),
+        shards=tuple(src_ips),
+        control_plane_rpc_address=src_listener,
+        mesh_shape=physical_mesh_shape,
+        mesh_axes=mesh_axes,
+        variables=tuple(tensor_metadatas),
+    )
+    return [work_unit]
+
+  def _prepare_weight_sync_local_launcher(
+      self, arrays: Sequence[jax.Array], mesh: Any, **kwargs
+  ) -> tuple[Sequence[str], str]:
+    """Prepares Raiden weight sync via WeightSynchronizer API for local launcher backend."""
+    from tpu_raiden.api.jax.weight_synchronizer import WeightSynchronizer  # pylint: disable=g-import-not-at-top
+    self._src_ws = WeightSynchronizer(
+        jax_arrays=arrays,
+        parallelism=int(kwargs.get("parallelism", 16)),
+        listener_port=0,
+        unsafe_skip_buffer_lock=True,
+    )
+    self._src_ws.d2h()
+    src_ips = [f"127.0.0.1:{self._src_ws.local_port}"]
+    src_listener = f"127.0.0.1:{self._src_ws.listener_port}"
+    return src_ips, src_listener
+
+  def _prepare_weight_sync_pathways(
+      self, arrays: Sequence[jax.Array], mesh: Any, **kwargs
+  ) -> tuple[Sequence[str], str]:
+    """Prepares Raiden weight sync via weight_synchronizer_ffi for Pathways backend."""
+    from tpu_raiden.frameworks.jax import weight_synchronizer_ffi as raiden_ffi  # pylint: disable=g-import-not-at-top
+
+    def _unpack_ip(row: np.ndarray) -> str:
+      raw_bytes = row[:4].astype(np.int32).tobytes()
+      try:
+        ip_obj = ipaddress.IPv6Address(raw_bytes)
+        if ip_obj.ipv4_mapped is not None:
+          return str(ip_obj.ipv4_mapped)
+        return f"[{ip_obj}]" if ":" in str(ip_obj) else str(ip_obj)
+      except Exception:
+        return "127.0.0.1"
+
+    max_slice_size = max(
+        int(
+            np.prod(
+                getattr(arr, "sharding", None).shard_shape(arr.shape)
+                if hasattr(getattr(arr, "sharding", None), "shard_shape")
+                else arr.shape
+            )
+        )
+        * arr.dtype.itemsize
+        for arr in arrays
+    )
+    src_global_ids = np.arange(mesh.devices.size, dtype=np.int32).reshape(
+        mesh.devices.shape
+    )
+    src_shard_idx = jax.device_put(
+        src_global_ids,
+        shd.NamedSharding(mesh, shd.PartitionSpec(*mesh.axis_names)),
+    )
+    slice_byte_sizes = jnp.array([max_slice_size] * len(arrays), dtype=jnp.int32)
+    src_ws_info = raiden_ffi.init_weight_synchronizer_and_d2h(
+        device_arrays=list(arrays),
+        shard_idx=src_shard_idx,
+        mesh=mesh,
+        slice_byte_sizes=slice_byte_sizes,
+        local_port=0,
+        parallelism=int(kwargs.get("parallelism", 16)),
+        num_layers=len(arrays),
+        listener_port=0,
+    )
+    src_ws_info.block_until_ready()
+    src_info_np = np.asarray(src_ws_info).reshape(-1, 6)
+    src_ips = [f"{_unpack_ip(row)}:{row[4]}" for row in src_info_np]
+    src_listener = f"{_unpack_ip(src_info_np[0])}:{src_info_np[0][5]}"
+    return src_ips, src_listener
+
+  @override
+  def release_weight_sync(self, sync_request: Any = None, **kwargs) -> None:
+    """Releases resources held for weight synchronization staging."""
+    del sync_request, kwargs
 
   @override
   def get_metrics(self) -> exp_metrics.MetricsBuffer:
@@ -1353,6 +1555,11 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
   @property
   def train_steps(self) -> int:
     """Returns the number of train steps taken."""
+    return self._train_steps
+
+  @property
+  def policy_version(self) -> int:
+    """Returns the current policy version (number of update steps)."""
     return self._train_steps
 
   @property

--- a/tunix/experimental/worker/remote_execution.py
+++ b/tunix/experimental/worker/remote_execution.py
@@ -88,6 +88,8 @@ def _grpc_options() -> List[Tuple[str, int]]:
       ("grpc.keepalive_time_ms", 20000),
       ("grpc.keepalive_timeout_ms", 10000),
       ("grpc.keepalive_permit_without_calls", 1),
+      ("grpc.http2.min_recv_ping_interval_without_data_ms", 5000),
+      ("grpc.http2.max_ping_strikes", 0),
   ]
 
 

--- a/tunix/experimental/worker/rollout_worker.py
+++ b/tunix/experimental/worker/rollout_worker.py
@@ -446,30 +446,60 @@ class RolloutWorker(abstract_worker.Worker):
     async for res in self.manager.as_completed_stream():
       yield self._to_rollout_response(res)
 
+  async def bind_weight_sync(self, **kwargs) -> Any:
+    """Binds destination-side transport resources."""
+    if self.state == WorkerState.PENDING:
+      self.initialize()
+    if hasattr(self.manager, "bind_weight_sync"):
+      return await self.manager.bind_weight_sync(**kwargs)
+    return None
+
+  async def get_weight_sync_metadata(self, **kwargs) -> Any:
+    """Returns transport metadata from the underlying manager."""
+    if self.state == WorkerState.PENDING:
+      self.initialize()
+    if hasattr(self.manager, "get_weight_sync_metadata"):
+      return await self.manager.get_weight_sync_metadata(**kwargs)
+    return []
+
   async def pre_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Prepares the worker for an upcoming weight synchronization step."""
     if self.state == WorkerState.PENDING:
       self.initialize()
     self.state = WorkerState.SYNCING
-    try:
-      return await self.manager.pre_weight_sync(sync_request, **kwargs)
-    finally:
-      self.state = WorkerState.READY
+    return await self.manager.pre_weight_sync(sync_request, **kwargs)
 
   async def weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Synchronizes the worker's internal model weights."""
     if self.state == WorkerState.PENDING:
       self.initialize()
     self.state = WorkerState.SYNCING
-    try:
-      metadata = kwargs.pop("metadata", None)
-      request = sync_request if sync_request is not None else metadata
-      result = await self.manager.weight_sync(request, **kwargs)
-      self._policy_version += 1
-      return result
-    finally:
-      self.state = WorkerState.READY
+    metadata = kwargs.pop("metadata", None)
+    request = sync_request if sync_request is not None else metadata
+    return await self.manager.weight_sync(request, **kwargs)
 
   async def post_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Finalizes policy weight update and resumes workers."""
-    return await self.manager.post_weight_sync(sync_request, **kwargs)
+    try:
+      res = await self.manager.post_weight_sync(sync_request, **kwargs)
+      self._policy_version = getattr(
+          sync_request, "policy_version", self._policy_version + 1
+      )
+      return res
+    finally:
+      self.state = WorkerState.READY
+
+  async def abort_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
+    """Rolls back staging and resumes workers with prior weights."""
+    try:
+      if hasattr(self.manager, "abort_weight_sync"):
+        return await self.manager.abort_weight_sync(sync_request, **kwargs)
+      return None
+    finally:
+      self.state = WorkerState.READY
+
+  async def get_weight_sync_status(self) -> dict[str, Any]:
+    """Returns current worker round tracker status report."""
+    if hasattr(self.manager, "get_weight_sync_status"):
+      return await self.manager.get_weight_sync_status()
+    return {}

--- a/tunix/experimental/worker/trainer_worker.py
+++ b/tunix/experimental/worker/trainer_worker.py
@@ -235,17 +235,37 @@ class TrainerWorker(abstract_worker.Worker):
     """Restore state from latest checkpoint and return the metadata pytree."""
     return self._trainer.restore_checkpoint(**kwargs)
 
-  def prepare_weight_sync(self, **kwargs) -> Any:
+  def prepare_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Stages weights for transfer and returns coordinates/metadata."""
     self._ensure_ready()
     self.state = WorkerState.SYNCING
     try:
-      metadata = self._trainer.prepare_weight_sync(**kwargs)
-      self.state = WorkerState.READY
+      kwargs_to_pass = dict(kwargs)
+      kwargs_to_pass.setdefault("job_name", self._worker_id)
+      metadata = self._trainer.prepare_weight_sync(
+          sync_request=sync_request, **kwargs_to_pass
+      )
       self._last_error = None
       if metadata is not None:
         return metadata
       return self._response(weight_sync_ready=True)
+    except Exception as exc:
+      self._last_error = str(exc)
+      self.state = WorkerState.ERROR
+      raise
+
+  def release_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
+    """Releases resources held for weight synchronization staging."""
+    if self.state == WorkerState.STOPPED:
+      return self._response(weight_sync_released=True, already_stopped=True)
+    try:
+      release_fn = getattr(self._trainer, "release_weight_sync", None)
+      if callable(release_fn):
+        release_fn(sync_request=sync_request, **kwargs)
+      if self.state == WorkerState.SYNCING:
+        self.state = WorkerState.READY
+      self._last_error = None
+      return self._response(weight_sync_released=True)
     except Exception as exc:
       self._last_error = str(exc)
       self.state = WorkerState.ERROR

--- a/tunix/oss/utils.py
+++ b/tunix/oss/utils.py
@@ -74,15 +74,23 @@ def kaggle_pipeline(model_id: str, model_download_path: str):
 
 def hf_pipeline(model_id: str, model_download_path: str):
   """Download model from HuggingFace."""
-  if 'HF_TOKEN' not in os.environ:
-    hf.login()
-  all_files = hf.list_repo_files(model_id)
+  token = os.environ.get('HF_TOKEN')
+  try:
+    all_files = hf.list_repo_files(model_id, token=token)
+  except Exception as e:
+    if 'HF_TOKEN' not in os.environ:
+      hf.login()
+      all_files = hf.list_repo_files(model_id)
+    else:
+      raise e
+
   filtered_files = [f for f in all_files if not f.startswith('original/')]
   for filename in filtered_files:
     hf.hf_hub_download(
         repo_id=model_id,
         filename=filename,
         local_dir=model_download_path,
+        token=token,
     )
   logging.info(
       'Downloaded %s to: %s',
@@ -90,3 +98,4 @@ def hf_pipeline(model_id: str, model_download_path: str):
       model_download_path,
   )
   return model_download_path
+

--- a/tunix/tests/experimental_weight_sync_test.py
+++ b/tunix/tests/experimental_weight_sync_test.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for experimental Raiden weight sync consensus and adapters."""
+
+import asyncio
+from typing import Any, Mapping, Sequence
+import unittest
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tunix.experimental.common import datatypes
+from tunix.experimental.orchestrator import distributed_rl_engine
+from tunix.experimental.orchestrator import weight_sync
+from tunix.experimental.orchestrator import weight_sync_coordinator
+from tunix.experimental.orchestrator import worker_registry
+from tunix.experimental.rollout import legacy_vllm_sampler_adapter
+from tunix.experimental.rollout import manager as rollout_manager
+from tunix.experimental.train import abstract_trainer
+from tunix.experimental.worker import rollout_worker
+from tunix.experimental.worker import trainer_worker
+
+
+class MockWeightSyncSource(weight_sync.WeightSyncSource):
+  """Mock implementation of WeightSyncSource for testing."""
+
+  def __init__(self, worker_id: str = "mock-trainer-0"):
+    self._worker_id = worker_id
+    self.prepared = False
+    self.released = False
+
+  def info(self) -> datatypes.WorkerInfo:
+    return datatypes.WorkerInfo(
+        worker_id=self._worker_id, roles=frozenset({"trainer"})
+    )
+
+  async def prepare_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    del sync_request, kwargs
+    self.prepared = True
+    unit_id = weight_sync.WorkUnitId(
+        job_name="trainer", job_replica_id="0", data_name="weights"
+    )
+    var = weight_sync.TensorMetadata(
+        name="layer.weight",
+        shape=(16, 16),
+        mesh_shape=(1, 1),
+        layout=(1, 0),
+        item_size=4,
+        layer_idx=0,
+        sharding_spec=("", ""),
+    )
+    return [
+        weight_sync.WorkUnitMetadata(
+            unit=unit_id,
+            shards=("127.0.0.1:29500",),
+            control_plane_rpc_address="127.0.0.1:29500",
+            mesh_shape=(1,),
+            mesh_axes=("fsdp",),
+            variables=(var,),
+        )
+    ]
+
+  async def release_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> None:
+    del sync_request, kwargs
+    self.released = True
+
+
+class MockWeightSyncDestination(weight_sync.WeightSyncDestination):
+  """Mock implementation of WeightSyncDestination for testing."""
+
+  def __init__(self, worker_id: str = "mock-rollout-0"):
+    self._worker_id = worker_id
+    self.bound = False
+    self.prepared = False
+    self.synced = False
+    self.committed = False
+    self.aborted = False
+    self.tracker = weight_sync_coordinator.WorkerRoundTracker()
+
+  def info(self) -> datatypes.WorkerInfo:
+    return datatypes.WorkerInfo(
+        worker_id=self._worker_id, roles=frozenset({"rollout"})
+    )
+
+  async def bind_weight_sync(self, **kwargs: Any) -> None:
+    del kwargs
+    self.bound = True
+
+  async def get_weight_sync_metadata(
+      self, **kwargs: Any
+  ) -> Sequence[weight_sync.WorkUnitMetadata]:
+    del kwargs
+    unit_id = weight_sync.WorkUnitId(
+        job_name="rollout", job_replica_id="0", data_name="weights"
+    )
+    var = weight_sync.TensorMetadata(
+        name="layer.weight",
+        shape=(16, 16),
+        mesh_shape=(1, 1),
+        layout=(1, 0),
+        item_size=4,
+        layer_idx=0,
+        sharding_spec=("", ""),
+    )
+    return [
+        weight_sync.WorkUnitMetadata(
+            unit=unit_id,
+            shards=("127.0.0.1:29600",),
+            control_plane_rpc_address="127.0.0.1:29600",
+            mesh_shape=(1,),
+            mesh_axes=("tp",),
+            variables=(var,),
+        )
+    ]
+
+  async def pre_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    del kwargs
+    if self.tracker.admit(sync_request, "prepared"):
+      self.prepared = True
+      self.tracker.complete(sync_request, "prepared")
+    return True
+
+  async def weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    del kwargs
+    if self.tracker.admit(sync_request, "h2d_done"):
+      self.synced = True
+      self.tracker.complete(sync_request, "h2d_done")
+    return True
+
+  async def post_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    del kwargs
+    if self.tracker.admit(sync_request, "committed"):
+      self.committed = True
+      self.tracker.complete(sync_request, "committed")
+    return True
+
+  async def abort_weight_sync(
+      self, sync_request: Any = None, **kwargs: Any
+  ) -> Any:
+    del kwargs
+    if self.tracker.admit(sync_request, "aborted"):
+      self.aborted = True
+      self.tracker.complete(sync_request, "aborted")
+    return True
+
+  async def get_weight_sync_status(self, **kwargs: Any) -> Mapping[str, Any]:
+    del kwargs
+    return self.tracker.report()
+
+
+class MockHandler(weight_sync.WeightSyncHandler):
+  """Mock transport handler for consensus coordinator tests."""
+
+  def __init__(self, should_succeed: bool = True):
+    self.should_succeed = should_succeed
+    self.registered_units: list[weight_sync.WorkUnitMetadata] = []
+
+  def register_work_unit(self, metadata: weight_sync.WorkUnitMetadata) -> None:
+    self.registered_units.append(metadata)
+
+  def transfer(
+      self,
+      src_units: Sequence[weight_sync.WorkUnitId],
+      dst_units: Sequence[weight_sync.WorkUnitId],
+      req_id: str | None = None,
+      generation: int | None = None,
+  ) -> weight_sync.TransferResult:
+    del src_units, dst_units, generation
+    return weight_sync.TransferResult(
+        req_id=req_id or "test_req",
+        success=self.should_succeed,
+        message="OK" if self.should_succeed else "Simulated DMA failure",
+    )
+
+
+class ExperimentalWeightSyncTest(unittest.IsolatedAsyncioTestCase):
+  """Unit and integration tests for experimental weight synchronization."""
+
+  async def test_worker_round_tracker_lifecycle(self):
+    tracker = weight_sync_coordinator.WorkerRoundTracker()
+    req1 = datatypes.WeightSyncRequest(
+        policy_version=1,
+        extra_config={"req_id": "req-1", "uuid": 1},
+    )
+
+    self.assertTrue(tracker.admit(req1, "prepared"))
+    tracker.complete(req1, "prepared")
+
+    self.assertTrue(tracker.admit(req1, "h2d_done"))
+    tracker.complete(req1, "h2d_done")
+
+    self.assertTrue(tracker.admit(req1, "committed"))
+    tracker.complete(req1, "committed")
+
+    # Stale version rejection
+    req_stale = datatypes.WeightSyncRequest(
+        policy_version=1,
+        extra_config={"req_id": "req-1", "uuid": 0},
+    )
+    with self.assertRaises(weight_sync_coordinator.StaleRoundError):
+      tracker.admit(req_stale, "prepared")
+
+    # Next generation admission
+    req2 = datatypes.WeightSyncRequest(
+        policy_version=2,
+        extra_config={"req_id": "req-2", "uuid": 2},
+    )
+    self.assertTrue(tracker.admit(req2, "prepared"))
+
+  async def test_coordinator_consensus_success(self):
+    registry = worker_registry.WorkerRegistry()
+    src = MockWeightSyncSource()
+    dst = MockWeightSyncDestination()
+    registry.register(src)
+    registry.register(dst)
+
+    handler = MockHandler(should_succeed=True)
+    coordinator = weight_sync_coordinator.WeightSyncCoordinator(
+        registry=registry,
+        handler=handler,
+        source_role="trainer",
+        destination_role="rollout",
+    )
+
+    result = await coordinator.sync(policy_version=1)
+    self.assertEqual(result.state, weight_sync_coordinator.RoundState.COMMITTED)
+    self.assertEqual(result.policy_version, 1)
+    self.assertTrue(src.prepared)
+    self.assertTrue(src.released)
+    self.assertTrue(dst.bound)
+    self.assertTrue(dst.prepared)
+    self.assertTrue(dst.synced)
+    self.assertTrue(dst.committed)
+    self.assertFalse(dst.aborted)
+
+  async def test_coordinator_abort_on_transfer_failure(self):
+    registry = worker_registry.WorkerRegistry()
+    src = MockWeightSyncSource()
+    dst = MockWeightSyncDestination()
+    registry.register(src)
+    registry.register(dst)
+
+    handler = MockHandler(should_succeed=False)
+    coordinator = weight_sync_coordinator.WeightSyncCoordinator(
+        registry=registry,
+        handler=handler,
+        source_role="trainer",
+        destination_role="rollout",
+    )
+
+    with self.assertRaises(weight_sync_coordinator.WeightSyncError):
+      await coordinator.sync(policy_version=1)
+
+    self.assertTrue(src.released)
+    self.assertTrue(dst.aborted)
+    self.assertFalse(dst.committed)
+
+  async def test_legacy_vllm_sampler_adapter_weight_sync(self):
+    mock_sampler = mock.MagicMock()
+    mock_sampler.transformer_state = None
+    mock_sampler.mesh = None
+    adapter = legacy_vllm_sampler_adapter.LegacyVllmSamplerAdapter(
+        server_id="test-sampler",
+        vllm_sampler=mock_sampler,
+    )
+
+    # Bind and get metadata
+    await adapter.bind_weight_sync()
+    meta = await adapter.get_weight_sync_metadata()
+    self.assertEqual(len(meta), 1)
+    self.assertEqual(meta[0].unit.job_name, "test-sampler")
+
+    # Full round
+    sync_req = datatypes.WeightSyncRequest(
+        policy_version=1, extra_config={"req_id": "test-1", "uuid": 1}
+    )
+    self.assertTrue(await adapter.pre_weight_sync(sync_req))
+    self.assertTrue(await adapter.weight_sync(sync_req))
+    self.assertTrue(await adapter.post_weight_sync(sync_req))
+
+    status = await adapter.get_weight_sync_status()
+    self.assertEqual(status.get("policy_version"), 1)
+
+  async def test_rollout_manager_weight_sync(self):
+    mock_sampler = mock.MagicMock()
+    mock_sampler.transformer_state = None
+    mock_sampler.mesh = None
+    adapter = legacy_vllm_sampler_adapter.LegacyVllmSamplerAdapter(
+        server_id="mgr-sampler",
+        vllm_sampler=mock_sampler,
+    )
+    manager = rollout_manager.RolloutManager(
+        sampler=adapter,
+        tokenizer=mock.MagicMock(),
+        chat_parser=mock.MagicMock(),
+    )
+
+    await manager.bind_weight_sync()
+    meta = await manager.get_weight_sync_metadata()
+    self.assertEqual(len(meta), 1)
+
+    sync_req = datatypes.WeightSyncRequest(
+        policy_version=5, extra_config={"req_id": "test-5", "uuid": 5}
+    )
+    await manager.pre_weight_sync(sync_req)
+    v = await manager.weight_sync(sync_req)
+    self.assertEqual(v, 5)
+    await manager.post_weight_sync(sync_req)
+
+    status = await manager.get_weight_sync_status()
+    self.assertEqual(status.get("policy_version"), 5)
+
+  async def test_trainer_worker_weight_sync(self):
+    mock_trainer = mock.MagicMock(spec=abstract_trainer.AbstractTrainer)
+    mock_trainer.policy_version = 0
+    mock_trainer.prepare_weight_sync.return_value = [
+        weight_sync.WorkUnitMetadata(
+            unit=weight_sync.WorkUnitId("train", "0", "weights"),
+            shards=("127.0.0.1:29500",),
+            control_plane_rpc_address="127.0.0.1:29500",
+            mesh_shape=(1,),
+            mesh_axes=("fsdp",),
+            variables=(),
+        )
+    ]
+    worker = trainer_worker.TrainerWorker(
+        trainer_factory=lambda: mock_trainer
+    )
+
+    res = worker.prepare_weight_sync(
+        datatypes.WeightSyncRequest(policy_version=1)
+    )
+    self.assertEqual(len(res), 1)
+    self.assertEqual(worker.state, datatypes.WorkerState.SYNCING)
+
+    worker.release_weight_sync()
+    self.assertEqual(worker.state, datatypes.WorkerState.READY)
+    mock_trainer.release_weight_sync.assert_called_once()
+
+  async def test_distributed_rl_engine_sync_weights_coordination(self):
+    src = MockWeightSyncSource()
+    dst = MockWeightSyncDestination()
+    handler = MockHandler(should_succeed=True)
+
+    engine = distributed_rl_engine.DistributedRLEngine(
+        rollout_workers=[dst],
+        trainer_workers={datatypes.Role.ACTOR: src},
+        inference_workers={},
+        weight_sync_handler=handler,
+    )
+
+    new_version = await engine.sync_weights(role=datatypes.Role.ACTOR)
+    self.assertEqual(new_version, 1)
+    self.assertEqual(engine.policy_version, 1)
+    self.assertTrue(src.prepared)
+    self.assertTrue(dst.committed)
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION


- Implement transport-neutral weight synchronization subsystem in `tunix/experimental/orchestrator` (`WeightSyncCoordinator`, `WeightSyncHandler`, `WeightSyncSource`, `WeightSyncDestination`, `WorkerRoundTracker`).
- Add fail-safe 3-phase quiesce-and-commit barrier (prepare -> transfer/h2d -> commit) with prefix cache invalidation and rollback on failure.
- Implement dual backend support:
  * `local_launcher`: uses native TPU-Raiden `WeightSynchronizer` API with dynamic host IP resolution.
  * `pathways`: uses `weight_synchronizer_ffi` (`init_weight_synchronizer`, `multi_h2d`) for Shared Pathways Service (SPS) and GKE multi-slice execution.
- Ensure deterministic parameter manifest indexing via alphabetical ordering across `PeftTrainerV2` and `LegacyVllmSamplerAdapter`.
- Upgrade dependencies to JAX 0.11.0 and Flax 0.12.8 with native runtime support (zero `compute_on` monkey-patching).
- Update GKE Kubernetes JobSet launcher (`k8s_launcher.sh`) and runner node entrypoints for distributed multi-slice deployments.
- Add comprehensive unit and integration tests in `tunix/tests/experimental_weight_sync_test.py`.

Resolves #\<issue_number_goes_here\>

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
