### PR TITLE
fix(scripts): fix checkpoint sharding restore, precompile CLI flag, and rollout sync in grpo demo

### DIFF
--- a/scripts/grpo_demo_llama3_qwen2.py
+++ b/scripts/grpo_demo_llama3_qwen2.py
@@ -68,12 +68,14 @@ show_hbm_usage = utils.show_hbm_usage
 
 print("This script is still WIP and try at your own discretion")
 
-# Disable precompilation for faster iteration, need to toggle it back for
-# official run
-os.environ["SKIP_JAX_PRECOMPILE"] = "1"
-
 # Parse command line options
 parser = argparse.ArgumentParser(description="Arguments for GRPO demo")
+parser.add_argument(
+    "--skip-jax-precompile",
+    action="store_true",
+    default=False,
+    help="Disable JAX precompilation for faster iteration.",
+)
 parser.add_argument(
     "--root-dir",
     type=str,
@@ -316,6 +318,11 @@ parser.add_argument(
 
 # Parse arguments
 args = parser.parse_args()
+
+if args.skip_jax_precompile:
+  os.environ["SKIP_JAX_PRECOMPILE"] = "1"
+else:
+  os.environ.pop("SKIP_JAX_PRECOMPILE", None)
 
 
 def validata_args():
@@ -1285,9 +1292,12 @@ trained_ckpt_path = os.path.join(
 )
 
 filter_type = nnx.LoRAParam if ENABLE_LORA else nnx.Param
+training_state = nnx.state(training_model, filter_type)
 abs_params = jax.tree.map(
-    lambda x: jax.ShapeDtypeStruct(x.shape, x.dtype),
-    nnx.state(training_model, filter_type),
+    lambda x: jax.ShapeDtypeStruct(
+        x.shape, x.dtype, sharding=getattr(x, "sharding", None)
+    ),
+    training_state,
 )
 checkpointer = ocp.StandardCheckpointer()
 trained_lora_params = checkpointer.restore(trained_ckpt_path, target=abs_params)
@@ -1296,10 +1306,15 @@ nnx.update(
     training_model,
     jax.tree.map(
         lambda a, b: b,
-        nnx.state(training_model, filter_type),
+        training_state,
         trained_lora_params,
     ),
 )
+
+# Synchronize restored weights to the rollout worker/sampler for post-training evaluation
+filter_types = (filter_type,)
+src_filtered_params = nnx.state(training_model, filter_types)
+rl_engine.rollout.update_params(src_filtered_params, filter_types)
 
 (eval_corr, eval_total, eval_accuracy, eval_partial_accuracy, eval_format_accuracy) = evaluate(  # pylint: disable=unbalanced-tuple-unpacking
     test_dataset,


### PR DESCRIPTION
## Description
This PR addresses issues observed when running GRPO with SGLang-JAX and Pathways (#874) by fixing checkpoint restore sharding, enabling static graph precompilation by default, and ensuring restored policy weights are synchronized to the rollout worker before post-training evaluation.

### Key Changes
1. **Orbax Checkpoint Sharding Restore Fix**:
   - Passed `sharding=getattr(x, "sharding", None)` to `jax.ShapeDtypeStruct` during checkpoint restoration.
   - Eliminates the `UserWarning: Sharding info not provided when restoring` warning and eliminates redundant metadata disk inspection overhead.
2. **Rollout Policy Weight Synchronization**:
   - Added `rl_engine.rollout.update_params(src_filtered_params, filter_types)` immediately after checkpoint restoration so that final evaluation accurately tests the trained/restored weights instead of stale initial rollout weights.
3. **Configurable JAX Precompilation (`--skip-jax-precompile`)**:
   - Replaced hardcoded `os.environ["SKIP_JAX_PRECOMPILE"] = "1"` with an optional CLI flag `--skip-jax-precompile` (defaulting to `False`), allowing static graph precompilation during official training/benchmarking runs to reduce step execution latency.

Closes #874
