### PR TITLE
Support `enable_continuous_profiling` option in the Tunix JAX profiler wrapper

### DIFF
--- a/tunix/sft/profiler.py
+++ b/tunix/sft/profiler.py
@@ -31,7 +31,7 @@ class ProfilerOptions:
   skip_first_n_steps: int
   # Number of steps to profile.
   profiler_steps: int
-  # Whether to set the profile options.
+  # Whether to set tracer level options (host_tracer_level, python_tracer_level).
   set_profile_options: bool = True
   # https://github.com/jax-ml/jax/blob/0b1b909dd66a113ee0d7e54e55d0efef480e2a8a/docs/profiling.md?plain=1#L285
   host_tracer_level: int = 2  # set to 2 to capture HBM profiles.
@@ -40,7 +40,8 @@ class ProfilerOptions:
   # Maximum number of hosts to profile. Only supported for Pathways workloads
   # using pathwaysutils.
   max_num_hosts: int | None = None
-
+  # Whether to enable continuous profiling via JAX advanced_configuration.
+  enable_continuous_profiling: bool = False
 
 class Profiler:
   """Activate/deactivate a profiler based on the ProfilerOptions."""
@@ -127,19 +128,21 @@ class Profiler:
         )
         return
       logging.info("Starting JAX profiler at step %d.", step)
+      profile_options = jax.profiler.ProfileOptions()
       if self._profiler_options.set_profile_options:
-        profile_options = jax.profiler.ProfileOptions()
         profile_options.host_tracer_level = (
             self._profiler_options.host_tracer_level
         )
         profile_options.python_tracer_level = (
             self._profiler_options.python_tracer_level
         )
-        self._start_trace(
-            log_dir=self._output_path, profiler_options=profile_options
-        )
-      else:
-        self._start_trace(log_dir=self._output_path)
+      if self._profiler_options.enable_continuous_profiling:
+        profile_options.advanced_configuration = {
+            "enable_continuous_profiling": True
+        }
+      self._start_trace(
+          log_dir=self._output_path, profiler_options=profile_options
+      )
       Profiler._is_active = True
       self._started_by_this_instance = True
 


### PR DESCRIPTION
### Description
Support `enable_continuous_profiling` option in the Tunix JAX profiler wrapper (`sft/profiler.py`).

When `enable_continuous_profiling=True` is configured in profiler options, this change sets `advanced_configuration["enable_continuous_profiling"] = True` in `jax.profiler.ProfileOptions()`. This configures JAX profiler to stream smaller trace chunks into `.xplane.riegeli` record containers, avoiding the 2GB Protocol Buffer size limit for large profiles.

Tested with the MaxText RL continuous profiling workflow. Related MaxText PR: https://github.com/google/maxtext/pull/5061

**Note**: 
* This flag can be configured even when `set_profile_options=False`. MaxText sets `set_profile_options=False` to disable custom tracer level overrides, while `enable_continuous_profiling` is configured in `profiler_options`.
* This flag is only effective with JAX version >=0.11.1.

**Checklist**

- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).