### PR TITLE
feat(examples): integrate MaxText trainer backend into distributed GSM8K example

### DIFF
--- a/tests/experimental/examples/math_gsm8k_dist/run_trainer_node_test.py
+++ b/tests/experimental/examples/math_gsm8k_dist/run_trainer_node_test.py
@@ -160,7 +160,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
       mock_ensure_model_dir,
       mock_create_mesh,
       mock_load_actor_model,
-      mock_create_trainer,
+      mock_create_trainer_factory,
       mock_trainer_worker_cls,
       mock_grpc_server_cls,
   ):
@@ -168,7 +168,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     mock_mesh = mock.MagicMock(spec=Mesh)
     mock_create_mesh.return_value = mock_mesh
     mock_load_actor_model.return_value = mock.MagicMock()
-    mock_create_trainer.return_value = mock.MagicMock()
+    mock_create_trainer_factory.return_value = mock.MagicMock()
     mock_trainer_worker_cls.return_value = self.mock_worker_service
     mock_grpc_server_cls.return_value = self.mock_server
 
@@ -192,14 +192,14 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
   @mock.patch.object(run_trainer_node, "_ensure_model_dir_for_trainer")
   @mock.patch.object(run_trainer_node, "_create_mesh")
   @mock.patch.object(run_trainer_node, "_load_actor_model")
-  @mock.patch.object(run_trainer_node, "_create_trainer")
+  @mock.patch.object(run_trainer_node, "_create_trainer_factory")
   @mock.patch.object(trainer_worker, "TrainerWorker")
   @mock.patch.object(remote_execution, "GrpcRemoteExecutionServer")
   def test_shutdown_handler_drains_worker_on_sigterm(
       self,
       mock_grpc_server_cls,
       mock_trainer_worker_cls,
-      mock_create_trainer,
+      mock_create_trainer_factory,
       mock_load_actor_model,
       mock_create_mesh,
       mock_ensure_model_dir,
@@ -208,7 +208,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
         mock_ensure_model_dir,
         mock_create_mesh,
         mock_load_actor_model,
-        mock_create_trainer,
+        mock_create_trainer_factory,
         mock_trainer_worker_cls,
         mock_grpc_server_cls,
     )
@@ -237,14 +237,14 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
   @mock.patch.object(run_trainer_node, "_ensure_model_dir_for_trainer")
   @mock.patch.object(run_trainer_node, "_create_mesh")
   @mock.patch.object(run_trainer_node, "_load_actor_model")
-  @mock.patch.object(run_trainer_node, "_create_trainer")
+  @mock.patch.object(run_trainer_node, "_create_trainer_factory")
   @mock.patch.object(trainer_worker, "TrainerWorker")
   @mock.patch.object(remote_execution, "GrpcRemoteExecutionServer")
   def test_shutdown_handler_drains_worker_on_sigint(
       self,
       mock_grpc_server_cls,
       mock_trainer_worker_cls,
-      mock_create_trainer,
+      mock_create_trainer_factory,
       mock_load_actor_model,
       mock_create_mesh,
       mock_ensure_model_dir,
@@ -253,7 +253,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
         mock_ensure_model_dir,
         mock_create_mesh,
         mock_load_actor_model,
-        mock_create_trainer,
+        mock_create_trainer_factory,
         mock_trainer_worker_cls,
         mock_grpc_server_cls,
     )
@@ -279,14 +279,14 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
   @mock.patch.object(run_trainer_node, "_ensure_model_dir_for_trainer")
   @mock.patch.object(run_trainer_node, "_create_mesh")
   @mock.patch.object(run_trainer_node, "_load_actor_model")
-  @mock.patch.object(run_trainer_node, "_create_trainer")
+  @mock.patch.object(run_trainer_node, "_create_trainer_factory")
   @mock.patch.object(trainer_worker, "TrainerWorker")
   @mock.patch.object(remote_execution, "GrpcRemoteExecutionServer")
   def test_shutdown_handler_handles_drain_exception_and_stops_server(
       self,
       mock_grpc_server_cls,
       mock_trainer_worker_cls,
-      mock_create_trainer,
+      mock_create_trainer_factory,
       mock_load_actor_model,
       mock_create_mesh,
       mock_ensure_model_dir,
@@ -295,7 +295,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
         mock_ensure_model_dir,
         mock_create_mesh,
         mock_load_actor_model,
-        mock_create_trainer,
+        mock_create_trainer_factory,
         mock_trainer_worker_cls,
         mock_grpc_server_cls,
     )
@@ -319,14 +319,14 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
   @mock.patch.object(run_trainer_node, "_ensure_model_dir_for_trainer")
   @mock.patch.object(run_trainer_node, "_create_mesh")
   @mock.patch.object(run_trainer_node, "_load_actor_model")
-  @mock.patch.object(run_trainer_node, "_create_trainer")
+  @mock.patch.object(run_trainer_node, "_create_trainer_factory")
   @mock.patch.object(trainer_worker, "TrainerWorker")
   @mock.patch.object(remote_execution, "GrpcRemoteExecutionServer")
   def test_shutdown_ignores_not_implemented_error_on_add_signal_handler(
       self,
       mock_grpc_server_cls,
       mock_trainer_worker_cls,
-      mock_create_trainer,
+      mock_create_trainer_factory,
       mock_load_actor_model,
       mock_create_mesh,
       mock_ensure_model_dir,
@@ -335,7 +335,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
         mock_ensure_model_dir,
         mock_create_mesh,
         mock_load_actor_model,
-        mock_create_trainer,
+        mock_create_trainer_factory,
         mock_trainer_worker_cls,
         mock_grpc_server_cls,
     )
@@ -366,6 +366,22 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
 
     self.mock_worker_service.stop.assert_called_once()
     self.mock_server.stop_serving.assert_called_once()
