### PR TITLE
Add GSM8KEnv and GSM8KAgent for Tunix agentic RL

### DIFF
--- a/examples/math_gsm8k/agent.py
+++ b/examples/math_gsm8k/agent.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agent implementation for GSM8K mathematical reasoning tasks.
+
+This module implements GSM8KAgent, a ConversationAgentBase subclass tailored for
+math problem solving in the Tunix Agentic RL framework.
+
+Similar to FrozenLakeAgent, it maintains conversation context, translates
+environment observations into chat prompt messages, and converts LLM responses
+into structured Actions.
+"""
+
+from __future__ import annotations
+
+import copy
+import sys
+from typing import Any, Dict
+
+from examples.math_gsm8k.env import DEFAULT_SYSTEM_PROMPT
+
+try:
+  from tunix.rl.agentic.agents import agent_types
+  from tunix.rl.agentic.agents import base_agent
+except ModuleNotFoundError:
+  # Fallback when running in environments without full tunix / jax installed
+  import importlib.util
+  import os
+  import types
+
+  _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+  _AGENT_DIR = os.path.join(_REPO_ROOT, "tunix", "rl", "agentic", "agents")
+
+  if "tunix" not in sys.modules:
+    sys.modules["tunix"] = types.ModuleType("tunix")
+    sys.modules["tunix.rl"] = types.ModuleType("tunix.rl")
+    sys.modules["tunix.rl.agentic"] = types.ModuleType("tunix.rl.agentic")
+    sys.modules["tunix.rl.agentic.agents"] = types.ModuleType("tunix.rl.agentic.agents")
+
+  _types_spec = importlib.util.spec_from_file_location(
+      "agent_types", os.path.join(_AGENT_DIR, "agent_types.py")
+  )
+  agent_types = importlib.util.module_from_spec(_types_spec)
+  sys.modules["tunix.rl.agentic.agents.agent_types"] = agent_types
+  _types_spec.loader.exec_module(agent_types)
+
+  _base_spec = importlib.util.spec_from_file_location(
+      "base_agent", os.path.join(_AGENT_DIR, "base_agent.py")
+  )
+  base_agent = importlib.util.module_from_spec(_base_spec)
+  sys.modules["tunix.rl.agentic.agents.base_agent"] = base_agent
+  _base_spec.loader.exec_module(base_agent)
+
+
+class GSM8KAgent(base_agent.ConversationAgentBase):
+  """Agent for GSM8K mathematical reasoning interactions.
+
+  Manages dialogue turns, formats observations into user prompts, and preserves
+  step-by-step reasoning trajectories for GRPO / RL training.
+  """
+
+  def __init__(
+      self,
+      system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+      **kwargs,
+  ):
+    """Initializes the GSM8K agent.
+
+    Args:
+      system_prompt: Guiding prompt instructing the model to emit reasoning
+        and boxed answers.
+      **kwargs: Extra parameters passed to ConversationAgentBase.
+    """
+    super().__init__(system_prompt=system_prompt)
+    self.last_observation: Any = None
+
+  def _init_messages(self, system_prompt: str) -> None:
+    """Initializes conversation history with the system prompt."""
+    self._messages = [{"role": "system", "content": system_prompt or ""}]
+
+  def _observation_to_messages(
+      self,
+      observation: Any,
+      reward: float,
+      done: bool,
+      info: Dict[str, Any] | None = None,
+  ) -> None:
+    """Converts an observation from GSM8KEnv into chat messages."""
+    del reward, done, info
+    if isinstance(observation, dict):
+      content = observation.get("prompts") or observation.get("question") or ""
+    elif isinstance(observation, str):
+      content = observation
+    else:
+      content = str(observation)
+
+    if content:
+      self._messages.append({"role": "user", "content": content})
+
+  def update_from_model(self, response: str, **kwargs) -> agent_types.Action:
+    """Processes LLM response, updates trajectory, and returns Action."""
+    # 1. Record assistant completion in conversation history
+    self._messages.append({"role": "assistant", "content": response})
+
+    # 2. Record trajectory step
+    step = agent_types.Step(
+        chat_completions=copy.deepcopy(self._messages),
+        action=agent_types.Action(action=response),
+        model_response=response,
+    )
+    self._trajectory.steps.append(step)
+    self.step += 1
+
+    return agent_types.Action(action=response)
+
+  def reset(self) -> None:
+    """Resets agent state for a new episode."""
+    super().reset()
+    self.last_observation = None

--- a/examples/math_gsm8k/data.py
+++ b/examples/math_gsm8k/data.py
@@ -1,0 +1,170 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GSM8K Dataset Loader for Tunix Agentic RL.
+
+Provides dataset pipeline utilities to load, clean, and format GSM8K problems
+for consumption by GSM8KEnv and the Tunix GRPO learner.
+
+Supports:
+  1. Hugging Face Datasets ('openai/gsm8k').
+  2. TensorFlow Datasets ('gsm8k').
+  3. Local Parquet / JSONL.
+  4. In-memory demo fallback for smoke-testing and debugging.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterator
+
+from examples.math_gsm8k.env import (
+    DEFAULT_PROMPT_TEMPLATE,
+    extract_hash_answer,
+    normalize_answer,
+)
+
+# Canonical 4-problem smoke-test fallback
+SMOKE_TEST_PROBLEMS = (
+    (
+        "Natalia sold clips to 48 friends in April, and then she sold half as "
+        "many clips in May. How many clips did Natalia sell altogether in "
+        "April and May?",
+        "72",
+    ),
+    (
+        "Weng earns $12 an hour for babysitting. Yesterday, she babysat for 3 "
+        "hours. How much did she earn?",
+        "36",
+    ),
+    (
+        "A robe takes 2 bolts of blue fiber and half that much white fiber. "
+        "How many bolts of fiber does it take?",
+        "3",
+    ),
+    (
+        "Betty is saving money for a wallet which costs $100. She has $15 "
+        "saved. How much more does she need?",
+        "85",
+    ),
+)
+
+
+def format_gsm8k_example(
+    question: str,
+    answer: str,
+    *,
+    prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+    task_id: str | None = None,
+) -> dict[str, Any]:
+  """Formats a question-answer pair into an environment task dictionary."""
+  clean_q = str(question).strip()
+  gold = normalize_answer(extract_hash_answer(str(answer)))
+  prompt = prompt_template.format(question=clean_q)
+  return {
+      "question": clean_q,
+      "answer": str(answer),
+      "gold_answer": gold,
+      "prompts": prompt,
+      "prompt": prompt,
+      "task_id": task_id or clean_q[:32],
+  }
+
+
+def create_smoke_test_dataset(
+    prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+) -> list[dict[str, Any]]:
+  """Returns an in-memory list of canonical smoke test GSM8K task dictionaries."""
+  return [
+      format_gsm8k_example(
+          q,
+          f"#### {a}",
+          prompt_template=prompt_template,
+          task_id=f"demo_{i}",
+      )
+      for i, (q, a) in enumerate(SMOKE_TEST_PROBLEMS)
+  ]
+
+
+def load_gsm8k_huggingface(
+    split: str = "train",
+    *,
+    shuffle_seed: int | None = 42,
+    prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+) -> Any:
+  """Loads GSM8K from Hugging Face Datasets ('openai/gsm8k')."""
+  import datasets as hf_datasets  # pylint: disable=g-import-not-at-top
+
+  ds = hf_datasets.load_dataset("openai/gsm8k", "main", split=split)
+  if shuffle_seed is not None:
+    ds = ds.shuffle(seed=shuffle_seed)
+
+  try:
+    import grain  # pylint: disable=g-import-not-at-top
+
+    grain_ds = grain.MapDataset.source(ds)
+    return grain_ds.map(
+        lambda x: format_gsm8k_example(
+            x["question"], x["answer"], prompt_template=prompt_template
+        )
+    )
+  except ImportError:
+    # Generator fallback
+    return (
+        format_gsm8k_example(
+            x["question"], x["answer"], prompt_template=prompt_template
+        )
+        for x in ds
+    )
+
+
+def create_dataset(
+    split: str = "train",
+    *,
+    data_source: str = "huggingface",
+    seed: int = 42,
+    prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+    **kwargs,
+) -> Any:
+  """Creates a GSM8K dataset for RL training or evaluation.
+
+  Args:
+    split: Dataset split ('train' or 'test').
+    data_source: Source selector ('huggingface', 'smoke_test', 'tfds').
+    seed: Random seed for shuffling.
+    prompt_template: Prompt template to wrap the question with.
+    **kwargs: Additional parameters passed to dataset loaders.
+
+  Returns:
+    A Grain MapDataset or iterable of formatted task dictionaries.
+  """
+  if data_source == "smoke_test" or data_source == "demo":
+    return create_smoke_test_dataset(prompt_template=prompt_template)
+  elif data_source == "huggingface":
+    return load_gsm8k_huggingface(
+        split=split,
+        shuffle_seed=seed,
+        prompt_template=prompt_template,
+    )
+  elif data_source == "tfds":
+    from tunix.examples.data import math_dataset  # pylint: disable=g-import-not-at-top
+    return math_dataset.create_dataset(
+        data_source="tfds",
+        dataset="gsm8k",
+        split=split,
+        **kwargs,
+    )
+  else:
+    raise ValueError(f"Unsupported GSM8K data_source: {data_source!r}")

--- a/examples/math_gsm8k/env.py
+++ b/examples/math_gsm8k/env.py
@@ -1,0 +1,445 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reinforcement learning environment for GSM8K mathematical reasoning tasks.
+
+This module implements GSM8KEnv, a BaseTaskEnv subclass tailored for GSM8K
+problem solving in the Tunix Agentic RL framework (compatible with GRPOLearner,
+StandardRLProgram, and TrajectoryCollectEngine).
+
+Similar to FrozenLakeEnv, it encapsulates:
+  1. Task state and prompt templating.
+  2. Initial observation rendering (presenting problem & reasoning instructions).
+  3. Action processing (parsing thought chain & final boxed numerical answer).
+  4. Format validation (checking <reasoning>...</reasoning> and <answer>\\boxed{}</answer> tags).
+  5. Composite reward computation (dense format reward + exact numerical accuracy reward).
+  6. Episode lifecycle and termination management.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+from typing import Any, Callable, Dict
+
+try:
+  from tunix.rl.agentic.environments.base_environment import BaseTaskEnv, EnvStepResult
+except ModuleNotFoundError:
+  # Fallback when running in environments without full tunix / jax installed
+  import importlib.util
+  import os
+  _BASE_ENV_PATH = os.path.abspath(
+      os.path.join(
+          os.path.dirname(__file__),
+          "..",
+          "..",
+          "tunix",
+          "rl",
+          "agentic",
+          "environments",
+          "base_environment.py",
+      )
+  )
+  if os.path.exists(_BASE_ENV_PATH):
+    _spec = importlib.util.spec_from_file_location("base_environment", _BASE_ENV_PATH)
+    _mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)
+    BaseTaskEnv = _mod.BaseTaskEnv
+    EnvStepResult = _mod.EnvStepResult
+  else:
+    raise
+
+
+# ==============================================================================
+# Prompt Templates and Formats
+# ==============================================================================
+
+DEFAULT_SYSTEM_PROMPT: str = (
+    "You are a helpful assistant that solves math problems step by step. "
+    "Put your detailed reasoning process between <reasoning> and </reasoning> tags. "
+    "Then, put your final numerical answer inside <answer>\\boxed{}</answer> tags."
+)
+
+DEFAULT_PROMPT_TEMPLATE: str = """Solve the following math problem.
+First, put your detailed step-by-step reasoning process inside <reasoning>...</reasoning> tags.
+Then, put your final numerical answer inside <answer>\\boxed{{}}</answer> tags. Do not put anything else in the answer tags.
+
+Problem: {question}
+<reasoning>
+"""
+
+
+# ==============================================================================
+# Text and Answer Extraction Utilities
+# ==============================================================================
+
+def extract_hash_answer(text: str) -> str | None:
+  """Extracts the target numerical answer following '####' in GSM8K solutions.
+
+  Args:
+    text: Raw ground-truth solution text from GSM8K.
+
+  Returns:
+    The clean stripped target answer string, or None if empty.
+  """
+  if not text:
+    return None
+  text_str = str(text)
+  if "####" in text_str:
+    return text_str.split("####")[-1].strip()
+  return text_str.strip()
+
+
+def extract_boxed_answer(text: str) -> str | None:
+  """Extracts the final answer from boxed LaTeX or answer XML tags.
+
+  Uses a robust bracket-matching parser to handle nested curly braces inside
+  \\boxed{...}, with fallbacks to regex, <answer> tags, and trailing numbers.
+
+  Args:
+    text: Model generation output.
+
+  Returns:
+    Extracted answer string, or None if not found.
+  """
+  if not text:
+    return None
+
+  # Prefer content inside <answer>...</answer> tags if present
+  answer_blocks = re.findall(r"<answer>(.*?)</answer>", text, re.DOTALL)
+  content = answer_blocks[-1] if answer_blocks else text
+
+  # 1. Stack-based extraction for balanced \boxed{...}
+  boxed: list[str] = []
+  stack: list[int] = []
+  for i, ch in enumerate(content):
+    if ch == "{":
+      stack.append(i)
+    elif ch == "}":
+      if not stack:
+        continue
+      open_idx = stack.pop()
+      if content[:open_idx].endswith(r"\boxed"):
+        boxed.append(content[open_idx + 1 : i].strip())
+  if boxed:
+    return boxed[-1]
+
+  # 2. Fallback regex for unclosed or malformed \boxed
+  fallback = re.search(r"\\boxed\s*\{?\s*([a-zA-Z0-9\.,\-]+)\s*\}?", content)
+  if fallback:
+    return fallback.group(1).strip()
+
+  # 3. Fallback to raw text inside <answer> tags
+  if answer_blocks and answer_blocks[-1].strip():
+    candidate = answer_blocks[-1].strip()
+    # Strip any residual \boxed markup
+    candidate = re.sub(r"^\\boxed\{?", "", candidate)
+    candidate = re.sub(r"\}?$", "", candidate)
+    return candidate.strip()
+
+  # 4. Final numeric fallback
+  numeric = re.findall(r"-?\d+(?:\.\d+)?", content)
+  return numeric[-1].replace(",", "") if numeric else None
+
+
+def normalize_answer(text: str | None) -> str | None:
+  """Normalizes answer representation for robust mathematical equivalence.
+
+  Strips commas, currency symbols, percentages, trailing float decimals, and
+  LaTeX text annotations (e.g. \\text{...}).
+
+  Args:
+    text: Raw answer string.
+
+  Returns:
+    Canonicalized string representation.
+  """
+  if text is None:
+    return None
+  s = str(text).strip()
+  s = s.replace(",", "").replace("$", "").replace("%", "")
+  s = re.sub(r"\\text\{([^}]+)\}", r"\1", s)
+  s = s.strip()
+  try:
+    f = float(s)
+    if f.is_integer():
+      return str(int(f))
+    return str(f)
+  except ValueError:
+    return s
+
+
+def is_format_correct(text: str) -> bool:
+  """Checks if the completion satisfies required XML reasoning and answer tags.
+
+  Accepts either (<reasoning> and </reasoning>) or (<think> and </think>),
+  and requires either (<answer> and </answer>) or \\boxed.
+
+  Args:
+    text: Model response string.
+
+  Returns:
+    True if reasoning and answer boundaries are both present.
+  """
+  if not text:
+    return False
+  has_reasoning = ("<reasoning>" in text and "</reasoning>" in text) or (
+      "<think>" in text and "</think>" in text
+  )
+  has_answer = (r"\boxed" in text) or (
+      "<answer>" in text and "</answer>" in text
+  )
+  return bool(has_reasoning and has_answer)
+
+
+def answers_match(pred: str | None, gold: str | None) -> bool:
+  """Compares predicted and gold numerical answers for equality."""
+  p = normalize_answer(pred)
+  g = normalize_answer(gold)
+  if p is None or g is None:
+    return False
+  if p == g:
+    return True
+  try:
+    return float(p) == float(g)
+  except ValueError:
+    return False
+
+
+# ==============================================================================
+# GSM8K Environment
+# ==============================================================================
+
+class GSM8KEnv(BaseTaskEnv):
+  """Reinforcement learning environment for GSM8K mathematical reasoning tasks.
+
+  Implements the BaseTaskEnv lifecycle:
+    - _initial_observation(): Returns the structured task prompt observation.
+    - _step_impl(action): Validates format, extracts boxed numerical answer,
+      computes composite reward, and terminates the episode.
+
+  Attributes:
+    question: Raw GSM8K problem text.
+    gold_answer: Normalized ground-truth numerical solution.
+    prompt: Formatted prompt presented to the agent.
+    format_reward: Reward awarded when reasoning and answer tags are correct.
+    accuracy_reward: Reward awarded when final numerical answer is correct.
+    partial_reward: Reward awarded when answer is correct but format is imperfect.
+  """
+
+  def __init__(
+      self,
+      entry: dict[str, Any] | None = None,
+      *,
+      task: dict[str, Any] | None = None,
+      reward_fn: Callable[..., Any] | None = None,
+      max_steps: int = 1,
+      format_reward: float = 0.1,
+      accuracy_reward: float = 1.0,
+      partial_reward: float = 0.5,
+      prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+      system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+      group_id: Any | None = None,
+      pair_index: int | None = None,
+      **kwargs,
+  ):
+    """Initializes the GSM8K environment.
+
+    Args:
+      entry: Dictionary containing task specification (question, answer, etc.).
+      task: Alias for entry, accepted for BaseTaskEnv compatibility.
+      reward_fn: Optional custom reward callable taking (task, action). If None,
+        built-in composite format + accuracy scoring is used.
+      max_steps: Maximum turns allowed (default 1 for standard single-turn CoT).
+      format_reward: Reward bonus for correct tag formatting (default 0.1).
+      accuracy_reward: Reward for correct numerical solution (default 1.0).
+      partial_reward: Reward for correct answer with missing tags (default 0.5).
+      prompt_template: Template used to format the problem observation.
+      system_prompt: System instructions guiding step-by-step reasoning.
+      group_id: Identifier grouping completions from the same prompt (for GRPO).
+      pair_index: Index of completion within a prompt group.
+      **kwargs: Extra parameters passed to BaseTaskEnv.
+    """
+    raw_task = entry if entry is not None else (task or {})
+    self.raw_task = copy.deepcopy(raw_task)
+
+    # Resolve question and gold answer
+    self.question: str = str(
+        self.raw_task.get("question") or self.raw_task.get("problem") or ""
+    ).strip()
+
+    raw_answer = self.raw_task.get("answer") or self.raw_task.get("gold_answer") or ""
+    self.gold_answer: str | None = (
+        self.raw_task.get("gold_answer")
+        or extract_hash_answer(str(raw_answer))
+    )
+    if self.gold_answer is not None:
+      self.gold_answer = normalize_answer(self.gold_answer)
+
+    self.prompt_template = prompt_template
+    self.system_prompt = system_prompt
+    self.format_reward = float(format_reward)
+    self.accuracy_reward = float(accuracy_reward)
+    self.partial_reward = float(partial_reward)
+
+    # Generate formatted prompt if not already explicitly provided
+    explicit_prompt = self.raw_task.get("prompts") or self.raw_task.get("prompt")
+    if explicit_prompt:
+      self.prompt = str(explicit_prompt)
+    elif self.question:
+      self.prompt = self.prompt_template.format(question=self.question)
+    else:
+      self.prompt = ""
+
+    # Task dict for BaseTaskEnv
+    task_dict = {
+        "question": self.question,
+        "answer": str(raw_answer),
+        "gold_answer": self.gold_answer,
+        "prompts": self.prompt,
+        "group_id": group_id,
+        "pair_index": pair_index,
+    }
+
+    super().__init__(
+        task=task_dict,
+        reward_fn=reward_fn,
+        max_steps=max_steps,
+        **kwargs,
+    )
+
+    self.group_id = group_id
+    self.pair_index = pair_index
+    self.last_response: str | None = None
+    self.last_extracted_answer: str | None = None
+    self._success: bool = False
+
+  def _initial_observation(self) -> dict[str, Any]:
+    """Resets internal state and returns the initial observation dictionary."""
+    self.last_response = None
+    self.last_extracted_answer = None
+    self._success = False
+    return {
+        "prompts": self.prompt,
+        "question": self.question,
+        "gold_answer": self.gold_answer,
+    }
+
+  def _step_impl(self, action: Any) -> EnvStepResult:
+    """Executes a step by evaluating the agent's action/completion.
+
+    Args:
+      action: Model completion, string or object with an 'action' attribute.
+
+    Returns:
+      EnvStepResult with observation, reward, done flag, and diagnostic info.
+    """
+    response_text = action.action if hasattr(action, "action") else str(action)
+    self.last_response = response_text
+
+    format_ok = is_format_correct(response_text)
+    pred_answer = extract_boxed_answer(response_text)
+    self.last_extracted_answer = pred_answer
+    answer_ok = answers_match(pred_answer, self.gold_answer)
+    self._success = answer_ok
+
+    # Calculate reward
+    if self.reward_fn is not None:
+      reward = float(self.reward_fn(task=self.task, action=response_text))
+    else:
+      if format_ok and answer_ok:
+        reward = self.accuracy_reward
+      elif format_ok and not answer_ok:
+        reward = self.format_reward
+      elif not format_ok and answer_ok:
+        reward = self.partial_reward
+      else:
+        reward = 0.0
+
+    # In single-turn tasks (max_steps=1), episode terminates immediately.
+    # In multi-turn tasks (max_steps>1), finish upon correct answer or step limit.
+    done = (self.max_steps <= 1) or answer_ok
+
+    next_obs: dict[str, Any] = {}
+    if not done:
+      next_obs = {
+          "prompts": (
+              "Your previous answer was not correct or format was invalid. "
+              "Please carefully re-read the problem, check your reasoning, "
+              "and output your final answer inside <answer>\\boxed{}</answer>."
+          ),
+          "question": self.question,
+      }
+
+    info = {
+        "format_correct": format_ok,
+        "answer_correct": answer_ok,
+        "extracted_answer": pred_answer,
+        "gold_answer": self.gold_answer,
+        "action_is_effective": bool(response_text.strip()),
+        "response": response_text,
+    }
+
+    return EnvStepResult(
+        observation=next_obs,
+        reward=float(reward),
+        done=done,
+        info=info,
+    )
+
+  def success(self) -> bool:
+    """Returns whether the agent has achieved the correct mathematical answer."""
+    return self._success
+
+  def render(self, mode: str = "text") -> str:
+    """Renders the current environment state or interaction summary."""
+    lines = [
+        f"Problem: {self.question}",
+        f"Gold Answer: {self.gold_answer}",
+    ]
+    if self.last_response is not None:
+      lines.extend([
+          "--- Last Completion ---",
+          self.last_response,
+          "-----------------------",
+          f"Extracted Answer: {self.last_extracted_answer}",
+          f"Success: {self._success}",
+      ])
+    return "\n".join(lines)
+
+  @classmethod
+  def from_dict(cls, env_info: dict[str, Any]) -> "GSM8KEnv":
+    """Factory method to instantiate GSM8KEnv from a configuration dictionary.
+
+    Args:
+      env_info: Configuration dictionary containing task data and settings.
+
+    Returns:
+      A fully initialized GSM8KEnv instance.
+    """
+    info = dict(env_info)
+    entry = info.pop("entry", info.pop("task", info))
+    group_id = info.pop("group_id", None)
+    pair_index = info.pop("pair_index", None)
+    max_steps = info.pop("max_steps", 1)
+    reward_fn = info.pop("reward_fn", None)
+    return cls(
+        entry=entry,
+        reward_fn=reward_fn,
+        group_id=group_id,
+        pair_index=pair_index,
+        max_steps=max_steps,
+        **info,
+    )

--- a/examples/math_gsm8k/env_test.py
+++ b/examples/math_gsm8k/env_test.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for GSM8KEnv and GSM8KAgent."""
+
+import unittest
+
+from examples.math_gsm8k import env as gsm8k_env
+from examples.math_gsm8k import agent as gsm8k_agent
+
+
+class GSM8KUtilitiesTest(unittest.TestCase):
+
+  def test_extract_hash_answer(self):
+    self.assertEqual(
+        gsm8k_env.extract_hash_answer(
+            "Natalia sold 48 clips in April. In May she sold half. In total 48 + 24 = 72. #### 72"
+        ),
+        "72",
+    )
+    self.assertEqual(
+        gsm8k_env.extract_hash_answer("The cost is $1,250. #### 1,250"),
+        "1,250",
+    )
+    self.assertEqual(gsm8k_env.extract_hash_answer("72"), "72")
+    self.assertIsNone(gsm8k_env.extract_hash_answer(""))
+
+  def test_extract_boxed_answer(self):
+    # Standard format
+    text1 = "<reasoning>Step by step</reasoning>\n<answer>\\boxed{72}</answer>"
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text1), "72")
+
+    # Nested braces
+    text2 = "<answer>\\boxed{\\frac{72}{1}}</answer>"
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text2), "\\frac{72}{1}")
+
+    # Text markup
+    text3 = "<answer>\\boxed{\\text{85}}</answer>"
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text3), "\\text{85}")
+
+    # Unclosed brace fallback
+    text4 = "The result is \\boxed{36"
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text4), "36")
+
+    # Raw <answer> tag
+    text5 = "<reasoning>Done</reasoning><answer>42</answer>"
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text5), "42")
+
+    # Trailing numeric fallback
+    text6 = "Therefore the final amount is 85 clips."
+    self.assertEqual(gsm8k_env.extract_boxed_answer(text6), "85")
+
+  def test_normalize_answer(self):
+    self.assertEqual(gsm8k_env.normalize_answer("72,000"), "72000")
+    self.assertEqual(gsm8k_env.normalize_answer("$85"), "85")
+    self.assertEqual(gsm8k_env.normalize_answer("50%"), "50")
+    self.assertEqual(gsm8k_env.normalize_answer("72.0"), "72")
+    self.assertEqual(gsm8k_env.normalize_answer("\\text{36}"), "36")
+    self.assertIsNone(gsm8k_env.normalize_answer(None))
+
+  def test_answers_match(self):
+    self.assertTrue(gsm8k_env.answers_match("72", "72"))
+    self.assertTrue(gsm8k_env.answers_match("72.0", "72"))
+    self.assertTrue(gsm8k_env.answers_match("1,000", "1000"))
+    self.assertTrue(gsm8k_env.answers_match("$85", "85"))
+    self.assertFalse(gsm8k_env.answers_match("72", "36"))
+    self.assertFalse(gsm8k_env.answers_match(None, "72"))
+
+  def test_is_format_correct(self):
+    valid_vtc = (
+        "<reasoning>First 48, then 24.</reasoning>\n"
+        "<answer>\\boxed{72}</answer>"
+    )
+    self.assertTrue(gsm8k_env.is_format_correct(valid_vtc))
+
+    valid_think = (
+        "<think>First 48, then 24.</think>\n"
+        "<answer>\\boxed{72}</answer>"
+    )
+    self.assertTrue(gsm8k_env.is_format_correct(valid_think))
+
+    missing_reasoning = "<answer>\\boxed{72}</answer>"
+    self.assertFalse(gsm8k_env.is_format_correct(missing_reasoning))
+
+    missing_answer = "<reasoning>First 48, then 24.</reasoning> 72"
+    self.assertFalse(gsm8k_env.is_format_correct(missing_answer))
+
+
+class GSM8KEnvTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    self.sample_task = {
+        "question": (
+            "Natalia sold clips to 48 friends in April, and then she sold half"
+            " as many clips in May. How many clips did Natalia sell altogether"
+            " in April and May?"
+        ),
+        "answer": "In April 48. In May 24. Total = 72. #### 72",
+    }
+
+  def test_initial_observation(self):
+    env = gsm8k_env.GSM8KEnv(entry=self.sample_task)
+    obs, info = env.reset()
+
+    self.assertIn("question", obs)
+    self.assertEqual(obs["gold_answer"], "72")
+    self.assertIn("Problem: Natalia sold clips", obs["prompts"])
+    self.assertEqual(info, {})
+
+  def test_step_correct_format_and_answer(self):
+    env = gsm8k_env.GSM8KEnv(entry=self.sample_task)
+    env.reset()
+
+    action = (
+        "<reasoning>\n"
+        "Natalia sold 48 in April. In May: 48 / 2 = 24.\n"
+        "Total = 48 + 24 = 72.\n"
+        "</reasoning>\n"
+        "<answer>\\boxed{72}</answer>"
+    )
+    obs, reward, done, info = env.step(action)
+
+    self.assertEqual(reward, 1.0)
+    self.assertTrue(done)
+    self.assertTrue(info["format_correct"])
+    self.assertTrue(info["answer_correct"])
+    self.assertEqual(info["extracted_answer"], "72")
+    self.assertTrue(env.success())
+
+  def test_step_correct_format_wrong_answer(self):
+    env = gsm8k_env.GSM8KEnv(entry=self.sample_task)
+    env.reset()
+
+    action = (
+        "<reasoning>\n"
+        "Natalia sold 48 in April. In May: 48 / 2 = 20.\n"
+        "Total = 48 + 20 = 68.\n"
+        "</reasoning>\n"
+        "<answer>\\boxed{68}</answer>"
+    )
+    obs, reward, done, info = env.step(action)
+
+    self.assertEqual(reward, 0.1)  # Format bonus
+    self.assertTrue(done)
+    self.assertTrue(info["format_correct"])
+    self.assertFalse(info["answer_correct"])
+    self.assertEqual(info["extracted_answer"], "68")
+    self.assertFalse(env.success())
+
+  def test_step_wrong_format_correct_answer(self):
+    env = gsm8k_env.GSM8KEnv(entry=self.sample_task)
+    env.reset()
+
+    action = "She sold 48 + 24 = 72 clips altogether."
+    obs, reward, done, info = env.step(action)
+
+    self.assertEqual(reward, 0.5)  # Partial accuracy reward
+    self.assertTrue(done)
+    self.assertFalse(info["format_correct"])
+    self.assertTrue(info["answer_correct"])
+    self.assertEqual(info["extracted_answer"], "72")
+    self.assertTrue(env.success())
+
+  def test_step_both_wrong(self):
+    env = gsm8k_env.GSM8KEnv(entry=self.sample_task)
+    env.reset()
+
+    action = "I am not sure how to solve this."
+    obs, reward, done, info = env.step(action)
+
+    self.assertEqual(reward, 0.0)
+    self.assertTrue(done)
+    self.assertFalse(info["format_correct"])
+    self.assertFalse(info["answer_correct"])
+    self.assertFalse(env.success())
+
+  def test_from_dict_factory(self):
+    env = gsm8k_env.GSM8KEnv.from_dict({
+        "question": "What is 2 + 2?",
+        "answer": "#### 4",
+        "group_id": "test_group_1",
+        "pair_index": 0,
+    })
+    self.assertEqual(env.question, "What is 2 + 2?")
+    self.assertEqual(env.gold_answer, "4")
+    self.assertEqual(env.group_id, "test_group_1")
+
+
+class GSM8KAgentInteractionTest(unittest.TestCase):
+
+  def test_agent_env_interaction(self):
+    task = {
+        "question": "Weng babysat for 3 hours at $12/hr. How much did she earn?",
+        "answer": "3 * 12 = 36. #### 36",
+    }
+    env = gsm8k_env.GSM8KEnv(entry=task)
+    agent = gsm8k_agent.GSM8KAgent()
+
+    obs, _ = env.reset()
+    agent._observation_to_messages(obs, reward=0.0, done=False)
+
+    # Verify agent's chat completions have system prompt and user question
+    completions = agent.chat_completions
+    self.assertEqual(len(completions), 2)
+    self.assertEqual(completions[0]["role"], "system")
+    self.assertEqual(completions[1]["role"], "user")
+    self.assertIn("Weng babysat", completions[1]["content"])
+
+    # Simulate model response
+    model_response = (
+        "<reasoning>Weng works 3 hours at $12. 3 * 12 = 36.</reasoning>\n"
+        "<answer>\\boxed{36}</answer>"
+    )
+    action = agent.update_from_model(model_response)
+
+    # Step environment with agent's action
+    next_obs, reward, done, info = env.step(action)
+    self.assertEqual(reward, 1.0)
+    self.assertTrue(done)
+    self.assertTrue(env.success())
+    self.assertEqual(len(agent.trajectory.steps), 1)
+
+
+class GSM8KDataTest(unittest.TestCase):
+
+  def test_smoke_test_dataset(self):
+    from examples.math_gsm8k import data as gsm8k_data
+
+    ds = gsm8k_data.create_smoke_test_dataset()
+    self.assertEqual(len(ds), 4)
+    self.assertEqual(ds[0]["gold_answer"], "72")
+    self.assertIn("<reasoning>", ds[0]["prompts"])
+    self.assertEqual(ds[1]["gold_answer"], "36")
+
+
+if __name__ == "__main__":
+  unittest.main()
+

