### PR TITLE
Support checkpoint_storage_use_ocdbt and checkpoint_storage_use_zarr3…

### DIFF
--- a/tests/models/automodel_test.py
+++ b/tests/models/automodel_test.py
@@ -182,6 +182,8 @@ class AutoModelTest(parameterized.TestCase):
             use_flash_attention=True,
             tunix_fake_arg_that_should_be_dropped=False,
             skip_jax_distributed_system=False,
+            checkpoint_storage_use_ocdbt=False,
+            checkpoint_storage_use_zarr3=False,
         )
 
       m_maxtext_configs_pyconfig.initialize.assert_called_once()
@@ -196,6 +198,8 @@ class AutoModelTest(parameterized.TestCase):
       self.assertIn("hf_access_token=mock_token", called_argv)
 
       self.assertIn("skip_jax_distributed_system=false", called_argv)
+      self.assertIn("checkpoint_storage_use_ocdbt=false", called_argv)
+      self.assertIn("checkpoint_storage_use_zarr3=false", called_argv)
 
       self.assertNotIn("use_flash_attention=true", called_argv)
 

--- a/tunix/models/automodel.py
+++ b/tunix/models/automodel.py
@@ -422,6 +422,8 @@ class AutoModel:
         **kwargs: Additional keyword arguments passed to the underlying model
           creation functions. - For ModelSource.KAGGLE, Gemma models:
           `intermediate_ckpt_dir` , `rng_seed`
+          - For ModelSource.MAXTEXT: `checkpoint_storage_use_ocdbt`,
+          `checkpoint_storage_use_zarr3`, `skip_jax_distributed_system`
 
     Returns:
         The loaded nnx.Module model.
@@ -483,6 +485,12 @@ class AutoModel:
         valid_keys = set(MaxTextConfig.model_fields.keys())
       elif hasattr(MaxTextConfig, '__annotations__'):
         valid_keys = set(MaxTextConfig.__annotations__.keys())
+
+      # Explicitly allow checkpoint storage format overrides if provided
+      valid_keys.update({
+          'checkpoint_storage_use_ocdbt',
+          'checkpoint_storage_use_zarr3',
+      })
 
       for k, v in kwargs.items():
         if v is not None and k in valid_keys:


### PR DESCRIPTION
… in AutoModel for MaxText

Adds explicit support for passing checkpoint_storage_use_ocdbt and checkpoint_storage_use_zarr3 kwargs to AutoModel.from_pretrained when model_source=ModelSource.MAXTEXT. This allows callers to toggle between OCDBT/Zarr3 and legacy Zarr v2 TensorStore checkpoint formats.

The two flags are not correctly passed to maxText and prevent us to read MaxText checkpoint.

- [x ] I have added all the necessary unit tests for my change.
- [ x] I have verified that my change does not break existing code and all unit tests pass.
- [ x] I have added all appropriate doc-strings/documentation.
- [ x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