+
+  @mock.patch.object(run_trainer_node, "_create_tunix_trainer_factory")
+  @mock.patch.object(run_trainer_node, "_create_maxtext_trainer_factory")
+  def test_create_trainer_factory_delegates_by_backend(
+      self, mock_create_maxtext, mock_create_tunix
+  ):
+    args_tunix = mock.MagicMock(trainer_backend="tunix")
+    run_trainer_node._create_trainer_factory(args_tunix)
+    mock_create_tunix.assert_called_once_with(args_tunix)
+    mock_create_maxtext.assert_not_called()
+
+    mock_create_tunix.reset_mock()
+    args_maxtext = mock.MagicMock(trainer_backend="maxtext")
+    run_trainer_node._create_trainer_factory(args_maxtext)
+    mock_create_maxtext.assert_called_once_with(args_maxtext)
+    mock_create_tunix.assert_not_called()
 
   def test_main_raises_without_discovery_context(self):
     with self.assertRaisesRegex(RuntimeError, "Require discovery API"):

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -14,12 +14,16 @@
 # limitations under the License.
 
 COMMAND=""
-TUNIX_IMAGE="us-central1-docker.pkg.dev/cloud-tpu-multipod-dev/yangmu/tunix/tunix_base_image:trellis-demo-0813"
+TUNIX_IMAGE=${TUNIX_IMAGE:-}
 
 export MODEL_NAME=${MODEL_NAME:-Qwen3-1.7B}
 export MODEL_ID=${MODEL_ID:-Qwen/Qwen3-1.7B}
-export MODEL_DIR=${MODEL_DIR:-artifacts/qwen3_dist_gsm8k/models}
-export TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_DIR}}
+# Must be model-specific: vLLM prioritizes non-empty local snapshot directories,
+# which can cause stale config/shape mismatches if shared across models.
+export MODEL_DIR=${MODEL_DIR:-artifacts/qwen3_dist_gsm8k/models/${MODEL_NAME}}
+# Defaults to MODEL_ID so AutoTokenizer downloads directly from HuggingFace
+# instead of failing on an initially empty local MODEL_DIR.
+export TOKENIZER_PATH=${TOKENIZER_PATH:-${MODEL_ID}}
 
 export MAX_PROMPT_LENGTH=${MAX_PROMPT_LENGTH:-512}
 export MAX_RESPONSE_LENGTH=${MAX_RESPONSE_LENGTH:-128}
@@ -27,11 +31,38 @@ export BATCH_SIZE=${BATCH_SIZE:-2}
 export NUM_GENERATIONS=${NUM_GENERATIONS:-2}
 export MAX_STEPS=${MAX_STEPS:-1}
 export TRAIN_MICRO_BATCH_SIZE=${TRAIN_MICRO_BATCH_SIZE:-1}
+
+# Set to tunix to run Tunix's PeftTrainer, and maxtext to run MaxText's MaxTextTrainingEngine
+export TRAINER_BACKEND=${TRAINER_BACKEND:-tunix}
 export MINI_BATCH_SIZE=${MINI_BATCH_SIZE:-$((BATCH_SIZE * NUM_GENERATIONS))}
 export EVAL_EVERY_N_STEPS=${EVAL_EVERY_N_STEPS:-1000000}
 export LORA_RANK=${LORA_RANK:-16}
 export LORA_ALPHA=${LORA_ALPHA:-16.0}
 export USE_LORA=${USE_LORA:-0}
+export DEBUG=${DEBUG:-0}
+export SAMPLER=${SAMPLER:-inprocess_vllm}
+
+# MaxText trainer configuration: only consulted when TRAINER_BACKEND=maxtext
+export MAXTEXT_MODEL_NAME=${MAXTEXT_MODEL_NAME:-qwen3-1.7b}
+export MAXTEXT_CKPT=${MAXTEXT_CKPT:-}
+# If TRAINER_BACKEND=maxtext, MAXTEXT_CKPT must be set to the path of an Orbax params-only checkpoint.
+if [[ "$TRAINER_BACKEND" == "maxtext" && -z "$MAXTEXT_CKPT" ]]; then
+  echo "Error: TRAINER_BACKEND=maxtext requires MAXTEXT_CKPT (Orbax params-only checkpoint)."
+  exit 1
+fi
+export MAXTEXT_OUTPUT_DIR=${MAXTEXT_OUTPUT_DIR:-artifacts/math_gsm8k_dist/maxtext}
+export TRAINER_MESH_TP=${TRAINER_MESH_TP:-1}
+export TRAINER_MESH_EXPERT=${TRAINER_MESH_EXPERT:-1}
+# Padded MoE MLP intermediate dimension; must match rollout TP padding for MoE models.
+export TRAINER_PADDED_MOE_MLP_DIM=${TRAINER_PADDED_MOE_MLP_DIM:-}
+export ROLLOUT_MESH_TP=${ROLLOUT_MESH_TP:-4}
+# Optional: enable experimental batched-RPA attention kernel for rollout.
+export ROLLOUT_USE_BATCHED_RPA=${ROLLOUT_USE_BATCHED_RPA:-}
+export ROLLOUT_MAXTEXT_ATTENTION=${ROLLOUT_MAXTEXT_ATTENTION:-}
+
+# Logs source/destination Raiden tensor checksums on both the trainer and
+# rollout sides during weight sync, for cross-verification of a real run.
+export VERIFY_WEIGHTS=${VERIFY_WEIGHTS:-false}
 
 export WANDB_PROJECT=${WANDB_PROJECT:-trellis-gsm8k}
 export WANDB_RUN_NAME=${WANDB_RUN_NAME:-}
@@ -46,6 +77,14 @@ export ROLLOUT_PORT=20001
 export TRAINER_ID=$USER-train
 export TRAINER_PORT=20002
 
