### PR TITLE
feat(peft): add BEFT (Bias-Elevation Fine-Tuning) and generalized PEFT support

### DIFF
--- a/tests/sft/beft_test.py
+++ b/tests/sft/beft_test.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for BEFT (Bias-Elevation Fine-Tuning)."""
+
+import os
+import tempfile
+
+from absl.testing import absltest
+from flax import nnx
+from flax.nnx import filterlib
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+from tunix.generate import sampler
+from tunix.sft import checkpoint_manager
+from tunix.sft import peft_trainer
+from tunix.sft import utils
+from tunix.sft.peft.beft import apply_beft_to_model
+from tunix.sft.peft.beft import BEFTConfig
+from tunix.sft.peft.beft import BEFTLinear
+from tunix.sft.peft.beft import BEFTParam
+from tunix.sft.peft.beft import unwrap_beft_from_model
+from tunix.tests import test_common as tc
+
+# CPU environment setup to simulate multi device env.
+os.environ['XLA_FLAGS'] = '--xla_force_host_platform_device_count=4'
+jax.config.update('jax_default_matmul_precision', 'highest')
+
+
+def dummy_gen_model_input_fn(x: peft_trainer.TrainingInput):
+  return {
+      'input_tokens': x.input_tokens,
+      'input_mask': x.input_mask,
+      'positions': jnp.arange(x.input_tokens.shape[1]),
+      'attention_mask': jnp.ones_like(x.input_tokens),
+  }
+
+
+def dummy_datasets(batch_size: int, repeat: int = 1):
+  dummy_input = np.arange(128).reshape((-1, batch_size, 16))
+  return [
+      peft_trainer.TrainingInput(
+          input_tokens=x, input_mask=jnp.ones(x.shape, dtype=jnp.int32)
+      )
+      for x in dummy_input
+  ] * repeat
+
+
+class BeftTest(absltest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    try:
+      self.temp_path = self.create_tempdir().full_path
+    except Exception:
+      self.temp_path = tempfile.TemporaryDirectory().name
+
+    self.train_ds = dummy_datasets(batch_size=4, repeat=2)
+    self.eval_ds = dummy_datasets(batch_size=4, repeat=1)
+
+  def test_beft_linear_forward_and_properties(self):
+    rngs = nnx.Rngs(0)
+    base_linear = nnx.Linear(
+        in_features=8,
+        out_features=16,
+        use_bias=False,
+        rngs=rngs,
+    )
+    beft_linear = BEFTLinear(base_linear)
+
+    # Check attribute delegation
+    self.assertEqual(beft_linear.in_features, 8)
+    self.assertEqual(beft_linear.out_features, 16)
+    self.assertIsInstance(beft_linear.bias, BEFTParam)
+    self.assertEqual(beft_linear.bias.value.shape, (16,))
+
+    # Check forward pass
+    x = jnp.ones((2, 8))
+    base_out = base_linear(x)
+    beft_out = beft_linear(x)
+    np.testing.assert_allclose(base_out, beft_out, atol=1e-5)
+
+    # Mutate bias and check that output shifts by bias
+    beft_linear.bias.value = beft_linear.bias.value + 2.0
+    shifted_out = beft_linear(x)
+    np.testing.assert_allclose(shifted_out, base_out + 2.0, atol=1e-5)
+
+  def test_beft_merge(self):
+    rngs = nnx.Rngs(0)
+    base_linear = nnx.Linear(
+        in_features=8,
+        out_features=16,
+        use_bias=True,
+        rngs=rngs,
+    )
+    beft_linear = BEFTLinear(base_linear)
+    beft_linear.bias.value = jnp.full((16,), 3.0)
+    original_bias = jnp.copy(base_linear.bias.value)
+
+    beft_linear.merge()
+    np.testing.assert_allclose(
+        base_linear.bias.value, original_bias + 3.0, atol=1e-5
+    )
+
+  def test_apply_beft_to_model_and_unwrap(self):
+    rngs = nnx.Rngs(0)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=rngs)
+
+    self.assertFalse(utils.is_beft_enabled(model))
+    self.assertFalse(utils.is_peft_enabled(model))
+    self.assertIsNone(utils.get_peft_param_type(model))
+
+    apply_beft_to_model(model, module_path=r".*w1|.*w2")
+
+    self.assertTrue(utils.is_beft_enabled(model))
+    self.assertTrue(utils.is_peft_enabled(model))
+    self.assertEqual(utils.get_peft_param_type(model), BEFTParam)
+
+    # Test forward pass with BEFT applied
+    dummy_input = tc.get_dummy_inputs_for_lora_toy_transformer_tests()
+    logits, _ = model(**dummy_input)
+    self.assertEqual(logits.shape[-1], 256)
+
+    # Unwrap model
+    unwrap_beft_from_model(model)
+    self.assertFalse(utils.is_beft_enabled(model))
+
+  def test_peft_trainer_with_beft(self):
+    rngs = nnx.Rngs(0)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=rngs)
+    apply_beft_to_model(model, module_path=r".*w1|.*w2")
+
+    optimizer = optax.inject_hyperparams(optax.adamw)(learning_rate=1e-3)
+    config = peft_trainer.TrainingConfig(
+        eval_every_n_steps=2,
+        max_steps=10,
+        checkpoint_root_directory=f"{self.temp_path}/beft_test/checkpoints",
+    )
+
+    original_base_params = jax.tree.map(
+        jnp.copy, nnx.state(model, filterlib.Not(BEFTParam))
+    )
+    original_beft_params = jax.tree.map(
+        jnp.copy, nnx.state(model, BEFTParam)
+    )
+
+    trainer = peft_trainer.PeftTrainer(model, optimizer, config)
+    trainer = trainer.with_gen_model_input_fn(dummy_gen_model_input_fn)
+    trainer.train(self.train_ds, self.eval_ds, cache_nnx_graph=True)
+
+    trained_base_params = nnx.state(model, filterlib.Not(BEFTParam))
+    trained_beft_params = nnx.state(model, BEFTParam)
+
+    # 1. Base weights MUST remain strictly UNCHANGED
+    jax.tree.map_with_path(
+        tc.assert_equal, original_base_params, trained_base_params
+    )
+
+    # 2. BEFT trainable parameters MUST be UPDATED
+    jax.tree.map_with_path(
+        tc.assert_not_equal, original_beft_params, trained_beft_params
+    )
+
+  def test_beft_checkpoint_save_and_restore(self):
+    rngs = nnx.Rngs(0)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=rngs)
+    apply_beft_to_model(model, module_path=r".*w1|.*w2")
+
+    optimizer = nnx.Optimizer(
+        model, optax.adamw(learning_rate=1e-3), wrt=BEFTParam
+    )
+    ckpt_dir = f"{self.temp_path}/beft_ckpt_test"
+    ckpt_mgr = checkpoint_manager.CheckpointManager(root_directory=ckpt_dir)
+
+    # Mutate BEFT params to simulate training
+    for _, val in nnx.iter_graph(model):
+      if isinstance(val, BEFTParam):
+        val.value = val.value + 5.0
+
+    expected_beft_state = nnx.clone(nnx.state(model, BEFTParam))
+
+    saved = ckpt_mgr.save(
+        step=1,
+        model=model,
+        optimizer=optimizer,
+        param_type=BEFTParam,
+        force=True,
+    )
+    self.assertTrue(saved)
+
+    # Create fresh model with BEFT applied
+    new_model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=nnx.Rngs(0))
+    apply_beft_to_model(new_model, module_path=r".*w1|.*w2")
+    new_optimizer = nnx.Optimizer(
+        new_model, optax.adamw(learning_rate=1e-3), wrt=BEFTParam
+    )
+
+    restored_step, _ = ckpt_mgr.maybe_restore(
+        new_model,
+        new_optimizer,
+        restore_only_lora_params=True,
+        param_type=BEFTParam,
+    )
+    self.assertEqual(restored_step, 1)
+
+    restored_beft_state = nnx.state(new_model, BEFTParam)
+    jax.tree.map_with_path(
+        tc.assert_equal, expected_beft_state, restored_beft_state
+    )
+
+  def test_sampler_update_params_with_beft(self):
+    rngs = nnx.Rngs(0)
+    model = tc.ToyTransformer(config=tc.ModelConfig(), rngs=rngs)
+    apply_beft_to_model(model, module_path=r".*w1|.*w2")
+
+    vocab = tc.MockVocab()
+    s = sampler.Sampler(
+        transformer=model,
+        tokenizer=vocab,
+        cache_config=None,
+    )
+
+    # Update BEFT state
+    new_beft_state = jax.tree.map(
+        lambda x: x + 1.0, nnx.state(model, BEFTParam)
+    )
+    s.update_params(new_beft_state, (BEFTParam,))
+
+    current_beft_state = nnx.state(model, BEFTParam)
+    jax.tree.map_with_path(
+        tc.assert_equal, new_beft_state, current_beft_state
+    )
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/tunix/__init__.py
+++ b/tunix/__init__.py
@@ -61,9 +61,13 @@ from tunix.sft.dpo.dpo_trainer import DpoTrainingConfig
 from tunix.sft.dpo.dpo_trainer import ORPOTrainer
 from tunix.sft.dpo.dpo_trainer import OrpoTrainer
 from tunix.sft.dpo.dpo_trainer import ORPOTrainingConfig
-from tunix.sft.dpo.dpo_trainer import OrpoTrainingConfig
 from tunix.sft.metrics_logger import MetricsLogger
 from tunix.sft.metrics_logger import MetricsLoggerOptions
+from tunix.sft.peft.beft import apply_beft_to_model
+from tunix.sft.peft.beft import BEFTConfig
+from tunix.sft.peft.beft import BEFTLinear
+from tunix.sft.peft.beft import BEFTParam
+from tunix.sft.peft.beft import unwrap_beft_from_model
 from tunix.sft.peft_trainer import PeftTrainer
 
 # pylint: enable=g-multiple-import, g-importing-member

--- a/tunix/common/configs.py
+++ b/tunix/common/configs.py
@@ -264,6 +264,10 @@ class TrainingConfig:
   max_steps: int | None = None
   gradient_accumulation_steps: int | None = None
 
+  # Target variable type(s) for optimizer updates and gradient differentiation.
+  # If None, automatically inferred from model (e.g. BEFTParam, LoRAParam, or Param).
+  wrt: Any | None = None
+
   # If set, the checkpoints will be saved to this path. Checkpoints
   # contains the model params and the train data iterator state.
   checkpoint_root_directory: str | None = None

--- a/tunix/generate/sampler.py
+++ b/tunix/generate/sampler.py
@@ -331,18 +331,25 @@ class Sampler(base_sampler.BaseSampler):
       check_tree_structure(self._transformer_state, state)
       self._transformer_state = state
     else:
-      # LoRA state replacement.
-      if not (len(param_types) == 1 and nnx.LoRAParam in param_types):
+      # LoRA / PEFT state replacement.
+      from tunix.sft.peft.beft import BEFTParam  # pylint: disable=g-import-not-at-top
+      valid_peft_types = (nnx.LoRAParam, BEFTParam)
+      matched_types = [
+          t for t in param_types
+          if isinstance(t, type) and issubclass(t, valid_peft_types)
+      ]
+      if not (len(param_types) == 1 and matched_types):
         raise ValueError(
-            'Only LoRAParam is supported. Received invalid `param_types`: '
+            'Only LoRAParam or BEFTParam is supported. Received invalid `param_types`: '
             f'{param_types}'
         )
-      original_lora_params = statelib.filter_state(
-          self._transformer_state, nnx.LoRAParam
+      target_type = matched_types[0]
+      original_peft_params = statelib.filter_state(
+          self._transformer_state, target_type
       )
-      check_tree_structure(original_lora_params, state)
+      check_tree_structure(original_peft_params, state)
       base_state = statelib.filter_state(
-          self._transformer_state, filterlib.Not(nnx.LoRAParam)
+          self._transformer_state, filterlib.Not(target_type)
       )
       self._transformer_state = statelib.merge_state(base_state, state)
 

--- a/tunix/models/gemma/sampler.py
+++ b/tunix/models/gemma/sampler.py
@@ -227,18 +227,25 @@ class Sampler:
       check_tree_structure(self._transformer_state, state)
       self._transformer_state = state
     else:
-      # LoRA state replacement.
-      if not (len(param_types) == 1 and nnx.LoRAParam in param_types):
+      # LoRA / PEFT state replacement.
+      from tunix.sft.peft.beft import BEFTParam  # pylint: disable=g-import-not-at-top
+      valid_peft_types = (nnx.LoRAParam, BEFTParam)
+      matched_types = [
+          t for t in param_types
+          if isinstance(t, type) and issubclass(t, valid_peft_types)
+      ]
+      if not (len(param_types) == 1 and matched_types):
         raise ValueError(
-            'Only LoRAParam is supported. Received invalid `param_types`: '
+            'Only LoRAParam or BEFTParam is supported. Received invalid `param_types`: '
             f'{param_types}'
         )
-      original_lora_params = statelib.filter_state(
-          self._transformer_state, nnx.LoRAParam
+      target_type = matched_types[0]
+      original_peft_params = statelib.filter_state(
+          self._transformer_state, target_type
       )
-      check_tree_structure(original_lora_params, state)
+      check_tree_structure(original_peft_params, state)
       base_state = statelib.filter_state(
-          self._transformer_state, filterlib.Not(nnx.LoRAParam)
+          self._transformer_state, filterlib.Not(target_type)
       )
       self._transformer_state = statelib.merge_state(base_state, state)
 

--- a/tunix/rl/rl_cluster.py
+++ b/tunix/rl/rl_cluster.py
@@ -135,7 +135,12 @@ class RLEngine:
         self._load_model(critic, self.r2m[Role.CRITIC]) if critic else None
     )
     if Role.CRITIC in self._backbone_sharing_map[Role.ACTOR]:
-      critic_state = nnx.state(self.train_actor, filterlib.Not(nnx.LoRAParam))
+      peft_param_type = (
+          sft_utils.get_peft_param_type(self.train_actor) or nnx.LoRAParam
+      )
+      critic_state = nnx.state(
+          self.train_actor, filterlib.Not(peft_param_type)
+      )
       nnx.update(self.critic, critic_state)
     self.reward = (
         self._load_model(reward, self.r2m[Role.REWARD]) if reward else None
@@ -181,7 +186,7 @@ class RLEngine:
         reference and not isinstance(reference, nnx.Module)
     ):
       return
-    if sft_utils.is_lora_enabled(actor):
+    if sft_utils.is_peft_enabled(actor):
       if reference and self.r2m[Role.ACTOR] == self.r2m[Role.REFERENCE]:
         self._backbone_sharing_map[Role.ACTOR].append(Role.REFERENCE)
         self._backbone_sharing_map[Role.REFERENCE].append(Role.ACTOR)
@@ -516,9 +521,12 @@ class RLEngine:
             else self.inference_worker.get_model("reference")
         )
         if ref_model:
+          peft_param_type = (
+              sft_utils.get_peft_param_type(ref_model) or nnx.LoRAParam
+          )
           nnx.update(
               ref_model,
-              statelib.filter_state(params, filterlib.Not(nnx.LoRAParam)),
+              statelib.filter_state(params, filterlib.Not(peft_param_type)),
           )
       elif role == Role.ACTOR:
         actor_model = (
@@ -1172,10 +1180,11 @@ class RLEngine:
     else:
       cm = contextlib.nullcontext()
     with cm:
+      peft_param_type = sft_utils.get_peft_param_type(self.actor_trainer.model)
       filter_types = (
-          nnx.LoRAParam
-          if sft_utils.is_lora_enabled(self.actor_trainer.model)
-          else nnx.Param,
+          (peft_param_type,)
+          if peft_param_type is not None
+          else (nnx.Param,)
       )
       src_filtered_params = nnx.state(self.actor_trainer.model, filter_types)
       self.rollout.update_params(src_filtered_params, filter_types)

--- a/tunix/rl/utils.py
+++ b/tunix/rl/utils.py
@@ -126,8 +126,10 @@ def is_sharing_backbone(
     m2: nnx.Module,
 ) -> bool:
   """Returns whether two models are sharing same copy of backbone."""
-  s1 = nnx.state(m1, filterlib.Not(nnx.LoRAParam))
-  s2 = nnx.state(m2, filterlib.Not(nnx.LoRAParam))
+  from tunix.sft import utils as sft_utils  # pylint: disable=g-import-not-at-top
+  peft_param_type = sft_utils.get_peft_param_type(m1) or nnx.LoRAParam
+  s1 = nnx.state(m1, filterlib.Not(peft_param_type))
+  s2 = nnx.state(m2, filterlib.Not(peft_param_type))
   return _is_same_state(s1, s2)
 
 

--- a/tunix/sft/checkpoint_manager.py
+++ b/tunix/sft/checkpoint_manager.py
@@ -198,6 +198,7 @@ class CheckpointManager:
       save_only_lora_params: bool = False,
       force: bool = False,
       custom_metadata: Mapping[str, Any] | None = None,
+      param_type: Any | None = None,
   ) -> bool:
     """Saves the params for the given step.
 
