### PR TITLE
fix(distributed): forward RAIDEN_WEIGHT_SYNC_CHUNKS in k8s_launcher.sh

### DIFF
--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -64,6 +64,7 @@ export USE_LORA=${USE_LORA:-0}
 # Logs source/destination Raiden tensor checksums on both the trainer and
 # rollout sides during weight sync, for cross-verification of a real run.
 export VERIFY_WEIGHTS=${VERIFY_WEIGHTS:-false}
+export RAIDEN_WEIGHT_SYNC_CHUNKS=${RAIDEN_WEIGHT_SYNC_CHUNKS:-}
 
 export ORCHESTRATOR_ID=$USER-orch
 export ORCHESTRATOR_PORT=20000
@@ -158,7 +159,7 @@ start_trainer() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
-      VERIFY_WEIGHTS=${VERIFY_WEIGHTS} python -m tunix.experimental.distributed.runtime.main \
+      VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${RAIDEN_WEIGHT_SYNC_CHUNKS:+RAIDEN_WEIGHT_SYNC_CHUNKS=${RAIDEN_WEIGHT_SYNC_CHUNKS}} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.math_gsm8k_dist.run_trainer_node.main \


### PR DESCRIPTION
### Summary

In distributed training with MaxText and Raiden weight synchronization, `maxtext_engine` reads `RAIDEN_WEIGHT_SYNC_CHUNKS` from the environment to determine how many chunks to partition model parameters into for weight sync. When this variable is not exported or forwarded into the container environment, MaxText can split variables into multiple chunks (re-indexing `layer_idx` locally per chunk), while rollout nodes register a single chunk, causing a `layer_idx` bounds mismatch and destination rejection during weight sync:
```text
INVALID_ARGUMENT: Destination out of bounds in batched push (raw_buffer_transport.cc:335)
```

### Changes Included

1. Export `RAIDEN_WEIGHT_SYNC_CHUNKS=${RAIDEN_WEIGHT_SYNC_CHUNKS:-}` in `tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh`.
2. Forward `${RAIDEN_WEIGHT_SYNC_CHUNKS:+RAIDEN_WEIGHT_SYNC_CHUNKS=${RAIDEN_WEIGHT_SYNC_CHUNKS}}` to the trainer pod's `--worker_startup_command` so containerized runs respect caller overrides (such as `RAIDEN_WEIGHT_SYNC_CHUNKS=1`).

TAG=agy
CONV=2907f211-714a-4e9c-b009-de21347c291a