### PR TITLE
fix(peft_trainer): make scalar-metric host-fetch multi-process safe

### DIFF
--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -93,6 +93,31 @@ def _weighted_metric_mean(values: Iterable[Any]) -> float:
   return numerator / denominator if denominator else 0.0
 
 
+def _addressable_scalar(value: Any) -> Any:
+  """Returns a host-fetchable view of a (replicated) scalar metric.
+
+  Scalar metrics such as loss and learning rate are replicated across the mesh.
+  Under a multi-process / multi-host mesh the resulting ``jax.Array`` spans
+  non-process-local (non-addressable) devices, and ``jax.device_get`` /
+  ``np.asarray`` on it raises ``RuntimeError: Fetching value for jax.Array that
+  spans non-addressable ... devices``. Since the value is replicated, this
+  process's local addressable shard holds the correct scalar, so reduce to it
+  before the host fetch.
+
+  Only reduces to the local shard when the array is a *replicated scalar* (a
+  local shard whose shape matches the global shape) -- so a genuinely sharded,
+  non-scalar array is never silently truncated to a partial shard. Fully
+  addressable arrays and plain Python / NumPy scalars pass through unchanged.
+  """
+  if isinstance(value, jax.Array) and not getattr(
+      value, "is_fully_addressable", True
+  ):
+    shards = value.addressable_shards
+    if shards and shards[0].data.shape == value.shape:
+      return shards[0].data
+  return value
+
+
 def _metric_reducer(
     metric: _MetricValue,
 ) -> _MetricReducer:
@@ -133,7 +158,9 @@ class MetricsBuffer:
       if not all(weighted):
         raise TypeError("loss values must not mix weighted and scalar metrics")
       return _weighted_metric_mean(self.losses)
-    return np.mean(np.array([np.array(x) for x in self.losses]))
+    return np.mean(
+        np.array([np.asarray(_addressable_scalar(x)) for x in self.losses])
+    )
 
 
 def _calculate_global_batch_size(train_example: Any) -> int:
@@ -751,7 +778,7 @@ class PeftTrainer:
       additional_metrics: dict[str, ArrayLike] | None = None,
   ):
     """Logs the metrics to the metrics logger and console."""
-    perplexity = np.exp(jax.device_get(loss))
+    perplexity = np.exp(jax.device_get(_addressable_scalar(loss)))
     self.metrics_logger.log(self.metrics_prefix, "loss", loss, self._mode, step)  # pyrefly: ignore[missing-attribute]
     self.metrics_logger.log(  # pyrefly: ignore[missing-attribute]
         self.metrics_prefix, "perplexity", perplexity, self._mode, step
@@ -761,7 +788,7 @@ class PeftTrainer:
       self.metrics_logger.log(  # pyrefly: ignore[missing-attribute]
           self.metrics_prefix,
           "learning_rate",
-          jax.device_get(learning_rate),
+          jax.device_get(_addressable_scalar(learning_rate)),
           self._mode,
           step,
       )
@@ -836,7 +863,7 @@ class PeftTrainer:
   def _write_metrics(self, metrics_buffer: MetricsBuffer):
     def _to_np_array(v):
       if isinstance(v, jax.Array):
-        return np.asarray(v, dtype=np.float32)
+        return np.asarray(_addressable_scalar(v), dtype=np.float32)
       elif isinstance(v, list):
         return [_to_np_array(x) for x in v]
       return v


### PR DESCRIPTION
## What

Makes the scalar-metric host-fetch in `PeftTrainer` safe under a multi-process / multi-host mesh.

## Why

Loss, perplexity and learning_rate are **replicated scalars**. Under a multi-process / multi-host mesh the underlying `jax.Array` spans non-process-local (non-addressable) devices, so `jax.device_get` / `np.asarray` on it raises:

```
RuntimeError: Fetching value for `jax.Array` that spans non-addressable
(non process local) devices is not possible.
```

This crashes the train→metrics logging path on any multi-host / bare-SPMD run — the training step itself succeeds, but the metrics flush at the end of the step throws.

## What changes

Adds a small `_addressable_scalar` helper (following the existing `is_fully_addressable` idiom already used in `_shard`) that, for a **replicated scalar** `jax.Array`, returns this process's local addressable shard before the host fetch.

It only reduces when the local shard shape equals the global shape, so a genuinely sharded, non-scalar array is never silently truncated to a partial shard. Fully-addressable arrays and plain Python/NumPy scalars pass through unchanged — **single-process behavior is identical.**

Applied at the four scalar host-fetch sites:
- `MetricsBuffer.loss` (buffered-loss mean)
- `_log_metrics`: `jax.device_get(loss)` and `jax.device_get(learning_rate)`
- `_write_metrics._to_np_array` (additional scalar metrics: reward, kl, etc.)

## Test

Validated on a 16-process bare-SPMD RL run on TPU v7x: the metrics flush that previously crashed at `jax.device_get(learning_rate)` now completes, and training proceeds across many steps. `peft_trainer.py` py_compile clean and 80-col compliant.