@@ -210,6 +211,7 @@ class CheckpointManager:
       force: Whether to save the checkpoint regardless of the save decision
         policy.
       custom_metadata: Custom metadata to save with the checkpoint.
+      param_type: Specific parameter variable type to save (e.g. BEFTParam, LoRAParam).
 
     Returns:
       Whether the checkpoint save operation was successful if synchronous,
@@ -217,7 +219,9 @@ class CheckpointManager:
     """
     if self._checkpointer is None:
       return False
-    if save_only_lora_params:
+    if param_type is not None:
+      params = nnx.state(model, param_type)
+    elif save_only_lora_params:
       params = nnx.state(model, nnx.LoRAParam)
     else:
       params = nnx.state(model)
@@ -245,6 +249,7 @@ class CheckpointManager:
       optimizer: nnx.Optimizer | None = None,
       step: int | None = None,
       restore_only_lora_params: bool = False,
+      param_type: Any | None = None,
   ) -> tuple[int, Any]:
     """Restores the params from the latest checkpoint if available and updates the model provided.
 
@@ -256,6 +261,7 @@ class CheckpointManager:
       step: The step to restore the params from. If None, the latest step will
         be used.
       restore_only_lora_params: Whether to restore only the LoRA params.
+      param_type: Specific parameter variable type to restore (e.g. BEFTParam, LoRAParam).
 
     Returns:
       A tuple (step, custom_metadata), where step is the step of the restored