+export CPU_MACHINE=${CPU_MACHINE:-n2-standard-64}
+export GCS_SCRATCH_LOCATION=${GCS_SCRATCH_LOCATION:-gs://cloud-pathways-staging/tmp}
+
+export TRAINER_JOBSET_YAML=${TRAINER_JOBSET_YAML:-jobset.pathways.yaml}
+export TRAINER_TPU_SLICE=${TRAINER_TPU_SLICE:-tpuv5:2x2x2}
+export TRAINER_MESH_FSDP=${TRAINER_MESH_FSDP:-8}
+export ROLLOUT_TPU_SLICE=${ROLLOUT_TPU_SLICE:-tpuv5:2x2x1}
+
 stop_orchestrator() {
   kubectl delete jobset "${ORCHESTRATOR_ID}"
 }
@@ -54,7 +93,7 @@ start_orchestrator() {
   python tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/jobset.cpu.yaml \
     --jobset_name="${ORCHESTRATOR_ID}" \
-    --cpu_machine=n2-standard-64 \
+    --cpu_machine=${CPU_MACHINE} \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ORCHESTRATOR_PORT}" \
     --worker_startup_command=" \
@@ -76,6 +115,7 @@ start_orchestrator() {
         --wandb_project=\"${WANDB_PROJECT}\" \
         --wandb_run_name=\"${WANDB_RUN_NAME}\" \
         --stop_workers_on_exit \
+        ${DEBUG:+--debug} \
     " \
     | kubectl apply -f -
 }
@@ -85,20 +125,34 @@ stop_trainer() {
 }
 
 start_trainer() {
+  local maxtext_args=""                                                                                                                                                                                     
+  if [[ "${TRAINER_BACKEND}" == "maxtext" ]]; then                                                                                                                               
+    maxtext_args=" \
+      --maxtext_model_name=${MAXTEXT_MODEL_NAME} \
+      ${TRAINER_PADDED_MOE_MLP_DIM:+--maxtext_padded_moe_mlp_dim=${TRAINER_PADDED_MOE_MLP_DIM}} \
+      --maxtext_ckpt_path=${MAXTEXT_CKPT} \
+      --maxtext_output_directory=${MAXTEXT_OUTPUT_DIR} \
+      --mesh_tp=${TRAINER_MESH_TP} \
+      --mesh_expert=${TRAINER_MESH_EXPERT} \
+    "                                                                                                                                                                                                       
+  fi
   python tunix/experimental/distributed/deployment/yaml_generator.py \
-    tunix/experimental/distributed/deployment/yamls/jobset.pathways.yaml \
+    tunix/experimental/distributed/deployment/yamls/${TRAINER_JOBSET_YAML} \
     --jobset_name="${TRAINER_ID}" \
-    --tpu_slice=tpuv5:2x2x2 \
+    --tpu_slice=${TRAINER_TPU_SLICE} \
+    --cpu_machine=${CPU_MACHINE} \
+    --pathways_gcs_scratch_location=${GCS_SCRATCH_LOCATION} \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
-      python -m tunix.experimental.distributed.runtime.main \
+      VERIFY_WEIGHTS=${VERIFY_WEIGHTS} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.math_gsm8k_dist.run_trainer_node.main \
         --worker_id=${TRAINER_ID} \
         --port=${TRAINER_PORT} \
-        --mesh_fsdp=8 \
+        --mesh_fsdp=${TRAINER_MESH_FSDP} \
+        --trainer_backend=${TRAINER_BACKEND} \
         --model_name=${MODEL_NAME} \
         --model_id=${MODEL_ID} \
         --model_dir=${MODEL_DIR} \
@@ -110,9 +164,10 @@ start_trainer() {
         --eval_every_n_steps=${EVAL_EVERY_N_STEPS} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
+        ${maxtext_args} \
+        ${DEBUG:+--debug} \
     " \
     | kubectl apply -f -
-
 }
 
 stop_rollout() {
@@ -120,14 +175,27 @@ stop_rollout() {
 }
 
 start_rollout() {
+  local maxtext_args=""                                                                                                                                                                             
+  if [[ "${TRAINER_BACKEND}" == "maxtext" ]]; then                                                                                                                               
+    maxtext_args=" \
+      --maxtext_model_name=${MAXTEXT_MODEL_NAME} \
+      ${ROLLOUT_MAXTEXT_ATTENTION:+--maxtext_attention=${ROLLOUT_MAXTEXT_ATTENTION}} \
+    "                                                                                                                                                                                                       
+  fi
+  local vllm_args=""
+  if [[ "$SAMPLER" == "vllm" ]]; then
+    vllm_args="\
+    --sampler_mesh_tp=${ROLLOUT_MESH_TP} \
+    "
+  fi
   python tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/jobset.tpu.yaml \
     --jobset_name="${ROLLOUT_ID}" \
-    --tpu_slice=tpuv5:2x2x1 \
+    --tpu_slice=${ROLLOUT_TPU_SLICE} \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ROLLOUT_PORT}" \
     --worker_startup_command=" \
-      SKIP_JAX_PRECOMPILE=1 python -m tunix.experimental.distributed.runtime.main \
+      SKIP_JAX_PRECOMPILE=1 VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${ROLLOUT_USE_BATCHED_RPA:+USE_BATCHED_RPA_KERNEL=1} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.math_gsm8k_dist.run_rollout_node.main \
@@ -140,6 +208,9 @@ start_rollout() {
         --max_response_length=${MAX_RESPONSE_LENGTH} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
+        ${maxtext_args} \
+        ${vllm_args} \
+        ${DEBUG:+--debug} \
     " \
     | kubectl apply -f -
 }
@@ -169,6 +240,13 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -z "$TUNIX_IMAGE" ]]; then
+  echo "Error: no image set. Build one with tunix, maxtext, and" \
+       "tpu-inference installed, then pass it via TUNIX_IMAGE=... or" \
+       "--image=..."
+  exit 1
+fi
 
 if [[ "$COMMAND" == "start" ]]; then
   stop_orchestrator

--- a/tunix/experimental/examples/math_gsm8k_dist/models.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/models.py
@@ -39,7 +39,9 @@ def _gemma_config(model_name: str) -> gemma_model_lib.ModelConfig:
 
 def _qwen3_config(model_name: str) -> qwen3_model_lib.ModelConfig:
   normalized = model_name.lower().replace("_", "-")
-  if "1.7b" in normalized or "1p7b" in normalized:
+  if "0.6b" in normalized or "0p6b" in normalized:
+    config = qwen3_model_lib.ModelConfig.qwen3_0p6b()
+  elif "1.7b" in normalized or "1p7b" in normalized:
     config = qwen3_model_lib.ModelConfig.qwen3_1p7b()
   elif "32b" in normalized:
     config = qwen3_model_lib.ModelConfig.qwen3_32b()

--- a/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
@@ -169,6 +169,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
   parser.add_argument("--rpc_timeout_s", type=float, default=1800.0)
   parser.add_argument("--inference_addr", type=str, default="")
   parser.add_argument("--stop_workers_on_exit", action="store_true")
+  parser.add_argument(
+      "--debug",
+      action="store_true",
+      help="Enable debug logging and print full sampler responses.",
+  )
   return parser.parse_args(argv)
 
 
@@ -224,7 +229,7 @@ def _build_gsm8k_dataset(args: argparse.Namespace) -> grain.MapDataset:
   )
 
 
