### PR TITLE
Add MaxText and Raiden optional dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 # Upgrade pip
 RUN pip install --upgrade pip
 
+RUN pip install uv
 RUN pip install git+https://github.com/ayaka14732/jax-smi.git
 # If you encounter a checkpoint issue, try using following old version of pathways-utils.
 # RUN pip install git+https://github.com/AI-Hypercomputer/pathways-utils.git@b72729bb152b7b3426299405950b3af300d765a9#egg=pathwaysutils
@@ -36,6 +37,27 @@ COPY . .
 RUN pip install -e .
 
 RUN bash /app/scripts/install_tunix_vllm_requirement.sh
+
+# Build argument to conditionally install MaxText dependencies
+ARG INSTALL_MAXTEXT=false
+
+# Install MaxText specific dependencies conditionally
+RUN if [ "$INSTALL_MAXTEXT" = "true" ]; then \
+      uv pip install -r /app/requirements/maxtext_requirements.txt --torch-backend=cpu; \
+    fi
+
+# Build argument to conditionally install Raiden weight sync dependencies
+ARG INSTALL_RAIDEN=false
+
+# Install Raiden specific dependencies conditionally
+RUN if [ "$INSTALL_RAIDEN" = "true" ]; then \
+      if [ -d "/app/raiden_wheels" ] && ls /app/raiden_wheels/*.whl 1>/dev/null 2>&1; then \
+        pip install --force-reinstall --no-deps /app/raiden_wheels/*.whl; \
+      else \
+        pip install keyrings.google-artifactregistry-auth && \
+        pip install tpu-raiden-jax --extra-index-url https://us-python.pkg.dev/cloud-tpu-inference-test/tpu-raiden/simple/; \
+      fi; \
+    fi
 
 # Build argument to conditionally install DeepSWE evaluation dependencies
 ARG INSTALL_DEEPSWE_DEPS=false

--- a/requirements/maxtext_requirements.txt
+++ b/requirements/maxtext_requirements.txt
@@ -1,0 +1,14 @@
+maxtext @ git+https://github.com/AI-Hypercomputer/maxtext.git@8c2e29218c01b6287ba85e8d0dc9555561f7634c
+maxtext-vllm-adapter @ git+https://github.com/AI-Hypercomputer/maxtext.git@8c2e29218c01b6287ba85e8d0dc9555561f7634c#subdirectory=src/maxtext/integration/vllm
+aqtp
+tokamax>=0.0.4
+drjax>=0.1.4
+ml-goodput-measurement
+cloud-accelerator-diagnostics
+cloud-tpu-diagnostics
+google-cloud-mldiagnostics>=0.5.10
+google-cloud-monitoring
+einshape
+typeguard
+xprof
+cheroot

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,2 @@
-vllm @ git+https://github.com/vllm-project/vllm.git@9842d701450214d4b78cd9aefb8eee0c616bce33
+vllm @ git+https://github.com/vllm-project/vllm.git@d626108b1841888ec90aced33367149a6bbc7e4b
 

--- a/requirements/special_requirements.txt
+++ b/requirements/special_requirements.txt
@@ -2,5 +2,4 @@
 # --find-links https://storage.googleapis.com/jax-releases/libtpu_releases.html
 # --pre
 
-tpu-inference @ git+https://github.com/vllm-project/tpu-inference.git@12eed6e661a1ffacbce9d107a9894c1a471e7479
-
+tpu-inference @ git+https://github.com/vllm-project/tpu-inference.git@4a8951606026d5c0307554bc4ed93f4690c4640a


### PR DESCRIPTION
### Summary
  
This PR adds modular build support for MaxText and Raiden dependencies in Dockerfile via conditional build arguments (INSTALL_MAXTEXT and INSTALL_RAIDEN), allowing reproducible container builds for distributed RL workloads without bloating or breaking the standard base image.

### Key Changes
1. Dockerfile:
   - Installs uv directly in the virtual environment (/opt/venv).
   - Adds ARG `INSTALL_MAXTEXT=false` to conditionally install MaxText/Flax training dependencies from requirements/maxtext_requirements.txt.
   - Adds `ARG INSTALL_RAIDEN=false` to conditionally install Raiden weight synchronization wheels (/app/raiden_wheels/*.whl) or `tpu-raiden-jax` from Google Artifact Registry.
2. requirements/maxtext_requirements.txt (maxtext_requirements.txt):
   - Defines standalone dependencies required for running MaxText trainer backends (e.g. maxtext, flax, optax).
3. requirements/special_requirements.txt (special_requirements.txt):
   - Pins compatible package versions for distributed RL runtimes.
4. tunix/oss/utils.py (utils.py):
   - Refines OSS utility helper imports and formatting.


### Tests
Nightly regression tests: https://github.com/google/tunix/actions/runs/33435227159
  
**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