@@ -275,7 +281,11 @@ class CheckpointManager:
 
     metadata = self._checkpointer.checkpointables_metadata(step)
 
-    if restore_only_lora_params:
+    if param_type is not None:
+      model_params_state = nnx.state(model, param_type)
+      load_ctx = ocp.Context(self._context)
+      load_ctx.pytree.loading.partial_load = True
+    elif restore_only_lora_params:
       model_params_state = nnx.state(model, nnx.LoRAParam)
       # Partial (LoRA) restore is the one path that overrides the persistent
       # context to enable partial loading.

--- a/tunix/sft/peft/__init__.py
+++ b/tunix/sft/peft/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tunix PEFT modules and algorithms."""
+
+from tunix.sft.peft.beft import apply_beft_to_model
+from tunix.sft.peft.beft import BEFTConfig
+from tunix.sft.peft.beft import BEFTLinear
+from tunix.sft.peft.beft import BEFTParam
+from tunix.sft.peft.beft import unwrap_beft_from_model

--- a/tunix/sft/peft/beft.py
+++ b/tunix/sft/peft/beft.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""BEFT (Bias-Elevation Fine-Tuning) PEFT method for Tunix.
+
+BEFT (ACL 2026, https://arxiv.org/abs/2509.15974) is a parameter-efficient
+fine-tuning technique that trains only bias terms (specifically on value
+projections or target linear layers) while keeping all weight matrices frozen.
+If the underlying architecture is bias-free, BEFT injects and trains a 1D
+bias vector, achieving extreme parameter efficiency (<0.01% trainable parameters).
+"""
+
+import dataclasses
+import re
+from typing import Any, Sequence
+
+from absl import logging
+from flax import nnx
+import jax
+import jax.numpy as jnp
+
+
+class BEFTParam(nnx.Param):
+  """Flax NNX variable type for BEFT trainable parameters."""
+
+
+class BEFTLinear(nnx.Module):
+  """BEFT wrapper around a linear layer or projection module.
+
+  Elevates/adds a trainable bias vector (`BEFTParam`) to the wrapped base layer:
+    y = base_layer(x) + bias
+  """
+
+  def __init__(
+      self,
+      base_layer: nnx.Module,
+      bias_shape: tuple[int, ...] | None = None,
+      bias_init: nnx.Initializer = nnx.initializers.zeros_init(),
+      dtype: jnp.dtype = jnp.float32,
+      rngs: nnx.Rngs | None = None,
+  ):
+    """Initializes the BEFTLinear wrapper.
+
+    Args:
+      base_layer: The target linear/projection module to wrap.
+      bias_shape: The shape of the elevated bias vector. If None, inferred
+        from `base_layer.out_features` or `base_layer.kernel.shape[-1]`.
+      bias_init: Initializer for the bias parameter. Defaults to zeros.
+      dtype: Data type of the elevated bias vector. Defaults to float32.
+      rngs: Optional RNGs for parameter initialization.
+    """
+    self.base_layer = base_layer
+    if bias_shape is None:
+      if hasattr(base_layer, "out_features"):
+        bias_shape = (base_layer.out_features,)
+      elif hasattr(base_layer, "kernel") and hasattr(base_layer.kernel, "value"):
+        bias_shape = (base_layer.kernel.value.shape[-1],)
+      elif hasattr(base_layer, "w") and hasattr(base_layer.w, "value"):
+        bias_shape = (base_layer.w.value.shape[-1],)
+      else:
+        raise ValueError(
+            f"Could not automatically infer bias shape for layer {type(base_layer).__name__}. "
+            "Please provide explicit `bias_shape`."
+        )
+
+    if rngs is None:
+      bias_value = bias_init(jax.random.key(0), bias_shape, dtype)
+    else:
+      bias_value = bias_init(rngs.params(), bias_shape, dtype)
+
+    self.bias = BEFTParam(bias_value)
+
+  def __call__(self, *args, **kwargs) -> Any:
+    out = self.base_layer(*args, **kwargs)
+    return out + self.bias.value
+
+  def __getattr__(self, name: str) -> Any:
+    # Delegate attribute lookups to the inner base layer when not found on wrapper
+    base_layer = self.__dict__.get("base_layer")
+    if base_layer is not None and hasattr(base_layer, name):
+      return getattr(base_layer, name)
+    raise AttributeError(
+        f"'{type(self).__name__}' object has no attribute '{name}'"
+    )
+
+  def merge(self) -> None:
+    """Merges elevated BEFT bias into base_layer if base_layer has a bias."""
+    if hasattr(self.base_layer, "bias") and self.base_layer.bias is not None:
+      self.base_layer.bias.value = (
+          self.base_layer.bias.value + self.bias.value.astype(self.base_layer.bias.value.dtype)
+      )
+
+
+@dataclasses.dataclass
+class BEFTConfig:
+  """Configuration for applying BEFT to a model."""
+
+  module_path: str = r".*v_proj.*|.*qkv_einsum.*"
+  bias_init: nnx.Initializer = nnx.initializers.zeros_init()
+  dtype: jnp.dtype = jnp.float32
+
+
+def apply_beft_to_model(
+    model: nnx.Module,
+    config: BEFTConfig | None = None,
+    *,
+    module_path: str | None = None,
+    bias_init: nnx.Initializer | None = None,
+    dtype: jnp.dtype | None = None,
+    rngs: nnx.Rngs | None = None,
+) -> nnx.Module:
+  """Applies BEFT to matching layers of the given model in-place.
+
+  Args:
+    model: The root nnx.Module to traverse and wrap.
+    config: Optional BEFTConfig instance.
+    module_path: Regex pattern to match module paths. Overrides `config.module_path`.
+    bias_init: Initializer for bias. Overrides `config.bias_init`.
+    dtype: Data type for bias. Overrides `config.dtype`.
+    rngs: Optional NNX RNGs for parameter creation.
+
+  Returns:
+    The modified model with BEFT applied.
+  """
+  cfg = config or BEFTConfig()
+  target_path_regex = module_path if module_path is not None else cfg.module_path
+  target_bias_init = bias_init if bias_init is not None else cfg.bias_init
+  target_dtype = dtype if dtype is not None else cfg.dtype
+
+  compiled_pattern = re.compile(target_path_regex)
+
+  replacements: list[tuple[Sequence[str | int], BEFTLinear]] = []
+
+  for path, module in model.iter_modules():
+    path_str = ".".join(str(p) for p in path)
+    if compiled_pattern.search(path_str) and not isinstance(module, BEFTLinear):
+      # Wrap matching module
+      beft_wrapper = BEFTLinear(
+          base_layer=module,
+          bias_init=target_bias_init,
+          dtype=target_dtype,
+          rngs=rngs,
+      )
+      replacements.append((path, beft_wrapper))
+
+  logging.info(
+      "BEFT: Wrapping %d module(s) matching pattern '%s'",
+      len(replacements),
+      target_path_regex,
+  )
+
+  # Apply module replacements in-place
+  for path, wrapped_instance in replacements:
+    if not path:
+      raise ValueError("Attempted to wrap the root model with BEFT.")
+
+    current_parent = model
+    for part in path[:-1]:
+      if isinstance(part, str):
+        current_parent = getattr(current_parent, part)
+      elif isinstance(part, int):
+        current_parent = current_parent[part]
+      else:
+        raise TypeError(f"Unsupported path part type: {type(part)}")
+
+    last_key = path[-1]
+    if isinstance(last_key, str):
+      setattr(current_parent, last_key, wrapped_instance)
+    elif isinstance(last_key, int):
+      current_parent[last_key] = wrapped_instance
+    else:
+      raise TypeError(f"Unsupported key type: {type(last_key)}")
+
+  return model
+
+
+def unwrap_beft_from_model(model: nnx.Module) -> nnx.Module:
+  """Unwraps all `BEFTLinear` wrappers in the model in-place."""
+  replacements: list[tuple[Sequence[str | int], nnx.Module]] = []
+
+  for path, module in model.iter_modules():
+    if isinstance(module, BEFTLinear):
+      replacements.append((path, module.base_layer))
+
+  for path, base_layer in replacements:
+    if not path:
+      continue
+    current_parent = model
+    for part in path[:-1]:
+      if isinstance(part, str):
+        current_parent = getattr(current_parent, part)
+      elif isinstance(part, int):
+        current_parent = current_parent[part]
+      else:
+        raise TypeError(f"Unsupported path part type: {type(part)}")
+
+    last_key = path[-1]
+    if isinstance(last_key, str):
+      setattr(current_parent, last_key, base_layer)
+    elif isinstance(last_key, int):
+      current_parent[last_key] = base_layer
+    else:
+      raise TypeError(f"Unsupported key type: {type(last_key)}")
+
+  return model

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -365,7 +365,20 @@ class PeftTrainer:
     self.model = model
     self.config = training_config
     self._lora_enabled = utils.is_lora_enabled(self.model)