-def _make_reward_fn(mode: str):
+def _make_reward_fn(mode: str, debug: bool = False):
   """Creates the optional orchestrator-side reward function."""
   if mode == "env":
     return None
@@ -235,6 +240,17 @@ def _make_reward_fn(mode: str):
     reward, _ = gsm8k.score_gsm8k_completion(
         text, metadata.get("answer", metadata.get("gold_answer"))
     )
+    if debug:
+      prompt_id = metadata.get("prompt_id", getattr(item, "group_id", "unknown"))
+      gold_answer = metadata.get("gold_answer")
+      logging.debug(
+          "[Orchestrator] Sampler response for %s:\n"
+          "[Sampled Response] ---\n%s\n--- [End Response] ---\n"
+          "Gold Answer: %s",
+          prompt_id,
+          text,
+          gold_answer,
+      )
     return reward
 
   return reward_fn
@@ -467,11 +483,14 @@ def main(argv: list[str], context: Any = None) -> None:
 
     match service_type:
       case "trainer":
-        trainer_addr_future.set_result(service_address)
+        if not trainer_addr_future.done():
+          trainer_addr_future.set_result(service_address)
       case "rollout":
-        rollout_addr_future.set_result(service_address)
+        if not rollout_addr_future.done():
+          rollout_addr_future.set_result(service_address)
       case "inference":
-        inference_addr_future.set_result(service_address)
+        if not inference_addr_future.done():
+          inference_addr_future.set_result(service_address)
       case _:
         raise RuntimeError(f"unknown service type {service_type}")
 
@@ -534,7 +553,7 @@ def main(argv: list[str], context: Any = None) -> None:
       },
   )
 
-  reward_fn = _make_reward_fn(args.reward_mode)
+  reward_fn = _make_reward_fn(args.reward_mode, args.debug)
   program = rl_program.StandardRLProgram(
       algo=algo,
       dataset=_iter_prompt_items(args),
@@ -567,6 +586,7 @@ def main(argv: list[str], context: Any = None) -> None:
     )
     cluster.run_program(
         program=program,
+        num_steps=args.max_steps,
         bring_up=False,
     )
   finally:

--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -70,10 +70,6 @@ def _chat_parser_for(model_id: str, tokenizer):
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
   """Parses command line arguments for the rollout worker process."""
-  from tunix.experimental.weight_sync import (  # pylint: disable=g-import-not-at-top
-      weight_sync,
-  )
-
   parser = argparse.ArgumentParser(description="vLLM rollout worker process")
   parser.add_argument("--port", type=int, default=20001)
   parser.add_argument("--worker_id", type=str, default="vllm-rollout-0")
@@ -104,16 +100,32 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       "--sampler",
       type=str,
       default=os.getenv("SAMPLER", "inprocess_vllm"),
-      choices=["inprocess_vllm", "vanilla"],
+      choices=["vllm", "inprocess_vllm", "vanilla"],
+      help="Rollout sampler backend: vllm, inprocess_vllm, or vanilla.",
+  )
+  parser.add_argument("--sampler_mesh_tp", type=int, default=4)
+  parser.add_argument(
+      "--maxtext_model_name",
+      type=str,
+      default="",
+      help=(
+          "MaxText model name (e.g. qwen3-0.6b) to load via"
+          " maxtext_vllm_adapter's MaxTextForCausalLM."
+      ),
   )
   parser.add_argument(
-      "--weight_sync_mode",
-      type=weight_sync.WeightSyncMode,
-      default=weight_sync.WeightSyncMode(
-          os.getenv("WEIGHT_SYNC_MODE", "raiden")
+      "--maxtext_attention",
+      type=str,
+      default="",
+      help=(
+          "Override MaxText inference attention kernel (e.g."
+          " vllm_batched_rpa)."
       ),
-      choices=list(weight_sync.WeightSyncMode),
-      help="Weight sync mode (e.g. raiden, fallback).",
+  )
+  parser.add_argument(
+      "--debug",
+      action="store_true",
+      help="Enable debug logging for rollout worker.",
   )
   return parser.parse_args(argv)
 
@@ -142,12 +154,6 @@ def _create_vanilla_worker(args, tokenizer):
   from tunix.experimental.rollout import (  # pylint: disable=g-import-not-at-top
       vanilla_sampler_adapter,
   )
-  from tunix.experimental.weight_sync import (  # pylint: disable=g-import-not-at-top
-      raiden_weight_sync_delegate,
-  )
-  from tunix.experimental.weight_sync import (  # pylint: disable=g-import-not-at-top
-      weight_sync,
-  )
   from tunix.experimental.worker import (  # pylint: disable=g-import-not-at-top
       rollout_worker,
   )
@@ -161,11 +167,6 @@ def _create_vanilla_worker(args, tokenizer):
     model = models.create_model(
         args.model_name, args.model_dir or args.model_id, mesh
     )
-  raiden_delegate = (
-      raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
-      if args.weight_sync_mode == weight_sync.WeightSyncMode.RAIDEN
-      else None
-  )
   config = rollout_worker.RolloutConfig(
       sampler_type="vanilla",
       weight_sync_mode=args.weight_sync_mode,
@@ -183,7 +184,6 @@ def _create_vanilla_worker(args, tokenizer):
       tokenizer=tokenizer,
       cache_config=args.max_prompt_length + args.max_response_length,
       config=config,
-      raiden_sync_delegate=raiden_delegate,
   )
 
   rollout_tokenizer = tokenizer_adapter_lib.TokenizerAdapter(tokenizer)
@@ -199,6 +199,33 @@ def _create_vanilla_worker(args, tokenizer):
 
 
 def _create_vllm_worker(args, tokenizer):
+  """Creates an in-process vLLM sampler rollout worker instance."""
+  from tunix.experimental.worker import (  # pylint: disable=g-import-not-at-top
+      rollout_worker,
+  )
+  from tunix.generate import (  # pylint: disable=g-import-not-at-top
+      tokenizer_adapter as tokenizer_adapter_lib,
+  )
+
+  if args.sampler == "vllm":
+    sampler_adapter, rollout_config = _create_vllm_sampler(args)
+  else:
+    sampler_adapter, rollout_config = _create_inprocess_vllm_sampler(args, tokenizer)
+
+  rollout_tokenizer = tokenizer_adapter_lib.TokenizerAdapter(tokenizer)
+  chat_parser = _chat_parser_for(args.model_id or args.model_name, tokenizer)
+  logging.info("Creating RolloutWorker wrapper...")
+  return rollout_worker.RolloutWorker(
+      worker_id=args.worker_id,
+      config=rollout_config,
+      sampler=sampler_adapter,
+      tokenizer=rollout_tokenizer,
+      chat_parser=chat_parser,
+      max_concurrency=64,
+  )
+
+
+def _create_inprocess_vllm_sampler(args, tokenizer):
   """Creates an in-process vLLM sampler rollout worker instance."""
   vllm_sampler = _import_vllm_sampler()
   import jax  # pylint: disable=g-import-not-at-top
@@ -276,9 +303,7 @@ def _create_vllm_worker(args, tokenizer):
       config=vllm_config,
       weight_sync_mode=args.weight_sync_mode,
   )
