### PR TITLE
feat(worker): add execution logging, and tune gRPC keepalives

### DIFF
--- a/tests/experimental/worker/remote_execution_test.py
+++ b/tests/experimental/worker/remote_execution_test.py
@@ -909,7 +909,7 @@ class RemoteExecutionTest(absltest.TestCase):
   def test_grpc_options_tolerate_client_keepalive_pings(self):
     options = dict(remote_lib._grpc_options())
     self.assertEqual(
-        options["grpc.http2.min_recv_ping_interval_without_data_ms"], 10000
+        options["grpc.http2.min_recv_ping_interval_without_data_ms"], 5000
     )
     self.assertEqual(options["grpc.http2.max_ping_strikes"], 0)
 

--- a/tunix/experimental/worker/remote_execution.py
+++ b/tunix/experimental/worker/remote_execution.py
@@ -88,8 +88,10 @@ def _grpc_options() -> List[Tuple[str, int]]:
       ("grpc.keepalive_time_ms", 20000),
       ("grpc.keepalive_timeout_ms", 10000),
       ("grpc.keepalive_permit_without_calls", 1),
-      ("grpc.http2.min_recv_ping_interval_without_data_ms", 10000),
+      ("grpc.http2.max_pings_without_data", 0),
       ("grpc.http2.max_ping_strikes", 0),
+      ("grpc.http2.min_ping_interval_without_data_ms", 5000),
+      ("grpc.http2.min_recv_ping_interval_without_data_ms", 5000),
   ]
 
 
@@ -246,7 +248,24 @@ class RemoteExecutionServer(abc.ABC):
     return request.request_id
 
   async def _run_and_enqueue(self, request: ExecutionRequest) -> None:
+    logging.debug(
+        "[RemoteExecutionServer] Starting task %s method=%s",
+        request.request_id,
+        request.method_name,
+    )
     response = await self.execute_request(request)
+    if response.error_message:
+      logging.error(
+          "[RemoteExecutionServer] Task %s failed: %s\n%s",
+          request.request_id,
+          response.error_message,
+          response.traceback,
+      )
+    else:
+      logging.debug(
+          "[RemoteExecutionServer] Task %s finished successfully",
+          request.request_id,
+      )
     await self._get_response_queue().put(response)
 
   async def poll_response(


### PR DESCRIPTION
## Summary                                                                                                                                                                                                  
                                                                                                                                                                                                                
This PR adds task execution logging with error tracebacks to `RemoteExecutionServer`, and tunes gRPC keepalive parameters to maintain stable worker connections during long compilation and weight-staging windows.                                                                                                              
 
 ## Motivation & Context                                                                                                                                                                                     
1. **gRPC Channel Drops on Long Idle / Compiles**: During long JAX model compilations or multi-gigabyte weight-staging phases, gRPC channels could disconnect due to ping-interval strictness or idle timeouts. Setting `max_pings_without_data=0`, `max_ping_strikes=0`, and `min_recv_ping_interval_without_data_ms=5000` ensures channels stay healthy.
2. **Task Failure Observability**: When a task failed on `RemoteExecutionServer`, error details were wrapped in `ExecutionResponse` without server-side error logging, making remote worker crash debugging difficult.

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