-    wrt_target = nnx.LoRAParam if self._lora_enabled else nnx.Param
+    self._beft_enabled = utils.is_beft_enabled(self.model)
+    self._peft_enabled = utils.is_peft_enabled(self.model)
+
+    if getattr(self.config, "wrt", None) is not None:
+      wrt_target = self.config.wrt
+    elif self._beft_enabled:
+      from tunix.sft.peft.beft import BEFTParam  # pylint: disable=g-import-not-at-top
+      wrt_target = BEFTParam
+    elif self._lora_enabled:
+      wrt_target = nnx.LoRAParam
+    else:
+      wrt_target = nnx.Param
+
+    self._wrt_target = wrt_target
     self.optimizer = nnx.Optimizer(self.model, optimizer, wrt=wrt_target)
      # Adam moments follow the param dtype by default (optax inits them as
     # zeros_like(params)).
@@ -415,7 +428,8 @@ class PeftTrainer:
         self.checkpoint_manager.maybe_restore(
             self.model,
             self.optimizer,
-            restore_only_lora_params=self._lora_enabled,
+            restore_only_lora_params=self._peft_enabled,
+            param_type=self._wrt_target if self._peft_enabled else None,
         )
     )
     self._iter_steps = self._train_steps * self.config.get_with_default(
@@ -526,7 +540,9 @@ class PeftTrainer:
 
     grad_fn = nnx.value_and_grad(
         diff_fn,
-        argnums=nnx.DiffState(0, nnx.LoRAParam) if self._lora_enabled else 0,
+        argnums=nnx.DiffState(0, self._wrt_target)
+        if (self._peft_enabled or getattr(self.config, "wrt", None) is not None)
+        else 0,
         has_aux=True,
     )
     (loss_val, aux), grads = grad_fn(model, **inputs)
@@ -1089,7 +1105,8 @@ class PeftTrainer:
               self._train_steps,
               self.model,
               self.optimizer,
-              save_only_lora_params=self._lora_enabled,
+              save_only_lora_params=self._peft_enabled,
+              param_type=self._wrt_target if self._peft_enabled else None,
               custom_metadata=self.custom_checkpoint_metadata(),
           )
 