-  rollout_tokenizer = tokenizer_adapter_lib.TokenizerAdapter(tokenizer)
-  chat_parser = _chat_parser_for(args.model_id or args.model_name, tokenizer)
-  logging.info("Creating RolloutWorker wrapper...")
+  
   config = rollout_worker.RolloutConfig(
       sampler_type="inprocess_vllm",
       weight_sync_mode=args.weight_sync_mode,
@@ -291,14 +316,84 @@ def _create_vllm_worker(args, tokenizer):
       env_name=gsm8k.GSM8K_ENV_NAME,
       agent_name=gsm8k.GSM8K_AGENT_NAME,
   )
-  return rollout_worker.RolloutWorker(
-      worker_id=args.worker_id,
-      config=config,
-      sampler=sampler_adapter,
-      tokenizer=rollout_tokenizer,
-      chat_parser=chat_parser,
-      max_concurrency=args.max_concurrency,
+  return sampler_adapter, config
+
+
+def _create_vllm_sampler(args):
+  """Creates a vLLM sampler rollout worker instance."""
+  from tunix.experimental.rollout import vllm_sampler_adapter  # pylint: disable=g-import-not-at-top
+  from tunix.experimental.worker import rollout_worker  # pylint: disable=g-import-not-at-top
+  from vllm.engine.arg_utils import AsyncEngineArgs  # pylint: disable=g-import-not-at-top
+
+  vllm_model = (
+      args.model_dir
+      if (
+          args.model_dir
+          and os.path.exists(args.model_dir)
+          and any(os.scandir(args.model_dir))
+      )
+      else args.model_id
   )
+  max_model_len = args.max_prompt_length + args.max_response_length
+  logging.info(
+      "Creating vLLM RLVllmSampler config for model=%s tensor_parallel_size=%d "
+      "max_model_len=%d...",
+      vllm_model,
+      args.sampler_mesh_tp,
+      max_model_len,
+  )
+  engine_kwargs = dict(
+      model=vllm_model,
+      tokenizer=args.tokenizer_path or vllm_model,
+      tensor_parallel_size=args.sampler_mesh_tp,
+      max_model_len=max_model_len,
+      trust_remote_code=True,
+      dtype="bfloat16",
+      enable_lora=args.use_lora,
+      max_lora_rank=args.lora_rank if args.use_lora else None,
+      max_loras=1 if args.use_lora else None,
+  )
+  if args.maxtext_model_name:
+    logging.info(
+        "Loading MaxText model %r natively via maxtext_vllm_adapter's"
+        " MaxTextForCausalLM (architectures override).",
+        args.maxtext_model_name,
+    )
+    engine_kwargs["hf_overrides"] = {"architectures": ["MaxTextForCausalLM"]}
+    # MaxText inference config. prefuse_moe_weights is left False so rollout
+    # variable names match unfused trainer parameters during weight sync.
+    maxtext_config_overrides = {
+        "model_name": args.maxtext_model_name,
+        "model_call_mode": "inference",
+        "enable_dp_attention": False,
+        "allow_split_physical_axes": True,
+        "log_config": False,
+        "weight_dtype": "bfloat16",
+    }
+    if args.maxtext_attention:
+      maxtext_config_overrides["attention"] = args.maxtext_attention
+    engine_kwargs["additional_config"] = {
+        "maxtext_config": maxtext_config_overrides
+    }
+  engine_args = AsyncEngineArgs(**engine_kwargs)
+  sampler_adapter = vllm_sampler_adapter.VllmSamplerAdapter(
+      server_id=args.worker_id,
+      engine_args=engine_args,
+      model_name=vllm_model,
+  )
+  config = rollout_worker.RolloutConfig(
+      sampler_type="vllm",
+      weight_sync_mode=args.weight_sync_mode,
+      max_prompt_length=args.max_prompt_length,
+      max_tokens_to_generate=args.max_response_length,
+      temperature=1.0,
+      top_p=1.0,
+      return_logprobs=True,
+      rollout_vllm_model_version=vllm_model,
+      env_name=gsm8k.GSM8K_ENV_NAME,
+      agent_name=gsm8k.GSM8K_AGENT_NAME,
+  )
+  return sampler_adapter, config
 
 
 def main(argv: list[str], context: Any = None) -> None:
@@ -318,12 +413,14 @@ def main(argv: list[str], context: Any = None) -> None:
   args = _parse_args(argv)
   logging.info("Parsed args: %s", args)
 
-  if context:
+  if context and args.sampler != "vllm":
     context.jax.initialize()
   os.environ.setdefault("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1")
   os.environ.setdefault("VLLM_TPU_RPA_VERSION", "2")
   os.environ.setdefault("DISABLE_MOSAIC_ATTN", "1")
   os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+  if args.maxtext_model_name:
+    os.environ.setdefault("NEW_MODEL_DESIGN", "1")
   if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
   logging.info("Repo root inserted into sys.path: %s", REPO_ROOT)
@@ -353,6 +450,17 @@ def main(argv: list[str], context: Any = None) -> None:
     server = remote_execution.GrpcRemoteExecutionServer(worker_service)
     await server.start_serving_async(args.port)
     logging.info("Serving vLLM rollout worker on port %d.", args.port)
+
+    if args.sampler != "vanilla":
+      # Eagerly start the sampler engine so all pods in a multihost rollout
+      # jobset join the JAX distributed group at startup rather than lazily.
+      logging.info("Eagerly starting sampler engine...")
+      await worker_service.sampler.start()
+      logging.info("Sampler engine started.")
+      if hasattr(worker_service.sampler, "bind_weight_sync"):
+        logging.info("Eagerly warming up Raiden weight sync...")
+        await worker_service.sampler.bind_weight_sync()
+        logging.info("Raiden weight sync warmed up.")
 
     context.ipc.discovery.register(
         metadata=pickle.dumps({

--- a/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
@@ -28,6 +28,7 @@ import signal
 import sys
 from typing import Any
 
+from flax import nnx
 import jax
 from jax import numpy as jnp
 from jax.experimental import mesh_utils
@@ -39,6 +40,7 @@ from tunix.experimental.examples.math_gsm8k_dist import models
 from tunix.experimental.train import peft_trainer_v2
 from tunix.experimental.worker import remote_execution
 from tunix.experimental.worker import trainer_worker
+from tunix.utils import maxtext_utils
 
 REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
@@ -65,6 +67,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
   parser.add_argument("--tokenizer_path", type=str, default="")
   parser.add_argument("--mesh_fsdp", type=int, default=2)
   parser.add_argument("--mesh_tp", type=int, default=1)
+  parser.add_argument("--mesh_expert", type=int, default=1)
   parser.add_argument("--max_prompt_length", type=int, default=1024)
   parser.add_argument("--max_response_length", type=int, default=1024)
   parser.add_argument("--mini_batch_size", type=int, default=2)
@@ -84,6 +87,45 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       default=os.getenv(
           "CHECKPOINT_ROOT_DIRECTORY",
           os.path.join(REPO_ROOT, "checkpoints"),
+      ),
+  )
+  parser.add_argument(
+      "--trainer_backend",
+      choices=("tunix", "maxtext"),
+      default="tunix",
+      help=(
+          "tunix runs Tunix's PeftTrainer; maxtext runs MaxTextTrainingEngine"
+      ),
+  )
+  parser.add_argument("--maxtext_model_name", type=str, default="qwen3-0.6b")
+  parser.add_argument(
+      "--maxtext_padded_moe_mlp_dim",
+      type=int,
+      default=0,
+      help=(
+          "Explicit padded_base_moe_mlp_dim override to match rollout TP"
+          " tile-alignment padding for MoE models."
+      ),
+  )
+  parser.add_argument(
+      "--maxtext_ckpt_path",
+      type=str,
+      default=os.getenv("MAXTEXT_CKPT", ""),
+      help="Orbax params-only checkpoint for the MaxText trainer, e.g. gs://...",
+  )
+  parser.add_argument(
+        "--maxtext_output_directory",
+        type=str,
+        default=os.getenv("MAXTEXT_OUTPUT_DIR", os.path.join(REPO_ROOT, "artifacts", "math_gsm8k_dist", "maxtext")),
+        help="Base directory for MaxText trainer outputs.",
+    )
+  parser.add_argument(
+      "--maxtext_warmup_steps_fraction",
+      type=float,
+      default=0.0,
+      help=(
+          "Warmup fraction for MaxText LR schedule (0.0 enables updates from"
+          " step 0)."
       ),
   )
   return parser.parse_args(argv)
@@ -235,45 +277,50 @@ class _MeshBoundTrainer:
       self._trainer.close()
 
 
-def _create_trainer(
-    args,
-    actor_model: Any,
-    training_config: peft_trainer_v2.TrainingConfig,
-    mesh: Mesh,
-) -> _MeshBoundTrainer:
-  with mesh:
-    trainer = peft_trainer_v2.PeftTrainer(
-        actor_model,
-        optax.adamw(learning_rate=args.learning_rate),
-        training_config,
-    )
-  return _MeshBoundTrainer(trainer, mesh)
-
-
-def main(argv: list[str], context: Any = None) -> None:
-  if context and context.ipc and context.ipc.discovery:
-    pass
-  else:
-    raise RuntimeError(
-        "Require discovery API, but process context doesn't support."
-    )
-
-  logging.basicConfig(
-      level=logging.INFO,
-      format="%(asctime)s - [TrainerNode] %(message)s",
-      force=True,
+def _create_maxtext_trainer_factory(args) -> Any:
+  """Creates the trainer factory function for MaxText's MaxTextTrainingEngine."""
+  logging.info("Trainer backend: MaxText's MaxTextTrainingEngine.")
+  pad_id = maxtext_utils.tokenizer_pad_id(
+      args.model_id, args.tokenizer_path, args.model_dir
   )
+  maxtext_config = maxtext_utils.build_maxtext_config(
+      model_name=args.maxtext_model_name,
+      worker_id=args.worker_id,
+      train_micro_batch_size=args.train_micro_batch_size,
+      mesh_fsdp=args.mesh_fsdp,
+      mesh_tp=args.mesh_tp,
+      mesh_expert=args.mesh_expert,
+      num_devices=jax.device_count(),
+      max_prompt_length=args.max_prompt_length,
+      max_response_length=args.max_response_length,
+      learning_rate=args.learning_rate,
+      warmup_steps_fraction=args.maxtext_warmup_steps_fraction,
+      load_parameters_path=args.maxtext_ckpt_path,
+      padded_moe_mlp_dim=args.maxtext_padded_moe_mlp_dim,
+      base_output_directory=args.maxtext_output_directory,
+  )
+  logging.info("Creating MaxText device mesh...")
+  mesh = maxtext_utils.create_maxtext_mesh(maxtext_config)
+  logging.info("Trainer mesh: %s", mesh)
 
-  args = _parse_args(argv)
-  logging.info("Parsed args: %s", args)
+  def _factory():
+    engine = maxtext_utils.create_maxtext_engine(
+        maxtext_config,
+        mesh=mesh,
+        tokenizer_pad_id=pad_id,
+        wrap_with_tunix_adapter=True,
+    )
+    return _MeshBoundTrainer(engine, mesh)
 
-  if context:
-    context.jax.initialize()
-  if REPO_ROOT not in sys.path:
-    sys.path.insert(0, REPO_ROOT)
-  logging.info("Repo root inserted into sys.path: %s", REPO_ROOT)
+  return _factory
 
-  args.model_dir = _ensure_model_dir_for_trainer(args.model_dir, args.model_id)
+
+def _create_tunix_trainer_factory(args) -> Any:
+  """Creates the trainer factory function for Tunix's PeftTrainer."""
+  logging.info("Trainer backend: Tunix's PeftTrainer.")
+  args.model_dir = _ensure_model_dir_for_trainer(
+      args.model_dir, args.model_id
+  )
   logging.info("Prepared trainer safetensors directory: %s", args.model_dir)
 
   logging.info("Creating trainer mesh...")
@@ -284,8 +331,6 @@ def main(argv: list[str], context: Any = None) -> None:
   actor_model = _load_actor_model(args, mesh, lora=args.use_lora)
 
   logging.info("Building PeftTrainer v2 config...")
-  if args.train_micro_batch_size <= 0:
-    raise ValueError("--train_micro_batch_size must be positive.")
   grad_accumulation_steps = max(
       1, math.ceil(args.mini_batch_size / args.train_micro_batch_size)
   )
@@ -307,11 +352,55 @@ def main(argv: list[str], context: Any = None) -> None:
       grad_accumulation_steps,
   )
 
+  def _factory():
+    with mesh:
+      trainer = peft_trainer_v2.PeftTrainer(
+          actor_model,
+          optax.adamw(learning_rate=args.learning_rate),
+          training_config,
+      )
+    return _MeshBoundTrainer(trainer, mesh)
+
+  return _factory
+
+
+def _create_trainer_factory(args) -> Any:
+  """Creates the trainer factory function based on args.trainer_backend."""
+  if args.trainer_backend == "maxtext":
+    return _create_maxtext_trainer_factory(args)
+  return _create_tunix_trainer_factory(args)
+
+
+def main(argv: list[str], context: Any = None) -> None:
+  if context and context.ipc and context.ipc.discovery:
+    pass
+  else:
+    raise RuntimeError(
+        "Require discovery API, but process context doesn't support."
+    )
+
+  logging.basicConfig(
+      level=logging.INFO,
+      format="%(asctime)s - [RolloutNode] %(message)s",
+      force=True,
+  )
+
+  args = _parse_args(argv)
+  logging.info("Parsed args: %s", args)
+
+  if context:
+    context.jax.initialize()
+  if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+  logging.info("Repo root inserted into sys.path: %s", REPO_ROOT)
+
+  if args.train_micro_batch_size <= 0:
+    raise ValueError("--train_micro_batch_size must be positive.")
+
   logging.info("Creating generic TrainerWorker and gRPC server...")
+  trainer_factory = _create_trainer_factory(args)
   worker_service = trainer_worker.TrainerWorker(
-      trainer_factory=lambda: _create_trainer(  # pyrefly: ignore[bad-argument-type]
-          args, actor_model, training_config, mesh
-      ),
+      trainer_factory=trainer_factory,
       worker_id=args.worker_id,
   )
 

--- a/tunix/utils/maxtext_utils.py
+++ b/tunix/utils/maxtext_utils.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MaxText model configuration and runtime utilities."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+
+def maxtext_modules():
+  """Imports MaxText lazily; some installs nest it under maxtext.src.maxtext."""
+  try:
+    from maxtext.configs import pyconfig  # pylint: disable=g-import-not-at-top
+    from maxtext.training_engine import maxtext_engine  # pylint: disable=g-import-not-at-top
+    from maxtext.utils import maxtext_utils  # pylint: disable=g-import-not-at-top
+  except ImportError:  # pragma: no cover - layout-dependent
+    from maxtext.src.maxtext.configs import pyconfig  # pylint: disable=g-import-not-at-top
+    from maxtext.src.maxtext.training_engine import maxtext_engine  # pylint: disable=g-import-not-at-top
+    from maxtext.src.maxtext.utils import maxtext_utils  # pylint: disable=g-import-not-at-top
+  return pyconfig, maxtext_engine, maxtext_utils
+
+
+def tokenizer_pad_id(
+    model_id: str,
+    tokenizer_path: str = "",
+    model_dir: str = "",
+) -> int:
+  """Resolves the pad token id the MaxText adapter masks with."""
+  from transformers import AutoTokenizer  # pylint: disable=g-import-not-at-top
+
+  path = tokenizer_path or model_dir or model_id
+  tokenizer = AutoTokenizer.from_pretrained(path, trust_remote_code=True)
+  if tokenizer.pad_token_id is None and tokenizer.eos_token is not None:
+    tokenizer.pad_token = tokenizer.eos_token
+  return tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
+
+
+def build_maxtext_config(
+    model_name: str,
+    worker_id: str = "",
+    train_micro_batch_size: int = 1,
+    mesh_fsdp: int = 1,
+    mesh_tp: int = 1,
+    mesh_expert: int = 1,
+    num_devices: int = 1,
+    max_prompt_length: int = 512,
+    max_response_length: int = 128,
+    learning_rate: float = 1e-5,
+    warmup_steps_fraction: float = 0.0,
+    load_parameters_path: str = "",
+    padded_moe_mlp_dim: int = 0,
+    base_output_directory: str = "",
+) -> Any:
+  """Builds the MaxText HyperParameters the training engine runs on."""
+  pyconfig, _, _ = maxtext_modules()
+
+  if train_micro_batch_size % mesh_fsdp:
+    raise ValueError(
+        f"train_micro_batch_size={train_micro_batch_size} must be a multiple of "
+        f"mesh_fsdp={mesh_fsdp}; MaxText shards the batch dimension across it."
+    )
+  per_device_batch_size = train_micro_batch_size / num_devices
+
+  base_yml = os.path.join(
+      os.path.dirname(os.path.abspath(pyconfig.__file__)), "base.yml"
+  )
+  if not os.path.exists(base_yml):
+    raise FileNotFoundError(f"MaxText base.yml not found at {base_yml}")
+
+  output_dir = base_output_directory or "/tmp/maxtext"
+  enable_checkpointing = bool(load_parameters_path)
+  argv = [
+      "maxtext_trainer",
+      base_yml,
+      f"model_name={model_name}",
+      f"run_name={worker_id or 'tunix_maxtext'}",
+      f"base_output_directory={output_dir}",
+      f"enable_checkpointing={enable_checkpointing}",
+  ]
+  if load_parameters_path:
+    argv.append(f"load_parameters_path={load_parameters_path}")
+  argv.extend([
+      "scan_layers=True",
+      "convert_checkpoint_if_possible=False",
+      "skip_jax_distributed_system=True",
+      f"per_device_batch_size={per_device_batch_size}",
+      "gradient_accumulation_steps=1",
+      f"max_target_length={max_prompt_length + max_response_length}",
+      "attention=dot_product",
+      "use_tokamax_gmm=true",
+      "use_gmm_v2=true",
+      f"ici_fsdp_parallelism={mesh_fsdp}",
+      *(
+          [f"padded_base_moe_mlp_dim={padded_moe_mlp_dim}"]
+          if padded_moe_mlp_dim
+          else []
+      ),
+      f"ici_tensor_parallelism={mesh_tp}",
+      f"ici_expert_parallelism={mesh_expert}",
+      f"learning_rate={learning_rate}",
+      f"warmup_steps_fraction={warmup_steps_fraction}",
+      "dtype=bfloat16",
+      "weight_dtype=bfloat16",
+      "grad_dtype=float32",
+      "enable_tensorboard=False",
+      "record_internal_nn_metrics=False",
+      "init_weights_seed=42",
+  ])
+  logging.info("MaxText config argv: %s", argv)
+  return pyconfig.initialize(argv)
+
+
+def create_maxtext_mesh(maxtext_config: Any) -> Any:
+  """Builds the JAX device Mesh with axis names from MaxText config."""
+  from jax.sharding import Mesh  # pylint: disable=g-import-not-at-top
+
+  _, _, m_utils = maxtext_modules()
+  devices = m_utils.create_device_mesh(maxtext_config)
+  return Mesh(devices, maxtext_config.mesh_axes)
+
+
+def log_param_shapes(model: Any) -> None:
+  """Logs parameter shapes as a sanity check that weights loaded correctly."""
+  from flax import nnx  # pylint: disable=g-import-not-at-top
+
+  flat = nnx.to_pure_dict(nnx.state(model, nnx.Param))
+
+  def walk(node, path=""):
+    if isinstance(node, dict):
+      for key, value in node.items():
+        yield from walk(value, f"{path}.{key}" if path else str(key))
+    elif hasattr(node, "shape"):
+      yield path, node.shape
+
+  shapes = dict(walk(flat))
+  for name, shape in shapes.items():
+    if "wi_0" in name or "query" in name:
+      logging.info("MaxText param %s shape=%s", name, shape)
+  logging.info("MaxText model has %d parameter arrays.", len(shapes))
+
+
+def create_maxtext_engine(
+    maxtext_config: Any,
+    mesh: Any,
+    tokenizer_pad_id: int = 0,
+    wrap_with_tunix_adapter: bool = True,
+    log_shapes: bool = True,
+) -> Any:
+  """Builds and initializes a MaxTextTrainingEngine within the given mesh."""
+  _, maxtext_engine, _ = maxtext_modules()
+
+  with mesh:
+    engine = maxtext_engine.MaxTextTrainingEngine(
+        maxtext_config,
+        mesh=mesh,
+        wrap_with_tunix_adapter=wrap_with_tunix_adapter,
+        tokenizer_pad_id=tokenizer_pad_id,
+    )
+
+  model_type = type(engine.model).__name__
+  logging.info(
+      "MaxText engine model: %s (pad_id=%d)", model_type, tokenizer_pad_id
+  )
+  if wrap_with_tunix_adapter and model_type != "TunixMaxTextAdapter":
+    raise RuntimeError(
+        f"Expected the engine's model to be TunixMaxTextAdapter, got {model_type}."
+    )
+  if log_shapes:
+    log_param_shapes(engine.model)
+
+  return engine


### PR DESCRIPTION
This PR integrates the MaxText training backend into the distributed GSM8K GRPO training example `tunix/experimental/examples/math_gsm8k_dist/`.                                                                                                                                                             
                                                                                                                                                                                                                
## Key Highlights                                                                                                                                                                                           
1. **MaxText Training Engine Support**:                                                                                                                                                                     
    - Added `--trainer_backend=maxtext` support via `MaxTextTrainingEngine` in run_trainer_node.py, enabling model training with MaxText's native sharded optimizer states and Orbax checkpoint restoration.                                                                                                                                                       
    - Added `--maxtext_padded_moe_mlp_dim` override to align MoE tensor shapes between trainer and rollout workers for Raiden weight synchronization.                                                        
                                                                                                                                                                                                                
2. **Unified Sampler Interface & Native vLLM**:                                                                                                                                                             
   - Consolidated rollout sampler options in run_rollout_node.py under a unified `--sampler` argument (`"vllm"`, `"inprocess_vllm"`, `"vanilla"`).
   - Added native async vLLM sampler support (`VllmSamplerAdapter`) with optional `MaxTextForCausalLM` architecture overrides (`--maxtext_model_name`) and `vllm_batched_rpa` attention kernels (`--maxtext_attention`).
   - Added eager sampler engine initialization at rollout startup to prevent multi-host JAX deadlocks.
  
3. **Shared Model Construction**:
   - Added `qwen3-0.6b` / `0p6b` support to models.py.

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