--- a/examples/math_gsm8k/train_gsm8k_qwen3.py
+++ b/examples/math_gsm8k/train_gsm8k_qwen3.py
@@ -1,0 +1,457 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Agentic GSM8K GRPO training recipe for Qwen3-1.7B on TPU.
+
+Trains Qwen3-1.7B on the GSM8K mathematical reasoning task using the Tunix
+Agentic RL framework (GRPOLearner + GSM8KEnv + GSM8KAgent).
+
+Supports:
+  - Single-host (e.g. v5p-8, v6e-4) or multi-host TPU topologies.
+  - vLLM or vanilla rollout engines.
+  - Full-parameter fine-tuning or LoRA PEFT.
+  - Composite format & exact numerical accuracy rewards.
+  - Periodic evaluation on the held-out GSM8K test split.
+"""
+
+import argparse
+import contextlib
+import logging
+import math
+import os
+import sys
+from typing import Any, Dict
+
+from absl import logging as absl_logging
+from flax import nnx
+import grain
+import jax
+from jax import numpy as jnp
+import numpy as np
+import optax
+from orbax import checkpoint as ocp
+import transformers
+
+# ====== Logging Configuration ======
+absl_logging.use_python_logging()
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - [%(name)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    force=True,
+)
+logging.getLogger().setLevel(logging.INFO)
+logging.getLogger("absl").setLevel(logging.INFO)
+absl_logging.set_verbosity(absl_logging.INFO)
+absl_logging.set_stderrthreshold("info")
+
+from tunix.cli.utils import data as data_lib
+from tunix.google.stubs import utils_stub as oss_utils
+from tunix.models.qwen3 import model as qwen3_model_lib
+from tunix.models.qwen3 import params as qwen3_params_lib
+from tunix.rl import rl_cluster as rl_engine_lib
+from tunix.rl import rl_utils
+from tunix.rl.agentic.agentic_grpo_learner import GRPOConfig, GRPOLearner
+from tunix.rl.agentic.parser.chat_template_parser import parser
+from tunix.rl.rollout import base_rollout
+from tunix.sft import metrics_logger
+from tunix.sft import model_utils
+from tunix.sft import utils as sft_utils
+
+from examples.math_gsm8k.agent import GSM8KAgent
+from examples.math_gsm8k.data import create_dataset
+from examples.math_gsm8k.env import GSM8KEnv
+
+# ====== Distributed Initialization ======
+_DISTRIBUTED_INITIALIZED = False
+try:
+  import pathwaysutils
+
+  pathwaysutils.initialize()
+  _DISTRIBUTED_INITIALIZED = True
+except Exception:
+  pass
+
+if not _DISTRIBUTED_INITIALIZED:
+  try:
+    jax.distributed.initialize()
+  except Exception as exc:
+    print(f"jax.distributed.initialize() skipped or already initialized: {exc}")
+
+print("JAX devices:", jax.devices())
+
+
+# ====== Command-line Arguments ======
+def parse_args():
+  parser = argparse.ArgumentParser(
+      description="Train GSM8K on Qwen3-1.7B using Tunix Agentic RL."
+  )
+  # Model
+  parser.add_argument("--model_id", type=str, default="Qwen/Qwen3-1.7B")
+  parser.add_argument("--model_dir", type=str, default="/tmp/models/Qwen3-1.7B")
+
+  # PEFT / LoRA
+  parser.add_argument("--use_lora", action="store_true", default=False)
+  parser.add_argument("--lora_rank", type=int, default=16)
+  parser.add_argument("--lora_alpha", type=int, default=32)
+
+  # Training Hyperparameters
+  parser.add_argument("--batch_size", type=int, default=32)
+  parser.add_argument("--mini_batch_size", type=int, default=32)
+  parser.add_argument("--train_micro_batch_size", type=int, default=4)
+  parser.add_argument("--learning_rate", type=float, default=1e-6)
+  parser.add_argument("--b1", type=float, default=0.9)
+  parser.add_argument("--b2", type=float, default=0.95)
+  parser.add_argument("--weight_decay", type=float, default=0.0)
+  parser.add_argument("--max_grad_norm", type=float, default=100.0)
+  parser.add_argument("--num_batches", type=int, default=150)
+  parser.add_argument("--num_epochs", type=int, default=1)
+
+  # GRPO Hyperparameters
+  parser.add_argument("--num_generations", type=int, default=8)
+  parser.add_argument("--beta", type=float, default=0.0)
+  parser.add_argument("--epsilon", type=float, default=0.2)
+  parser.add_argument("--epsilon_high", type=float, default=0.2)
+  parser.add_argument(
+      "--loss_algo",
+      type=str,
+      default="grpo",
+      help="'grpo' (per-token PPO) or 'gspo-token' (sequence-mean IS).",
+  )
+  parser.add_argument(
+      "--advantage_estimator",
+      type=str,
+      default="grpo",
+      help="'grpo' (z-score) or 'rloo' (leave-one-out baseline).",
+  )
+  parser.add_argument(
+      "--loss_agg_mode", type=str, default="sequence-mean-token-mean"
+  )
+  parser.add_argument("--kl_loss_mode", type=str, default="low_var_kl")
+
+  # Rollout & Generation
+  parser.add_argument("--max_prompt_length", type=int, default=1024)
+  parser.add_argument("--max_response_length", type=int, default=1024)
+  parser.add_argument("--temperature", type=float, default=0.7)
+  parser.add_argument("--top_p", type=float, default=1.0)
+  parser.add_argument("--top_k", type=int, default=0)
+  parser.add_argument("--max_concurrency", type=int, default=128)
+  parser.add_argument(
+      "--rollout_engine",
+      type=str,
+      default=os.getenv("ROLLOUT_ENGINE", "vllm"),
+      help="'vllm' or 'vanilla'.",
+  )
+
+  # Data & Evaluation
+  parser.add_argument(
+      "--data_source",
+      type=str,
+      default="huggingface",
+      choices=["huggingface", "demo", "smoke_test", "tfds"],
+  )
+  parser.add_argument("--eval_every_n_steps", type=int, default=10)
+  parser.add_argument("--num_test_batches", type=int, default=2)
+  parser.add_argument("--seed", type=int, default=42)
+
+  # Infrastructure & Output
+  parser.add_argument("--tb_log_dir", type=str, default="/tmp/tunix-tb/gsm8k")
+  parser.add_argument("--ckpt_dir", type=str, default=None)
+  parser.add_argument("--save_interval_steps", type=int, default=50)
+
+  return parser.parse_known_args()[0]
+
+
+def main():
+  args = parse_args()
+
+  # ====== Mesh Setup ======
+  # Default to pure tensor parallel (1, N) on single-host TPU
+  shared_mesh_shape = (1, jax.device_count())
+  shared_mesh_axis_names = ("fsdp", "tp")
+
+  if jax.device_count() < math.prod(shared_mesh_shape):
+    raise ValueError(
+        f"Expected at least {math.prod(shared_mesh_shape)} devices for mesh "
+        f"{shared_mesh_shape}, got {jax.device_count()}."
+    )
+
+  device_list = jax._src.mesh_utils.create_device_mesh(
+      shared_mesh_shape, jax.devices()[: math.prod(shared_mesh_shape)]
+  )
+  shared_mesh = jax.sharding.Mesh(
+      device_list,
+      axis_names=shared_mesh_axis_names,
+      axis_types=(jax.sharding.AxisType.Auto,) * len(shared_mesh_shape),
+  )
+  print(f"Shared mesh initialized with devices: {shared_mesh.devices.shape}")
+
+  # ====== Tokenizer & Parser ======
+  tokenizer = transformers.AutoTokenizer.from_pretrained(args.model_id)
+  # Disable thinking tokens since explicit <reasoning>...</reasoning> tags are prompted
+  chat_parser = parser.QwenChatTemplateParser(tokenizer, enable_thinking=False)
+
+  # ====== Datasets ======
+  raw_train_ds = create_dataset(
+      split="train",
+      data_source=args.data_source,
+      seed=args.seed,
+  )
+  raw_test_ds = create_dataset(
+      split="test" if args.data_source != "smoke_test" else "train",
+      data_source=args.data_source,
+      seed=args.seed,
+  )
+
+  # Wrap in grain MapDataset if not already
+  if not hasattr(raw_train_ds, "map"):
+    raw_train_ds = grain.MapDataset.source(list(raw_train_ds))
+  if not hasattr(raw_test_ds, "map"):
+    raw_test_ds = grain.MapDataset.source(list(raw_test_ds))
+
+  train_dataset, _ = data_lib.post_init_dataset(
+      raw_train_ds,
+      tokenizer,
+      batch_size=args.batch_size,
+      num_batches=args.num_batches,
+      max_prompt_length=args.max_prompt_length,
+      num_epochs=args.num_epochs,
+  )
+  test_dataset, _ = data_lib.post_init_dataset(
+      raw_test_ds,
+      tokenizer,
+      batch_size=args.batch_size,
+      num_batches=args.num_test_batches,
+      max_prompt_length=args.max_prompt_length,
+  )
+  sft_utils.show_hbm_usage("Done loading datasets")
+
+  # ====== Model Weights Download & Instantiation ======
+  if not os.path.isdir(args.model_dir) or not any(
+      f.endswith(".safetensors") for f in os.listdir(args.model_dir)
+  ):
+    os.makedirs(args.model_dir, exist_ok=True)
+    oss_utils.hf_pipeline(args.model_id, args.model_dir)
+
+  # Config for Qwen3-1.7B
+  config = qwen3_model_lib.ModelConfig.qwen3_1p7b()
+  config.remat_config = qwen3_model_lib.RematConfig.DECODER
+  config.use_flash_attention = True
+  config.flash_attention_block_size = 256
+  config.dtype = jnp.bfloat16
+  config.param_dtype = jnp.float32
+
+  # Reference model (frozen, stored in bfloat16)
+  qwen_ref = qwen3_params_lib.create_model_from_safe_tensors(
+      args.model_dir, config, shared_mesh, dtype=jnp.bfloat16
+  )
+  sft_utils.show_hbm_usage("After loading qwen_ref")
+
+  # Actor model (fp32 storage for optimizer precision)
+  actor_base = qwen3_params_lib.create_model_from_safe_tensors(
+      args.model_dir, config, shared_mesh, dtype=jnp.float32
+  )
+
+  # Apply LoRA if requested
+  if args.use_lora:
+    lora_config = {
+        "module_path": (
+            ".*q_proj|.*k_proj|.*v_proj|.*o_proj|"
+            ".*gate_proj|.*down_proj|.*up_proj"
+        ),
+        "rank": args.lora_rank,
+        "alpha": args.lora_alpha,
+    }
+    qwen_actor = model_utils.apply_lora_to_model(
+        actor_base, mesh=shared_mesh, lora_config=lora_config
+    )
+  else:
+    qwen_actor = actor_base
+
+  # Pin parameters on device
+  graph_def, state = nnx.split(qwen_actor)
+  state = rl_utils.put_params_on_memory_kind(state, "device")
+  qwen_actor = nnx.merge(graph_def, state)
+  sft_utils.show_hbm_usage("After loading qwen_actor")
+
+  # ====== Optimizer ======
+  optimizer = optax.adamw(
+      learning_rate=args.learning_rate,
+      b1=args.b1,
+      b2=args.b2,
+      weight_decay=args.weight_decay,
+  )
+  if args.max_grad_norm is not None and args.max_grad_norm > 0:
+    optimizer = optax.chain(
+        optax.clip_by_global_norm(max_norm=args.max_grad_norm),
+        optimizer,
+    )
+
+  # ====== Checkpoint & Logging ======
+  if args.ckpt_dir:
+    checkpointing_options = ocp.CheckpointManagerOptions(
+        save_interval_steps=args.save_interval_steps,
+        max_to_keep=2,
+    )
+  else:
+    checkpointing_options = None
+
+  max_steps = int(args.num_batches * args.num_epochs)
+  metrics_logging_options = metrics_logger.MetricsLoggerOptions(
+      log_dir=args.tb_log_dir,
+      project_name="tunix-gsm8k-qwen3",
+      flush_every_n_steps=1,
+      backend_kwargs={"wandb": {"config": vars(args)}},
+  )
+
+  # ====== Rollout Configuration ======
+  base_rollout_dict = {
+      "max_prompt_length": args.max_prompt_length,
+      "kv_cache_size": args.max_prompt_length + args.max_response_length + 256,
+      "temperature": args.temperature,
+      "top_p": args.top_p,
+      "top_k": args.top_k,
+      "return_logprobs": True,
+      "max_tokens_to_generate": args.max_response_length,
+  }
+
+  vllm_max_num_seqs = 64
+  vllm_max_batched_tokens = vllm_max_num_seqs * 4 * 1024 // 8
+  vllm_rollout_dict = {
+      "rollout_vllm_model_version": args.model_id,
+      "rollout_vllm_hbm_utilization": 0.25,
+      "rollout_vllm_tpu_backend_type": "jax",
+      "rollout_vllm_server_mode": True,
+      "rollout_vllm_async_scheduling": False,
+      "rollout_vllm_init_with_random_weights": True,
+      "tensor_parallel_size": shared_mesh_shape[1],
+      "data_parallel_size": shared_mesh_shape[0],
+      "rollout_vllm_max_num_seqs": vllm_max_num_seqs,
+      "rollout_vllm_max_num_batched_tokens": vllm_max_batched_tokens,
+      "rollout_vllm_kwargs": {
+          "kv_cache_metrics": True,
+          "disable_log_stats": False,
+          "enable_prefix_caching": False,
+          "dtype": "bfloat16",
+      },
+  }
+
+  if args.rollout_engine == "vllm":
+    rollout_engine_config = base_rollout.RolloutConfig(
+        **base_rollout_dict, **vllm_rollout_dict
+    )
+  elif args.rollout_engine == "vanilla":
+    rollout_engine_config = base_rollout.RolloutConfig(**base_rollout_dict)
+  else:
+    raise ValueError(f"Unsupported rollout engine: {args.rollout_engine}")
+
+  cluster_config = rl_engine_lib.ClusterConfig(
+      role_to_mesh={
+          rl_engine_lib.Role.ACTOR: shared_mesh,
+          rl_engine_lib.Role.REFERENCE: shared_mesh,
+          rl_engine_lib.Role.ROLLOUT: shared_mesh,
+      },
+      rollout_engine=args.rollout_engine,
+      offload_to_cpu=False,
+      training_config=rl_engine_lib.RLTrainingConfig(
+          actor_optimizer=optimizer,
+          eval_every_n_steps=args.eval_every_n_steps,
+          max_steps=max_steps,
+          mini_batch_size=args.mini_batch_size,
+          train_micro_batch_size=args.train_micro_batch_size,
+          compute_logps_micro_batch_size=args.train_micro_batch_size,
+          metrics_logging_options=metrics_logging_options,
+          checkpoint_root_directory=args.ckpt_dir,
+          checkpointing_options=checkpointing_options,
+      ),
+      rollout_config=rollout_engine_config,
+  )
+
+  grpo_config = GRPOConfig(
+      num_generations=args.num_generations,
+      num_iterations=1,
+      max_response_length=args.max_response_length,
+      beta=args.beta,
+      epsilon=args.epsilon,
+      epsilon_high=args.epsilon_high,
+      system_prompt="",
+      max_concurrency=args.max_concurrency,
+      off_policy_steps=0,
+      loss_agg_mode=args.loss_agg_mode,
+      kl_loss_mode=args.kl_loss_mode,
+      loss_algo=args.loss_algo,
+      advantage_estimator=args.advantage_estimator,
+      sampler_is="token",
+      sampler_is_threshold=2.0,
+  )
+
+  rl_engine = rl_engine_lib.RLEngine(
+      actor=qwen_actor,
+      reference=qwen_ref,
+      tokenizer=tokenizer,
+      cluster_config=cluster_config,
+  )
+  sft_utils.show_hbm_usage("After RLEngine initialization")
+
+  # ====== Evaluation / Diagnostic Metric Callback ======
+  def gsm8k_metric_fn(prompts, completions, rewards, advantages, **kwargs):
+    del prompts, completions, advantages, kwargs
+    # GSM8K rewards: 1.0 (format+correct), 0.5 (unformatted correct), 0.1 (format only), 0.0 (neither)
+    solve_mask = rewards >= 0.5
+    format_mask = (rewards == 1.0) | (rewards == 0.1)
+
+    solve_ratio = float(solve_mask.mean())
+    format_ratio = float(format_mask.mean())
+    reward_mean = float(rewards.mean())
+    reward_max = float(rewards.max())
+
+    absl_logging.info(
+        "[gsm8k-metric] count=%d solve_ratio=%.3f format_ratio=%.3f"
+        " reward_mean=%.3f reward_max=%.3f",
+        len(rewards),
+        solve_ratio,
+        format_ratio,
+        reward_mean,
+        reward_max,
+    )
+    return {
+        "rewards/solve_ratio": (solve_ratio, np.mean),
+        "rewards/format_ratio": (format_ratio, np.mean),
+        "rewards/reward_mean": (reward_mean, np.mean),
+        "rewards/reward_max": (reward_max, np.max),
+    }
+
+  # ====== Instantiate GRPOLearner ======
+  grpo_trainer = GRPOLearner(
+      rl_engine=rl_engine,
+      agent_class=GSM8KAgent,
+      env_class=GSM8KEnv,
+      env_kwargs={"max_steps": 1},
+      algo_config=grpo_config,
+      chat_parser=chat_parser,
+      metric_fns=[gsm8k_metric_fn],
+  )
+  sft_utils.show_hbm_usage("After GRPOLearner instantiation")
+
+  # ====== Execute Training Loop ======
+  absl_logging.info(
+      "Starting GSM8K training for %d steps with Qwen3-1.7B...", max_steps
+  )
+  grpo_trainer.train(train_dataset, eval_dataset=test_dataset)
+  absl_logging.info("Training complete!")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
### Summary

This PR introduces a modular `GSM8KEnv` environment, `GSM8KAgent` agent, and an end-to-end training entrypoint script `train_gsm8k_qwen3.py` for Qwen3-1.7B for the Tunix Agentic RL framework, matching the architecture and conventions established in `examples/frozenlake/`.

### Changes Included

1. **`examples/math_gsm8k/env.py`**:
   - `GSM8KEnv`: Subclasses `BaseTaskEnv` to manage mathematical reasoning tasks.
   - Extracts ground-truth numerical answers from GSM8K solutions via `extract_hash_answer` (`... #### <num>`).
   - Parses model reasoning chains and LaTeX `\boxed{...}` answers using stack-based bracket matching with robust fallbacks.
   - Computes composite format and accuracy rewards (+0.1 format bonus, +1.0 exact accuracy, +0.5 partial credit).
   - Provides serialization and dynamic instantiation via `from_dict()`.

2. **`examples/math_gsm8k/agent.py`**:
   - `GSM8KAgent`: Subclasses `ConversationAgentBase` to maintain dialogue history and step-by-step reasoning trajectories for GRPO training.

3. **`examples/math_gsm8k/data.py`**:
   - GSM8K dataset loaders supporting Hugging Face (`openai/gsm8k`), TFDS, and in-memory smoke-testing.

4. **`examples/math_gsm8k/env_test.py`**:
   - 13 comprehensive unit tests validating answer extraction, tag checking, reward calculation, and agent-environment interaction.

5. **`examples/math_gsm8k/train_gsm8k_qwen3.py`**:
   - Agentic GRPO training entrypoint script for GSM8K on TPU using Qwen3-1.7B.
   - Integrates `GSM8KEnv` and `GSM8KAgent` with `GRPOLearner` and `RLEngine`.
   - Configures `ModelConfig.qwen3_1p7b()` with bf16 reference and fp32 actor (supporting full fine-tuning and LoRA).
   - Supports vLLM and vanilla rollout engines on shared or distributed mesh.
   - Computes and logs step-by-step math reasoning metrics (solve ratio, format ratio, reward).

TAG=agy
CONV=2907f211-714a-4e9c-b009-de21347c291a