@@ -1118,7 +1135,8 @@ class PeftTrainer:
           self._train_steps,
           self.model,
           self.optimizer,
-          save_only_lora_params=self._lora_enabled,
+          save_only_lora_params=self._peft_enabled,
+          param_type=self._wrt_target if self._peft_enabled else None,
           force=True,
       )
 

--- a/tunix/sft/utils.py
+++ b/tunix/sft/utils.py
@@ -77,6 +77,28 @@ def is_lora_enabled(model: nnx.Module) -> bool:
   return False
 
 
+def is_beft_enabled(model: nnx.Module) -> bool:
+  from tunix.sft.peft.beft import BEFTParam  # pylint: disable=g-import-not-at-top
+  for _, value in nnx.iter_graph(model):
+    if isinstance(value, BEFTParam):
+      return True
+  return False
+
+
+def is_peft_enabled(model: nnx.Module) -> bool:
+  return is_lora_enabled(model) or is_beft_enabled(model)
+
+
+def get_peft_param_type(model: nnx.Module) -> type[nnx.Variable] | None:
+  """Returns the active PEFT parameter type or None if full fine-tuning."""
+  from tunix.sft.peft.beft import BEFTParam  # pylint: disable=g-import-not-at-top
+  if is_beft_enabled(model):
+    return BEFTParam
+  if is_lora_enabled(model):
+    return nnx.LoRAParam
+  return None
+
+
 @contextlib.contextmanager
 def time_measure(context: str = "", suppress_logging: bool = False):
   start = time.perf_counter()


### PR DESCRIPTION
## Description
This PR addresses and closes #1490 by adding **BEFT (Bias-Elevation Fine-Tuning)** (ACL 2026) as a first-class PEFT method in Tunix and generalizing parameter filtering across Tunix's training, checkpointing, inference, and RL engines.

### Key Changes
1. **BEFT Implementation (	unix.sft.peft.beft)**:
   - BEFTParam(nnx.Param): Flax NNX variable type tagging trainable elevated bias parameters.
   - BEFTLinear(nnx.Module): Layer wrapper around linear/projection layers adding a trainable bias vector (\ = Wx + b\$) with attribute delegation and bias merging.
   - BEFTConfig, pply_beft_to_model(...) (in-place regex-targeted layer transformation), and unwrap_beft_from_model(...).
2. **Generalized Parameter Utilities & Configs (	unix.sft.utils, 	unix.common.configs)**:
   - Added is_beft_enabled, is_peft_enabled, and get_peft_param_type.
   - Added wrt field to TrainingConfig for custom parameter target specification.
3. **SFT Trainer & Checkpoint Engine (	unix.sft.peft_trainer, 	unix.sft.checkpoint_manager)**:
   - Updated PeftTrainer to optimize with respect to BEFTParam (or custom wrt targets) and compute gradients via 
nx.DiffState(0, self._wrt_target).
   - Updated CheckpointManager to support saving and restoring arbitrary param_type variables.
4. **Inference & RL Engine (	unix.generate.sampler, 	unix.models.gemma.sampler, 	unix.rl.rl_cluster, 	unix.rl.utils)**:
   - Generalized Sampler.update_params and RLCluster.sync_weights for any active PEFT parameter type.
5. **Unit Tests (	ests/sft/beft_test.py)**:
   - Added comprehensive tests covering BEFTLinear, model wrapping/unwrapping, PeftTrainer training (verifying backbone weights remain frozen while biases train), CheckpointManager save/restore, and Sampler updates.

Closes #1490