### PR TITLE
Carry rollout MoE routing from the vLLM sampler to the maxtext trainer

### DIFF
--- a/tests/experimental/common/datatypes_test.py
+++ b/tests/experimental/common/datatypes_test.py
@@ -535,5 +535,20 @@ class WireSerializationTest(absltest.TestCase):
     self.assertEqual(item_default.group_index, 0)
 
 
+class TokenSegmentRoutingTest(absltest.TestCase):
+  """`routed_experts` must line up with the tokens it describes."""
+
+  def test_rejects_length_mismatch(self):
+    """Only the per-token axis is checked; trailing axes are model-specific."""
+    tokens = np.arange(4, dtype=np.int32)
+    with self.assertRaisesRegex(ValueError, "routed_experts shape"):
+      datatypes.TokenSegment(
+          source="assistant",
+          tokens=tokens,
+          loss_mask=np.ones_like(tokens),
+          routed_experts=np.zeros((3, 2, 2), dtype=np.int32),
+      )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/experimental/orchestrator/algorithm_adapter_test.py
+++ b/tests/experimental/orchestrator/algorithm_adapter_test.py
@@ -79,5 +79,37 @@ class AlgorithmAdapterTest(absltest.TestCase):
     self.assertEqual(adapter.loss_fn(), algo_core.ppo_policy_loss_fn)
 
 
+_ROUTING_LAYERS = 2
+_ROUTING_TOP_K = 2
+
+
+def _routing(length, fill):
+  """`[length, num_layers, top_k]` routing where every slot holds `fill`."""
+  shape = (length, _ROUTING_LAYERS, _ROUTING_TOP_K)
+  return np.full(shape, fill, dtype=np.int32)
+
+
+class RoutedExpertsForItemTest(absltest.TestCase):
+  """`_routed_experts_for` must match the payload's sequence length exactly."""
+
+  def _align(self, routed, seq_len=8):
+    item = datatypes.TrajectoryItem(routed_experts=routed)
+    return algorithm_adapter._routed_experts_for(item, seq_len)  # pylint: disable=protected-access
+
+  def test_returns_none_without_capture(self):
+    self.assertIsNone(self._align(None))
+
+  def test_short_capture_is_padded_as_unset(self):
+    """Missing tail rows must fall back to the gate, not replay expert 0."""
+    out = self._align(_routing(5, 3))
+    self.assertEqual(out.shape, (8, _ROUTING_LAYERS, _ROUTING_TOP_K))
+    np.testing.assert_array_equal(out[:5], 3)
+    np.testing.assert_array_equal(out[5:], datatypes.UNSET_ROUTED_EXPERT)
+
+  def test_wrong_rank_is_rejected(self):
+    with self.assertRaisesRegex(ValueError, "length, num_layers, top_k"):
+      self._align(np.zeros((8, _ROUTING_TOP_K), dtype=np.int32))
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/experimental/orchestrator/batch_assembly_test.py
+++ b/tests/experimental/orchestrator/batch_assembly_test.py
@@ -834,5 +834,127 @@ class PaddedBatchAssemblerTest(absltest.TestCase):
     np.testing.assert_allclose(payload.advantages[0], [0.0, 0.0, 0.0, 0.0, 0.0])
 
 
+_ROUTING_LAYERS = 2
+_ROUTING_TOP_K = 2
+_UNSET = datatypes.UNSET_ROUTED_EXPERT
+
+
+def _routing(length, fill):
+  """`[length, num_layers, top_k]` routing where every slot holds `fill`."""
+  shape = (length, _ROUTING_LAYERS, _ROUTING_TOP_K)
+  return np.full(shape, fill, dtype=np.int32)
+
+
+class RoutedExpertsAlignmentTest(absltest.TestCase):
+  """Replayed routing must be padded the same way the token ids are."""
+
+  def test_prompt_is_right_aligned_and_completion_left_aligned(self):
+    """Routing must follow the token padding, not sit at the row start.
+
+    Prompts are left-padded and completions right-padded; if the routing does
+    not follow, every replayed expert lands on the wrong token.
+    """
+    prompt_len, completion_len = 2, 3
+    max_prompt, max_response = 5, 6
+    routed = np.concatenate(
+        [_routing(prompt_len, 7), _routing(completion_len, 9)], axis=0
+    )
+
+    out = batch_assembly._routed_experts_aligned(  # pylint: disable=protected-access
+        routed, prompt_len, completion_len, max_prompt, max_response
+    )
+
+    self.assertEqual(
+        out.shape, (max_prompt + max_response, _ROUTING_LAYERS, _ROUTING_TOP_K)
+    )
+    # Prompt window: leading pad unset, prompt routing flush against the end.
+    np.testing.assert_array_equal(out[: max_prompt - prompt_len], _UNSET)
+    np.testing.assert_array_equal(out[max_prompt - prompt_len : max_prompt], 7)
+    # Response window: completion routing first, trailing pad unset.
+    np.testing.assert_array_equal(
+        out[max_prompt : max_prompt + completion_len], 9
+    )
+    np.testing.assert_array_equal(out[max_prompt + completion_len :], _UNSET)
+
+  def test_overlong_prompt_keeps_the_tail(self):
+    """`_left_pad` keeps the last tokens, so routing must keep its last rows."""
+    # One prompt row per position, so a dropped row is visible by value.
+    prompt = np.broadcast_to(
+        np.arange(4, dtype=np.int32).reshape(4, 1, 1),
+        (4, _ROUTING_LAYERS, _ROUTING_TOP_K),
+    )
+    routed = np.concatenate([prompt, _routing(1, 9)], axis=0)
+    out = batch_assembly._routed_experts_aligned(routed, 4, 1, 2, 3)  # pylint: disable=protected-access
+    # Prompt rows 0 and 1 are dropped; 2 and 3 survive, in order.
+    np.testing.assert_array_equal(out[0], 2)
+    np.testing.assert_array_equal(out[1], 3)
+
+
+class PaddedBatchAssemblerRoutingTest(absltest.TestCase):
+  """The assembler must emit `[B, P + C, num_layers, top_k]`, or nothing."""
+
+  MAX_PROMPT = 4
+  MAX_RESPONSE = 4
+
+  def _assembler(self, batch_size=2):
+    return batch_assembly.PaddedBatchAssembler(
+        batch_size=batch_size,
+        max_prompt_length=self.MAX_PROMPT,
+        max_response_length=self.MAX_RESPONSE,
+        pad_id=0,
+    )
+
+  def _payload(self, fill, with_routing=True):
+    prompt = np.array([1, 2], dtype=np.int32)
+    completion = np.array([3, 4, 5], dtype=np.int32)
+    routed = None
+    if with_routing:
+      routed = np.concatenate(
+          [_routing(len(prompt), fill), _routing(len(completion), fill)],
+          axis=0,
+      )
+    return datatypes.RLTrainerPayload(
+        advantages=np.zeros(len(completion), dtype=np.float32),
+        loss_mask=np.ones(len(completion), dtype=np.float32),
+        prompt_ids=prompt,
+        prompt_mask=np.ones(len(prompt), dtype=np.float32),
+        completion_ids=completion,
+        completion_mask=np.ones(len(completion), dtype=np.float32),
+        routed_experts=routed,
+    )
+
+  def test_batches_routing_across_rows(self):
+    packed = self._assembler().pack([self._payload(1), self._payload(2)])
+    self.assertLen(packed, 1)
+    routed = packed[0].routed_experts
+    self.assertIsNotNone(routed, "assembler dropped the replayed routing")
+    self.assertEqual(
+        routed.shape,
+        (
+            2,
+            self.MAX_PROMPT + self.MAX_RESPONSE,
+            _ROUTING_LAYERS,
+            _ROUTING_TOP_K,
+        ),
+    )
+    # Row order must be preserved, or rows train on each other's routing.
+    self.assertEqual(int(routed[0, self.MAX_PROMPT, 0, 0]), 1)
+    self.assertEqual(int(routed[1, self.MAX_PROMPT, 0, 0]), 2)
+
+  def test_partial_capture_disables_replay_for_the_batch(self):
+    """A half-replayed batch would silently mix replayed and fresh routing."""
+    packed = self._assembler().pack(
+        [self._payload(1), self._payload(2, with_routing=False)]
+    )
+    self.assertIsNone(packed[0].routed_experts)
+
+  def test_short_batch_pads_rows_as_unset(self):
+    """Filler rows must not replay a real expert id."""
+    packed = self._assembler(batch_size=2).pack([self._payload(1)])
+    routed = packed[0].routed_experts
+    self.assertEqual(routed.shape[0], 2)
+    np.testing.assert_array_equal(routed[1], _UNSET)
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/experimental/rollout/inprocess_vllm_sampler_adapter_test.py
+++ b/tests/experimental/rollout/inprocess_vllm_sampler_adapter_test.py
@@ -270,5 +270,61 @@ class InprocessVllmSamplerAdapterTest(absltest.TestCase):
       asyncio.run(self.sampler_adapter.sample(None))
 
 
+class RoutedExpertsTest(absltest.TestCase):
+  """Captured MoE routing must reach the matching response."""
+
+  def _adapter(self, routed_experts, engine_captures=True):
+    rows = len(routed_experts) if routed_experts else 1
+    sampler = mock.MagicMock()
+    sampler.return_value = base_sampler.SamplerOutput(
+        text=["c"] * rows,
+        logits=None,
+        tokens=[np.array([10, 20, 30], dtype=np.int32)] * rows,
+        padded_prompt_tokens=np.tile(
+            np.array([1, 2], dtype=np.int32), (rows, 1)
+        ),
+        logprobs=None,
+        routed_experts=routed_experts,
+    )
+    sampler.config = mock.Mock(return_routed_experts=engine_captures)
+    adapter = inprocess_vllm_sampler_adapter.InprocessVllmSamplerAdapter(
+        server_id="rollout"
+    )
+    adapter.vllm_sampler = sampler
+    return adapter
+
+  def _requests(self, n):
+    return [
+        base_sampler_lib.SamplingRequest(
+            request_id=f"req-{i}",
+            prompt=np.array([1, 2], dtype=np.int32),
+            sampling_params=base_sampler_lib.SamplingParams(
+                max_tokens=3, return_routed_experts=True
+            ),
+        )
+        for i in range(n)
+    ]
+
+  def test_routing_reaches_each_response_in_order(self):
+    """Row i's routing must land on row i, or replay trains the wrong tokens."""
+    routed = [np.full((3, 2, 2), i, dtype=np.int32) for i in range(2)]
+    responses = asyncio.run(self._adapter(routed).sample(self._requests(2)))
+
+    self.assertLen(responses, 2)
+    for i, response in enumerate(responses):
+      self.assertEqual(response.request_id, f"req-{i}")
+      np.testing.assert_array_equal(response.routed_experts, routed[i])
+
+  def test_warns_when_engine_cannot_capture(self):
+    """Silently returning None would look like a dense model to the trainer."""
+    adapter = self._adapter(None, engine_captures=False)
+    with self.assertLogs(level="WARNING") as logs:
+      asyncio.run(adapter.sample(self._requests(1)))
+    self.assertTrue(
+        any("return_routed_experts" in line for line in logs.output),
+        f"expected a warning about the engine setting, got {logs.output}",
+    )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/experimental/rollout/router_replay_end_to_end_test.py
+++ b/tests/experimental/rollout/router_replay_end_to_end_test.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Rollout MoE routing, from vLLM's output object into a trainer payload.
+
+Drives the real `VllmSampler` with a stubbed vLLM engine that returns genuine
+`vllm.outputs.CompletionOutput` objects carrying `routed_experts`, so this
+half of the chain runs on the exact type vLLM produces:
+
+    CompletionOutput -> VllmSampler -> SamplerOutput -> sampler adapter
+      -> RLTrainerPayload -> batch assembler
+
+The other half -- payload to model -- is shared with the non-experimental
+stack and lives in `tests/rl/router_replay_maxtext_test.py`.
+
+Stubbing the engine keeps this a CPU test with no checkpoint and no TPU. What
+it therefore does NOT cover is tpu-inference's own capture kernel, which fills
+`routed_experts` in the first place; everything downstream of that is real.
+"""
+
+import asyncio
+from unittest import mock
+
+from absl.testing import absltest
+import jax
+from jax.sharding import Mesh
+import numpy as np
+
+from tunix.experimental.common import datatypes
+from tunix.experimental.orchestrator import batch_assembly
+from tunix.experimental.rollout import inprocess_vllm_sampler_adapter
+from tunix.experimental.rollout import sampler as base_sampler_lib
+from tunix.generate import base_sampler
+
+try:
+  from vllm.outputs import CompletionOutput, RequestOutput
+
+  from tunix.generate import vllm_sampler
+
+  VLLM_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on the environment
+  VLLM_AVAILABLE = False
+
+PROMPT_LEN = 4
+GEN_LEN = 4
+NUM_LAYERS = 2
+TOP_K = 2
+NUM_EXPERTS = 4
+
+
+class _StubTokenizer:
+  """Minimal tokenizer surface used by VllmSampler."""
+
+  pad_token_id = 0
+  eos_token_id = 2
+
+  def encode(self, text):
+    del text
+    return list(range(10, 10 + PROMPT_LEN))
+
+  def decode(self, ids):
+    return " ".join(str(int(i)) for i in ids)
+
+  def bos_id(self):
+    return None
+
+  def eos_id(self):
+    return 2
+
+  def pad_id(self):
+    return 0
+
+  def dedup_bos_ids(self, ids):
+    return ids
+
+
+def _routing(length, fill):
+  return np.full((length, NUM_LAYERS, TOP_K), fill, dtype=np.int32)
+
+
+def _request_output(routed_experts):
+  """A genuine vLLM RequestOutput carrying captured routing."""
+  completion = CompletionOutput(
+      index=0,
+      text="answer",
+      token_ids=list(range(20, 20 + GEN_LEN)),
+      cumulative_logprob=None,
+      logprobs=None,
+      routed_experts=routed_experts,
+      finish_reason="stop",
+  )
+  return RequestOutput(
+      request_id="req-0",
+      prompt="q",
+      prompt_token_ids=list(range(10, 10 + PROMPT_LEN)),
+      prompt_logprobs=None,
+      outputs=[completion],
+      finished=True,
+  )
+
+
+@absltest.skipUnless(VLLM_AVAILABLE, "requires vLLM")
+class VllmSamplerRoutingTest(absltest.TestCase):
+  """`VllmSampler` must surface what vLLM put on the CompletionOutput."""
+
+  def _sampler(self, routed_experts, return_routed_experts=True):
+    config = vllm_sampler.VllmConfig(
+        return_logprobs=False,
+        return_routed_experts=return_routed_experts,
+        mesh=Mesh(np.array(jax.devices()[:1]).reshape(1, 1), ("fsdp", "tp")),
+        tensor_parallel_size=1,
+        data_parallel_size=1,
+        engine_kwargs={"model": "stub", "max_model_len": 64},
+    )
+    with mock.patch.object(vllm_sampler, "LLM") as llm_cls:
+      llm = llm_cls.return_value
+      llm.get_default_sampling_params.return_value = (
+          vllm_sampler.SamplingParams()
+      )
+      llm.generate.return_value = [_request_output(routed_experts)]
+      sampler = vllm_sampler.VllmSampler(
+          tokenizer=_StubTokenizer(), config=config
+      )
+    return sampler
+
+  def test_routing_survives_the_sampler(self):
+    """The flag must reach vLLM's engine args, and routing must come back."""
+    routed = _routing(PROMPT_LEN + GEN_LEN, 3)
+    sampler = self._sampler(routed)
+    self.assertTrue(sampler.args.get("enable_return_routed_experts"))
+
+    out = sampler(input_strings=["q"], max_generation_steps=GEN_LEN)
+    self.assertIsNotNone(out.routed_experts, "sampler dropped the routing")
+    np.testing.assert_array_equal(np.asarray(out.routed_experts[0]), routed)
+
+  def test_routing_withheld_when_not_requested(self):
+    """Opt-in: capture off means the trainer sees a normal dense-style step."""
+    sampler = self._sampler(
+        _routing(PROMPT_LEN + GEN_LEN, 3), return_routed_experts=False
+    )
+    self.assertNotIn("enable_return_routed_experts", sampler.args)
+
+    out = sampler(input_strings=["q"], max_generation_steps=GEN_LEN)
+    self.assertIsNone(out.routed_experts)
+
+
+class SamplerToPayloadTest(absltest.TestCase):
+  """Routing must reach a batched RLTrainerPayload with its layout intact."""
+
+  def _sampling_response(self, fill):
+    stub = mock.MagicMock()
+    stub.config = mock.Mock(return_routed_experts=True)
+    stub.return_value = base_sampler.SamplerOutput(
+        text=["answer"],
+        logits=None,
+        tokens=[np.arange(20, 20 + GEN_LEN, dtype=np.int32)],
+        padded_prompt_tokens=np.arange(10, 10 + PROMPT_LEN, dtype=np.int32)[
+            None, :
+        ],
+        logprobs=None,
+        routed_experts=[_routing(PROMPT_LEN + GEN_LEN, fill)],
+    )
+
+    adapter = inprocess_vllm_sampler_adapter.InprocessVllmSamplerAdapter(
+        server_id="rollout"
+    )
+    adapter.vllm_sampler = stub
+    request = base_sampler_lib.SamplingRequest(
+        request_id="req-0",
+        prompt=np.arange(10, 10 + PROMPT_LEN, dtype=np.int32),
+        sampling_params=base_sampler_lib.SamplingParams(
+            max_tokens=GEN_LEN, return_routed_experts=True
+        ),
+    )
+    return asyncio.run(adapter.sample([request]))[0]
+
+  def test_chain_reaches_a_batched_payload(self):
+    response = self._sampling_response(fill=3)
+    self.assertIsNotNone(response.routed_experts)
+
+    payload = datatypes.RLTrainerPayload(
+        advantages=np.zeros(GEN_LEN, dtype=np.float32),
+        loss_mask=np.ones(GEN_LEN, dtype=np.float32),
+        prompt_ids=np.asarray(response.prompt_token_ids, dtype=np.int32),
+        prompt_mask=np.ones(PROMPT_LEN, dtype=np.float32),
+        completion_ids=np.asarray(response.token_ids, dtype=np.int32),
+        completion_mask=np.ones(GEN_LEN, dtype=np.float32),
+        routed_experts=np.asarray(response.routed_experts),
+    )
+    packed = batch_assembly.PaddedBatchAssembler(
+        batch_size=1,
+        max_prompt_length=PROMPT_LEN,
+        max_response_length=GEN_LEN,
+        pad_id=0,
+    ).pack([payload])
+
+    routed = packed[0].routed_experts
+    self.assertIsNotNone(routed, "routing lost between adapter and payload")
+    self.assertEqual(
+        routed.shape, (1, PROMPT_LEN + GEN_LEN, NUM_LAYERS, TOP_K)
+    )
+    # Nothing was truncated, so every slot should be the captured value.
+    np.testing.assert_array_equal(routed[0], 3)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/experimental/worker/trainer_worker_test.py
+++ b/tests/experimental/worker/trainer_worker_test.py
@@ -18,6 +18,8 @@ Verifies TrainerWorker RPC request unpacking (TrainRequest), delegation to
 AbstractTrainer (fwd_bwd, eval_step, update), and response metadata stamping.
 """
 
+from typing import Any
+
 from absl.testing import absltest
 import numpy as np
 from tunix.experimental.common import datatypes

--- a/tests/rl/common_test.py
+++ b/tests/rl/common_test.py
@@ -1014,5 +1014,101 @@ class CommonTest(parameterized.TestCase):
     )
 
 
+_ROUTING_LAYERS = 2
+_ROUTING_TOP_K = 2
+_UNSET = common.UNSET_ROUTED_EXPERT
+
+
+def _routing(length, fill):
+  """`[length, num_layers, top_k]` routing where every slot holds `fill`."""
+  return np.full(
+      (length, _ROUTING_LAYERS, _ROUTING_TOP_K), fill, dtype=np.int32
+  )
+
+
+class AlignRoutedExpertsTest(parameterized.TestCase):
+  """Rollout routing must be padded exactly like the token ids it describes."""
+
+  def test_prompt_right_aligned_and_completion_left_aligned(self):
+    """Prompts are left-padded and completions right-padded, so routing must
+    follow, or every replayed expert lands on the wrong token."""
+    prompt_len, completion_len = 2, 3
+    prompt_width, completion_width = 5, 6
+    routed = np.concatenate(
+        [_routing(prompt_len, 7), _routing(completion_len, 9)], axis=0
+    )
+
+    out = common.align_routed_experts(
+        [routed],
+        completion_lengths=[completion_len],
+        prompt_width=prompt_width,
+        completion_width=completion_width,
+    )
+
+    self.assertEqual(
+        out.shape,
+        (1, prompt_width + completion_width, _ROUTING_LAYERS, _ROUTING_TOP_K),
+    )
+    row = out[0]
+    np.testing.assert_array_equal(row[: prompt_width - prompt_len], _UNSET)
+    np.testing.assert_array_equal(
+        row[prompt_width - prompt_len : prompt_width], 7
+    )
+    np.testing.assert_array_equal(
+        row[prompt_width : prompt_width + completion_len], 9
+    )
+    np.testing.assert_array_equal(row[prompt_width + completion_len :], _UNSET)
+
+  def test_batches_rows_in_order(self):
+    """Row i's routing must stay on row i, or rows train on each other's."""
+    rows = [
+        np.concatenate([_routing(1, i), _routing(2, i)], axis=0)
+        for i in range(3)
+    ]
+    out = common.align_routed_experts(
+        rows, completion_lengths=[2] * 3, prompt_width=1, completion_width=2
+    )
+    self.assertEqual(out.shape[0], 3)
+    for i in range(3):
+      np.testing.assert_array_equal(out[i], i)
+
+  @parameterized.named_parameters(
+      ("nothing_captured", None),
+      ("empty", []),
+      ("partially_captured", "partial"),
+  )
+  def test_replay_is_all_or_nothing(self, rows):
+    """A half-replayed batch would mix replayed and freshly routed rows."""
+    if rows == "partial":
+      rows = [np.concatenate([_routing(1, 1), _routing(2, 1)], axis=0), None]
+    lengths = [2] * (len(rows) if rows else 0)
+    self.assertIsNone(
+        common.align_routed_experts(
+            rows, completion_lengths=lengths, prompt_width=1,
+            completion_width=2,
+        )
+    )
+
+  def test_overlong_prompt_keeps_the_tail(self):
+    """Left padding keeps the last prompt tokens, so routing must too."""
+    prompt = np.concatenate([_routing(1, 5), _routing(1, 6)], axis=0)
+    routed = np.concatenate([prompt, _routing(1, 9)], axis=0)
+    out = common.align_routed_experts(
+        [routed], completion_lengths=[1], prompt_width=1, completion_width=1
+    )
+    # Prompt row 5 is dropped; 6 survives.
+    np.testing.assert_array_equal(out[0, 0], 6)
+    np.testing.assert_array_equal(out[0, 1], 9)
+
+  def test_wrong_rank_is_rejected(self):
+    with self.assertRaisesRegex(ValueError, "length, num_layers, top_k"):
+      common.align_routed_experts(
+          [np.zeros((3, _ROUTING_TOP_K), dtype=np.int32)],
+          completion_lengths=[2],
+          prompt_width=1,
+          completion_width=2,
+      )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/rl/grpo/dapo_learner_test.py
+++ b/tests/rl/grpo/dapo_learner_test.py
@@ -62,6 +62,7 @@ class DAPOlearnerTest(parameterized.TestCase):
     example.segment_ids = None
     example.segment_positions = None
     example.sampler_is_weights = None
+    example.routed_experts = None
     return example
 
   def test_diff_loss(self):

--- a/tests/rl/grpo/drgrpo_learner_test.py
+++ b/tests/rl/grpo/drgrpo_learner_test.py
@@ -67,6 +67,7 @@ class DrGRPOlearnerTest(parameterized.TestCase):
     example.segment_ids = None
     example.segment_positions = None
     example.sampler_is_weights = None
+    example.routed_experts = None
     return example
 
   def test_create_config(self):

--- a/tests/rl/router_replay_maxtext_test.py
+++ b/tests/rl/router_replay_maxtext_test.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Router replay on the non-experimental RL stack, with a MaxText model.
+
+`tunix/rl` reaches the model through `compute_per_token_logps`, which only
+forwards `forced_routed_experts` to models that advertise the kwarg. MaxText's
+`TunixMaxTextAdapter` does; tunix's own models do not. These tests pin both
+halves of that, and that the replay actually changes what the trainer computes.
+
+Skipped unless MaxText is importable, since tunix does not depend on it.
+"""
+
+import os
+import sys
+import tempfile
+from unittest import mock
+
+from absl.testing import absltest
+import jax
+import numpy as np
+
+from tunix.rl import common
+
+try:
+  from flax import nnx
+  from jax.sharding import Mesh
+
+  from maxtext.configs import pyconfig
+  from maxtext.integration.tunix import tunix_adapter
+  from maxtext.models import models
+  from maxtext.utils import maxtext_utils
+
+  MAXTEXT_AVAILABLE = True
+except ImportError:  # pragma: no cover - depends on the environment
+  MAXTEXT_AVAILABLE = False
+
+PROMPT_LEN = 4
+COMPLETION_LEN = 4
+SEQ_LEN = PROMPT_LEN + COMPLETION_LEN
+NUM_LAYERS = 2
+TOP_K = 2
+NUM_EXPERTS = 4
+PAD_ID = 0
+EOS_ID = 1
+
+
+class ModelCallGateTest(absltest.TestCase):
+  """Only models that accept the kwarg may be handed replayed routing."""
+
+  def test_gate_matches_the_call_signature(self):
+
+    class WithReplay:
+
+      def __call__(self, x, forced_routed_experts=None):
+        del x, forced_routed_experts
+
+    class WithoutReplay:
+
+      def __call__(self, x):
+        del x
+
+    self.assertTrue(
+        common.model_call_contains(WithReplay(), "forced_routed_experts")
+    )
+    self.assertFalse(
+        common.model_call_contains(WithoutReplay(), "forced_routed_experts")
+    )
+
+  @absltest.skipUnless(MAXTEXT_AVAILABLE, "requires MaxText")
+  def test_maxtext_adapter_accepts_replay(self):
+    """The gate is worthless if MaxText's real adapter does not pass it."""
+    self.assertTrue(
+        common._call_contains_by_type(  # pylint: disable=protected-access
+            tunix_adapter.TunixMaxTextAdapter, "forced_routed_experts"
+        )
+    )
+
+
+@absltest.skipUnless(MAXTEXT_AVAILABLE, "requires MaxText")
+class ReplayThroughMaxTextTest(absltest.TestCase):
+  """Replayed routing must change the log-probs the trainer computes."""
+
+  def setUp(self):
+    super().setUp()
+    self.enterContext(
+        mock.patch.dict(
+            os.environ, {"NEW_MODEL_DESIGN": "1", "SKIP_JAX_PRECOMPILE": "1"}
+        )
+    )
+    base_yml = os.path.join(
+        os.path.dirname(maxtext_utils.__file__), "..", "configs", "base.yml"
+    )
+    cfg = pyconfig.initialize(
+        [sys.argv[0], base_yml],
+        enable_checkpointing=False,
+        log_config=False,
+        skip_jax_distributed_system=True,
+        override_model_config=True,
+        model_name="qwen3.5-35b-a3b",
+        attention="dot_product",
+        num_experts=NUM_EXPERTS,
+        num_experts_per_tok=TOP_K,
+        base_emb_dim=128,
+        base_num_query_heads=2,
+        base_num_kv_heads=2,
+        head_dim=128,
+        # Qwen3.5 enables MRoPE, whose mrope_section would pin head_dim to the
+        # full model's 256. Irrelevant to routing.
+        use_mrope=False,
+        partial_rotary_factor=0.25,
+        base_mlp_dim=128,
+        base_moe_mlp_dim=128,
+        vocab_size=200,
+        max_target_length=SEQ_LEN,
+        max_prefill_predict_length=PROMPT_LEN,
+        per_device_batch_size=1.0,
+        run_name="rl_router_replay_test",
+        base_output_directory=os.path.join(
+            tempfile.gettempdir(), "rl_router_replay_test"
+        ),
+        base_num_decoder_layers=NUM_LAYERS,
+        num_decoder_layers=NUM_LAYERS,
+        scan_layers=False,
+        enable_dropout=False,
+        weight_dtype="float32",
+        dtype="float32",
+    )
+    mesh = Mesh(maxtext_utils.create_device_mesh(cfg), cfg.mesh_axes)
+    base = models.Transformer(
+        config=cfg, mesh=mesh, quant=None, model_mode="train", rngs=nnx.Rngs(0)
+    )
+    self.model = tunix_adapter.TunixMaxTextAdapter(base, pad_id=PAD_ID)
+    self.prompt = np.arange(10, 10 + PROMPT_LEN, dtype=np.int32)[None, :]
+    self.completion = np.arange(
+        20, 20 + COMPLETION_LEN, dtype=np.int32
+    )[None, :]
+
+  def _logps(self, routed):
+    graphdef, state = nnx.split(self.model)
+    return np.asarray(
+        common.compute_per_token_logps(
+            graphdef,
+            state,
+            prompt_tokens=jax.numpy.asarray(self.prompt),
+            completion_tokens=jax.numpy.asarray(self.completion),
+            pad_id=PAD_ID,
+            eos_id=EOS_ID,
+            routed_experts=routed,
+        )
+    )
+
+  def _routing(self, first, second):
+    routed = np.zeros((1, SEQ_LEN, NUM_LAYERS, TOP_K), dtype=np.int32)
+    routed[..., 0] = first
+    routed[..., 1] = second
+    return jax.numpy.asarray(routed)
+
+  def test_replay_changes_the_logps(self):
+    """Two different replays must disagree.
+
+    Comparing log-probs rather than just asserting they are finite: dropping
+    the routing would still produce perfectly good log-probs, just the
+    normally-routed ones. Note the expert *set* has to differ -- permuting the
+    top-k slots yields identical output, since the MoE scatter accumulates
+    both experts' contributions.
+    """
+    logps_a = self._logps(self._routing(1, 3))
+    logps_b = self._logps(self._routing(0, 2))
+    self.assertFalse(np.isnan(logps_a).any(), "replay produced NaN log-probs")
+    self.assertFalse(
+        np.allclose(logps_a, logps_b),
+        "forcing different experts gave identical log-probs, so the replayed "
+        "routing is not reaching the MoE layers",
+    )
+
+  def test_no_replay_still_works(self):
+    """Replay stays opt-in: without routing this is an ordinary forward."""
+    logps = self._logps(None)
+    self.assertEqual(logps.shape[0], 1)
+    self.assertFalse(np.isnan(logps).any())
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tunix/common/configs.py
+++ b/tunix/common/configs.py
@@ -119,6 +119,11 @@ class RolloutConfig:
   # Whether to return logprobs from the sampler.
   return_logprobs: bool = False
 
+  # Whether to capture the MoE experts each token was routed through, so the
+  # trainer can replay them instead of re-running its own router. MoE models on
+  # a backend that supports capture only; a no-op otherwise.
+  return_routed_experts: bool = False
+
   # vLLM specific rollout configs.
 
   # Whether to run rollout in vLLM server mode or batch inference mode.

--- a/tunix/experimental/common/datatypes.py
+++ b/tunix/experimental/common/datatypes.py
@@ -37,6 +37,10 @@ Step = agent_types.Step
 TrajectoryStatus = agent_types.TrajectoryStatus
 Role = common_datatypes.Role
 
+# Marks a router-replay slot the trainer must not replay, so the model falls
+# back to its own gate there. Matches what MaxText's replay path expects.
+UNSET_ROUTED_EXPERT = -1
+
 
 # TODO(tunix-dev): Unify this extended TrajectoryItem back into
 # agent_types.TrajectoryItem so that all agentic workflows share the same strict
@@ -44,6 +48,7 @@ Role = common_datatypes.Role
 @dataclasses.dataclass(kw_only=True)
 class TrajectoryItem:
   """Extended TrajectoryItem for Orchestrator with token arrays."""
+
   prompt_id: str = ""
   group_index: int = 0
   start_step: int = 0
@@ -51,6 +56,9 @@ class TrajectoryItem:
   prompt_tokens: np.ndarray | None = None
   completion_tokens: np.ndarray | None = None
   action_mask: np.ndarray | None = None
+  # `[len(prompt_tokens) + len(completion_tokens), num_layers, top_k]` expert
+  # ids from the rollout, for replaying its routing during training.
+  routed_experts: np.ndarray | None = None
   policy_version: int = 0
   metadata: dict[str, Any] = dataclasses.field(default_factory=dict)
 
@@ -272,12 +280,17 @@ class TokenSegment:
     loss_mask: Array of ints, 1 where the token is model-emitted (trainable).
     logps: Array of per-token log-probabilities under the sampling distribution,
       or None for spans the model did not emit (e.g. env tokens).
+    routed_experts: `[len(tokens), num_layers, top_k]` MoE expert ids this span
+      was routed through, so training can replay the routing the rollout
+      actually used. None for dense models, spans the model did not emit, or
+      when the sampler was not asked to capture routing.
   """
 
   source: str
   tokens: np.ndarray
   loss_mask: np.ndarray
   logps: np.ndarray | None = None
+  routed_experts: np.ndarray | None = None
 
   def __post_init__(self):
     if self.loss_mask.shape != self.tokens.shape:
@@ -289,6 +302,19 @@ class TokenSegment:
       raise ValueError(
           f"logps shape {self.logps.shape} != tokens shape {self.tokens.shape}"
       )
+    if self.routed_experts is not None:
+      # The trailing axes are [num_layers, top_k] and are model-dependent, so
+      # only the rank and the leading (per-token) axis are checked.
+      if self.routed_experts.ndim != 3:
+        raise ValueError(
+            "routed_experts must be [length, num_layers, top_k]; got shape"
+            f" {self.routed_experts.shape}"
+        )
+      if self.routed_experts.shape[0] != self.tokens.shape[0]:
+        raise ValueError(
+            f"routed_experts shape {self.routed_experts.shape} does not cover"
+            f" tokens shape {self.tokens.shape} along axis 0"
+        )
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -577,6 +603,11 @@ class RLTrainerPayload(TrainerPayload):
     ref_per_token_logps: Optional [B, C] reference model log-probabilities.
     old_per_token_logps: Optional [B, C] behavior policy log-probabilities.
     sampler_is_weights: Optional [B, C] importance sampling weights.
+    routed_experts: Optional `[B, T, num_layers, top_k]` MoE expert ids
+      captured during rollout. When set, a training engine that supports router
+      replay forces these experts instead of re-running its own gate, so the
+      training forward pass matches the routing the rollout actually used. `-1`
+      marks a padded or unused slot.
     returns: Optional [B, C] value baseline returns (for PPO / Critic).
     old_values: Optional [B, C] critic value estimates (for PPO / Critic).
     metadata: Extra payload metadata dictionary.
@@ -594,6 +625,7 @@ class RLTrainerPayload(TrainerPayload):
   ref_per_token_logps: ArrayLike | None = None
   old_per_token_logps: ArrayLike | None = None
   sampler_is_weights: ArrayLike | None = None
+  routed_experts: ArrayLike | None = None
   returns: ArrayLike | None = None
   old_values: ArrayLike | None = None
   metadata: dict[str, Any] = dataclasses.field(default_factory=dict)

--- a/tunix/experimental/orchestrator/algorithm_adapter.py
+++ b/tunix/experimental/orchestrator/algorithm_adapter.py
@@ -29,6 +29,40 @@ from tunix.experimental.common import datatypes
 from tunix.rl import algo_core
 
 
+def _routed_experts_for(
+    item: datatypes.TrajectoryItem, seq_len: int
+) -> np.ndarray | None:
+  """Aligns a rollout's captured routing to the payload's token sequence.
+
+  Args:
+    item: Trajectory item, whose `routed_experts` (if any) is
+      `[captured_len, num_layers, top_k]`.
+    seq_len: Length of the prompt+completion sequence in the payload.
+
+  Returns:
+    `[seq_len, num_layers, top_k]`, or None when nothing was captured. Rows
+    beyond what the rollout reported are left `UNSET_ROUTED_EXPERT` so the
+    model falls back to its own gate there rather than replaying a wrong
+    expert.
+  """
+  if item.routed_experts is None:
+    return None
+  routed = np.asarray(item.routed_experts, dtype=np.int32)
+  if routed.ndim != 3:
+    raise ValueError(
+        "routed_experts must be [length, num_layers, top_k]; got shape"
+        f" {routed.shape}"
+    )
+  if routed.shape[0] >= seq_len:
+    return routed[:seq_len]
+  pad = np.full(
+      (seq_len - routed.shape[0],) + routed.shape[1:],
+      datatypes.UNSET_ROUTED_EXPERT,
+      dtype=np.int32,
+  )
+  return np.concatenate([routed, pad], axis=0)
+
+
 class AlgorithmAdapter(abc.ABC):
   """Abstract algorithm adapter for returns math, advantages, and loss functions."""
 
@@ -148,6 +182,7 @@ class GRPOAdapter(AlgorithmAdapter):
           completion_ids=c_arr,
           completion_mask=act_arr,
           ref_per_token_logps=np.asarray(ref_lp, dtype=np.float32) if ref_lp is not None else None,
+          routed_experts=_routed_experts_for(item, len(seq_tokens)),
       )
       payloads.append(payload)
     return payloads

--- a/tunix/experimental/orchestrator/batch_assembly.py
+++ b/tunix/experimental/orchestrator/batch_assembly.py
@@ -54,6 +54,51 @@ def _left_pad(
   return out, mask
 
 
+def _routed_experts_aligned(
+    routed: np.ndarray,
+    prompt_len: int,
+    completion_len: int,
+    max_prompt_length: int,
+    max_response_length: int,
+) -> np.ndarray:
+  """Lays one row of routing out over the padded `[prompt | completion]`.
+
+  Mirrors how the token ids themselves are padded -- prompts right-aligned in
+  the prompt window (keeping the tail, as `_left_pad` does) and completions
+  left-aligned in the response window -- so replayed routing stays attached to
+  the token it was captured for. Everything else is left unset.
+
+  Args:
+    routed: `[prompt_len + completion_len, num_layers, top_k]` for one
+      generation. Only axis 0 (the per-token axis) is ever sliced below; the
+      trailing `[num_layers, top_k]` axes are carried through untouched.
+    prompt_len: Unpadded prompt length, i.e. where the completion starts.
+    completion_len: Unpadded completion length.
+    max_prompt_length: Padded prompt width.
+    max_response_length: Padded completion width.
+
+  Returns:
+    `[max_prompt_length + max_response_length, num_layers, top_k]`.
+  """
+  routed = np.asarray(routed, dtype=np.int32)
+  # Prompts are left-padded, so an over-long one keeps its tail; completions are
+  # right-padded, so an over-long one keeps its head.
+  kept_prompt_start = max(prompt_len - max_prompt_length, 0)
+  kept_completion_end = prompt_len + min(completion_len, max_response_length)
+  prompt_part = routed[kept_prompt_start:prompt_len]
+  completion_part = routed[prompt_len:kept_completion_end]
+
+  out = np.full(
+      (max_prompt_length + max_response_length,) + routed.shape[1:],
+      datatypes.UNSET_ROUTED_EXPERT,
+      dtype=np.int32,
+  )
+  prompt_end = max_prompt_length
+  out[prompt_end - len(prompt_part) : prompt_end] = prompt_part
+  out[prompt_end : prompt_end + len(completion_part)] = completion_part
+  return out
+
+
 def _right_pad(
     values: np.ndarray,
     length: int,
@@ -486,6 +531,10 @@ class PaddedBatchAssembler:
     optional_rows: dict[str, list[np.ndarray]] = {
         name: [] for name in present_fields
     }
+    # Router replay is all-or-nothing per batch: a partially replayed batch
+    # would silently mix replayed and freshly routed rows.
+    replay_routing = all(it.routed_experts is not None for it in chunk)
+    routed_experts_rows: list[np.ndarray] = []
     truncated_prompts = truncated_completions = 0
 
     for item in chunk:
@@ -566,6 +615,23 @@ class PaddedBatchAssembler:
             )
         )
 
+      # `replay_routing` already guarantees this is set; binding it locally
+      # also narrows the optional field for the type checker.
+      routed = item.routed_experts
+      if replay_routing and routed is not None:
+        routed_experts_rows.append(
+            _routed_experts_aligned(
+                # `routed_experts` is declared ArrayLike, which admits jax
+                # arrays and scalars; concretise it here as the sibling fields
+                # above do.
+                np.asarray(routed, dtype=np.int32),
+                p_full.size,
+                c.size,
+                self.max_prompt_length,
+                self.max_response_length,
+            )
+        )
+
     if truncated_prompts or truncated_completions:
       logging.warning(
           "PaddedBatchAssembler truncated %d prompt(s) to %d tokens and %d "
@@ -591,6 +657,10 @@ class PaddedBatchAssembler:
       advantages.append(np.zeros(self.max_response_length, dtype=np.float32))
       for rows in optional_rows.values():
         rows.append(np.zeros(self.max_response_length, dtype=np.float32))
+      if routed_experts_rows:
+        routed_experts_rows.append(
+            np.full_like(routed_experts_rows[0], datatypes.UNSET_ROUTED_EXPERT)
+        )
 
     batched_prompt_ids = np.stack(prompt_ids)
     batched_prompt_mask = np.stack(prompt_mask)
@@ -619,4 +689,7 @@ class PaddedBatchAssembler:
         returns=stacked_optional.get("returns"),
         old_values=stacked_optional.get("old_values"),
         sampler_is_weights=stacked_optional.get("sampler_is_weights"),
+        routed_experts=(
+            np.stack(routed_experts_rows) if routed_experts_rows else None
+        ),
     )

--- a/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
@@ -224,6 +224,7 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
     top_ks = []
     seeds = []
     return_logprobs_list = []
+    return_routed_experts_list = []
 
     for req in requests:
       prompt = req.prompt if hasattr(req, "prompt") else req
@@ -241,6 +242,7 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
       top_ks.append(sp.top_k)
       seeds.append(sp.seed)
       return_logprobs_list.append(sp.return_logprobs)
+      return_routed_experts_list.append(sp.return_routed_experts)
 
     max_generation_steps = (
         max(max_gen_steps_list) if max_gen_steps_list else 64
@@ -252,6 +254,19 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
     return_logprobs = any(return_logprobs_list) or kwargs.get(
         "return_logprobs", False
     )
+    # Capture is an engine-level vLLM setting, so it cannot be turned on
+    # per request. Warn rather than silently handing back None routing, which
+    # would look like a dense model to the trainer.
+    if any(return_routed_experts_list) and not getattr(
+        self.vllm_sampler.config, "return_routed_experts", False
+    ):
+      logging.warning(
+          "InprocessVllmSamplerAdapter [%s]: routed experts were requested per"
+          " request, but the vLLM engine was built without"
+          " return_routed_experts, so none will be returned. Set"
+          " return_routed_experts on the sampler's VllmConfig.",
+          self.server_id,
+      )
 
     sampler_output = self.vllm_sampler(
         input_strings=prompts,
@@ -281,6 +296,9 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
       if sampler_output.logprobs and isinstance(sampler_output.logprobs, list):
         lps = sampler_output.logprobs[i]
 
+      routed_list = getattr(sampler_output, "routed_experts", None) or []
+      routed = routed_list[i] if i < len(routed_list) else None
+
       tok_ids = (
           np.array(toks, dtype=np.int32)
           if toks is not None
@@ -298,6 +316,7 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
               prompt_token_ids=prompt_token_ids,
               token_ids=tok_ids,
               logprobs=log_ps,
+              routed_experts=routed,
               finish_reason="stop",
           )
       )

--- a/tunix/experimental/rollout/sampler.py
+++ b/tunix/experimental/rollout/sampler.py
@@ -38,6 +38,10 @@ class SamplingParams:
     seed: Random seed for reproducible generation.
     return_logprobs: Whether to record per-token log probabilities.
     return_logits: Whether to record per-token output logits.
+    return_routed_experts: Whether to record the MoE expert ids each token was
+      routed through, so training can replay them instead of re-routing. Only
+      meaningful for MoE models on a backend that supports capture; the backend
+      must also be configured to capture, since it is an engine-level setting.
     beam_size: Beam width for beam search decoding.
   """
 
@@ -48,6 +52,7 @@ class SamplingParams:
   seed: int | None = None
   return_logprobs: bool = False
   return_logits: bool = False
+  return_routed_experts: bool = False
   beam_size: int | None = None
 
 
@@ -80,8 +85,10 @@ class SamplingResponse(datatypes.Response):
       "cancelled", "error").
     error: Structured failure details when sampling failed for this prompt, else
       None (inherited from datatypes.Response).
-    routed_experts: Array of routed expert IDs of shape [Batch, Layers, Length,
-      Top K], or None if not requested.
+    routed_experts: Per-token MoE expert ids for this one completion, shaped
+      `[Length, Layers, Top K]` to match what the backend reports. Covers the
+      prompt as well as the generated tokens. None if not requested, or if the
+      model is dense.
   """
 
   text: str = ""

--- a/tunix/generate/base_sampler.py
+++ b/tunix/generate/base_sampler.py
@@ -47,6 +47,11 @@ class SamplerOutput:
 
   logprobs: Optional[list[list[float]]]
 
+  # Per-generation MoE routing decisions, each `[length, num_layers, top_k]`.
+  # None unless the backend was asked to capture them. Used to replay the
+  # rollout's expert choices during training instead of re-routing.
+  routed_experts: Optional[list[np.ndarray | None]] = None
+
 
 class BaseSampler(ABC):
   """Base class for samplers."""

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -55,6 +55,9 @@ class VllmConfig:
       default_factory=MappingConfig
   )
   return_logprobs: bool = False
+  # Capture the MoE expert ids the rollout actually routed through, so training
+  # can replay them. Sets vLLM's `enable_return_routed_experts` engine arg.
+  return_routed_experts: bool = False
 
   # vLLM Env vars
   init_with_random_weights: bool = True
@@ -328,6 +331,9 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
 
     args["gpu_memory_utilization"] = config.hbm_utilization
 
+    if config.return_routed_experts:
+      args["enable_return_routed_experts"] = True
+
     args["additional_config"] = config.additional_config or {}
 
     if config.lora_config is not None:
@@ -407,13 +413,17 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
   def detokenize(
       self, input_strings: List[str], request_outputs: List[RequestOutput]
   ) -> Tuple[
-      List[List[str]], List[List[List[float] | None]], List[List[np.ndarray]]
+      List[List[str]],
+      List[List[List[float] | None]],
+      List[List[np.ndarray]],
+      List[List[np.ndarray | None]],
   ]:
     """Detokenize the vllm outputs."""
     generations = len(request_outputs[0].outputs)
     decoded_outputs = [[] for _ in range(generations)]
     out_logprobs = [[] for _ in range(generations)]
     out_tokens = [[] for _ in range(generations)]
+    out_routed_experts = [[] for _ in range(generations)]
     for input_string, multi_sampling_output in zip(
         input_strings, request_outputs
     ):
@@ -436,12 +446,16 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
             list(single_output.token_ids), single_output.logprobs  # pyrefly: ignore[bad-argument-type]
         )
         out_logprobs[idx].append(logprobs)
+        # `[length, num_layers, top_k]`, or None when capture is disabled.
+        out_routed_experts[idx].append(
+            getattr(single_output, "routed_experts", None)
+        )
         logging.debug(
             "Prompt: %r\n\nGenerated text: %r\n\n ",
             input_string,
             decoded_outputs[idx][-1],
         )
-    return decoded_outputs, out_logprobs, out_tokens
+    return decoded_outputs, out_logprobs, out_tokens, out_routed_experts
 
   def _generate_server_mode(
       self,
@@ -590,8 +604,8 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           sampling_params=sampling_params,
           use_tqdm=True,
       )
-    decoded_outputs, out_logprobs, out_tokens = self.detokenize(
-        input_strings, outputs
+    decoded_outputs, out_logprobs, out_tokens, out_routed_experts = (
+        self.detokenize(input_strings, outputs)
     )
     if self.config.return_logprobs and (
         out_logprobs is None or out_logprobs[0] is None
@@ -620,4 +634,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
         tokens=out_tokens[0],
         padded_prompt_tokens=all_input_ids,
         logprobs=out_logprobs[0] if self.config.return_logprobs else None,  # pyrefly: ignore[bad-argument-type]
+        routed_experts=(
+            out_routed_experts[0] if self.config.return_routed_experts else None
+        ),
     )

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -425,6 +425,7 @@ def grpo_loss_fn(
       segment_positions=getattr(train_example, "segment_positions", None),
       temperature=algo_config.temperature,
       chunk_size=kwargs.get("compute_logps_chunk_size", 0),
+      routed_experts=getattr(train_example, "routed_experts", None),
   )
   per_token_logps = jnp.astype(per_token_logps, jnp.float32)
   # TODO(tsbao): We should handle token level advantages.

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -15,7 +15,7 @@
 
 import functools
 import inspect
-from typing import Any, Iterable
+from typing import Any, Iterable, Sequence
 
 import flax
 from flax import nnx
@@ -123,6 +123,11 @@ class TrainExample:
   # to dampen positions where the trainer's recomputed log-probability
   # diverges from the rollout sampler's. ``None`` disables the correction.
   sampler_is_weights: ArrayType | None = None
+  # `[B, P + C, num_layers, top_k]` MoE experts the rollout routed through,
+  # laid out over the same `[prompt | completion]` padding as the token ids.
+  # When set, a model that accepts `forced_routed_experts` replays these
+  # instead of re-running its router. `-1` marks a slot to leave to the router.
+  routed_experts: ArrayType | None = None
 
   def to_jax_array(self) -> "TrainExample":
     """Returns a copy of the batch with all array fields moved to JAX array."""
@@ -291,6 +296,74 @@ def process_ids(
   return prompt_completion_ids, positions, attn_mask, input_seg_ids
 
 
+# Marks a router-replay slot the trainer must leave to the model's own router.
+# `-1` and not `0`, because expert 0 is a real expert.
+UNSET_ROUTED_EXPERT = -1
+
+
+def align_routed_experts(
+    routed_experts: Sequence[np.ndarray | None] | None,
+    completion_lengths: Sequence[int],
+    prompt_width: int,
+    completion_width: int,
+) -> np.ndarray | None:
+  """Lays rollout routing out over the padded `[prompt | completion]` stream.
+
+  The rollout reports `[prompt_len + completion_len, num_layers, top_k]` per
+  generation, while the trainer sees prompts left-padded to `prompt_width` and
+  completions right-padded to `completion_width`. Routing has to be padded the
+  same way, or every replayed expert detaches from the token it was captured
+  for -- a silent wrong-answer bug rather than a crash.
+
+  Args:
+    routed_experts: One array per generation, or None. Replay is
+      all-or-nothing: if any row is missing, the whole batch falls back to the
+      model's own router rather than mixing replayed and fresh rows.
+    completion_lengths: Unpadded completion length per generation. The prompt /
+      completion split cannot be inferred from the widths alone, since both
+      sides are padded.
+    prompt_width: Padded prompt length.
+    completion_width: Padded completion length.
+
+  Returns:
+    `[B, prompt_width + completion_width, num_layers, top_k]`, or None.
+  """
+  if not routed_experts or any(r is None for r in routed_experts):
+    return None
+  if len(routed_experts) != len(completion_lengths):
+    raise ValueError(
+        f"got {len(routed_experts)} routing rows but"
+        f" {len(completion_lengths)} completion lengths"
+    )
+
+  rows = []
+  for routed, completion_len in zip(routed_experts, completion_lengths):
+    routed = np.asarray(routed, dtype=np.int32)
+    if routed.ndim != 3:
+      raise ValueError(
+          "routed_experts must be [length, num_layers, top_k]; got shape"
+          f" {routed.shape}"
+      )
+    # Prompts are left-padded, so an over-long one keeps its tail; completions
+    # are right-padded, so an over-long one keeps its head.
+    split = max(routed.shape[0] - completion_len, 0)
+    kept_prompt_start = max(split - prompt_width, 0)
+    kept_completion_end = split + min(routed.shape[0] - split, completion_width)
+    prompt_part = routed[kept_prompt_start:split]
+    completion_part = routed[split:kept_completion_end]
+    row = np.full(
+        (prompt_width + completion_width,) + routed.shape[1:],
+        UNSET_ROUTED_EXPERT,
+        dtype=np.int32,
+    )
+    row[prompt_width - prompt_part.shape[0] : prompt_width] = prompt_part
+    row[prompt_width : prompt_width + completion_part.shape[0]] = (
+        completion_part
+    )
+    rows.append(row)
+  return np.stack(rows)
+
+
 @functools.cache
 def _call_contains_by_type(target_cls: type[Any], target_arg: str) -> bool:
   """Determines if a class' call function contains a target argument and caches the result."""
@@ -337,6 +410,7 @@ def compute_per_token_logps(
     segment_positions: jax.Array | None = None,
     temperature: float = 1.0,
     chunk_size: int = 0,
+    routed_experts: jax.Array | None = None,
 ) -> jax.Array | tuple[jax.Array, jax.Array]:
   """Computes the per-token log probabilities.
 
@@ -360,6 +434,10 @@ def compute_per_token_logps(
     temperature: temperature used for rollout.
     chunk_size: If not 0, computes the log probabilities in sequence chunks of
       this size.
+    routed_experts: Optional `[B, T, num_layers, top_k]` MoE experts captured
+      during rollout. Forwarded to the model as `forced_routed_experts` -- the
+      name MaxText's adapter uses -- so it replays this routing instead of
+      re-running its router. Ignored by models that do not accept the kwarg.
 
   Returns:
     per_token_logps: jax.Array token-level logarithmic values.
@@ -412,6 +490,13 @@ def compute_per_token_logps(
       model_kwargs["segment_ids"] = input_seg_ids
   if images is not None:
     model_kwargs["images"] = images
+  # Router replay. `forced_routed_experts` is the model-side name (MaxText's
+  # adapter); only models that advertise it can consume it, so everything else
+  # is unaffected.
+  if routed_experts is not None and model_call_contains(
+      model, "forced_routed_experts"
+  ):
+    model_kwargs["forced_routed_experts"] = routed_experts
 
   outputs, _ = model(input_tokens, **model_kwargs)
 

--- a/tunix/rl/grpo/grpo_learner.py
+++ b/tunix/rl/grpo/grpo_learner.py
@@ -269,6 +269,15 @@ class GRPOLearner(rl_learner.RLLearner[TGrpoConfig]):
         for completion_ids in rollout_output.tokens
     ])
     prompt_ids = jnp.array(rollout_output.left_padded_prompt_tokens)
+    # Router replay: lay the rollout's routing out over the same
+    # `[prompt | completion]` padding the token ids just got, so a replayed
+    # expert stays attached to the token it was captured for.
+    routed_experts = common.align_routed_experts(
+        rollout_output.routed_experts,
+        completion_lengths=[len(t) for t in rollout_output.tokens],
+        prompt_width=prompt_ids.shape[-1],
+        completion_width=rollout_config.max_tokens_to_generate,
+    )
 
     # Assemble masks
     prompt_mask = prompt_ids != pad_value
@@ -497,6 +506,9 @@ class GRPOLearner(rl_learner.RLLearner[TGrpoConfig]):
         advantages=jax.device_put(advantages),
         old_per_token_logps=old_per_token_logps,
         sampler_is_weights=sampler_is_weights,
+        routed_experts=(
+            None if routed_experts is None else jax.device_put(routed_experts)
+        ),
     )
 
   def _compute_trajectory_ids(

--- a/tunix/rl/rollout/base_rollout.py
+++ b/tunix/rl/rollout/base_rollout.py
@@ -57,6 +57,12 @@ class RolloutOutput:
   # The log probs from sampler generations.
   logprobs: list[np.ndarray] | None
 
+  # Per-generation MoE routing decisions, each `[length, num_layers, top_k]`
+  # covering prompt + completion, so training can replay the experts the
+  # rollout actually routed through instead of re-running the router. None
+  # unless the backend was asked to capture them, or for dense models.
+  routed_experts: list[np.ndarray | None] | None = None
+
 
 class BaseRollout(ABC):
   """Base RolloutWorker."""

--- a/tunix/rl/rollout/vllm_rollout.py
+++ b/tunix/rl/rollout/vllm_rollout.py
@@ -52,6 +52,7 @@ class VllmRollout(base_rollout.BaseRollout):
             ),
             mapping_config=mapping_config,
             return_logprobs=rollout_config.return_logprobs,
+            return_routed_experts=rollout_config.return_routed_experts,
             init_with_random_weights=rollout_config.rollout_vllm_init_with_random_weights,
             tpu_backend_type=rollout_config.rollout_vllm_tpu_backend_type,  # pyrefly: ignore[bad-argument-type]
             additional_config=rollout_config.rollout_vllm_additional_config,
@@ -117,6 +118,7 @@ class VllmRollout(base_rollout.BaseRollout):
         tokens=self.output.tokens,  # pyrefly: ignore[bad-argument-type]
         left_padded_prompt_tokens=self.output.padded_prompt_tokens,
         logprobs=self.output.logprobs,  # pyrefly: ignore[bad-argument-type]
+        routed_experts=self.output.routed_experts,
     )
 
   def get_per_token_logps(


### PR DESCRIPTION
Lets an RL run replay the MoE expert routing a rollout actually used instead of re-running the router during training. Both ends already existed -- vLLM and tpu-inference capture routing (`enable_return_routed_experts` -> `CompletionOutput.routed_experts`, `[length, num_layers, top_k]`) and MaxText consumes it (`forced_routed_experts`) -- so this is the middle.


Sampler side:
- `VllmConfig.return_routed_experts` sets vLLM's engine arg; `VllmSampler.detokenize` collects the arrays and `SamplerOutput` carries them.
- The in-process adapter populates `SamplingResponse.routed_experts`, and warns when a request asks for routing the engine was not built to capture, since capture is engine-level and the alternative is silently handing the trainer None -- indistinguishable from a dense model.

Pipeline side:
- `routed_experts` on `TokenSegment`, `TrajectoryItem` and `RLTrainerPayload`, plus `UNSET_ROUTED_EXPERT = -1` for slots the trainer must not replay.
- The GRPO adapter pads short captures with the sentinel rather than expert 0.
- The padded assembler lays routing out over `[prompt | completion]` the same way the token ids are padded: prompts right-aligned keeping the tail (as `_left_pad` does), completions left-aligned. Getting this wrong detaches every replayed expert from its token -- silent, not a crash.

Demo side (math_gsm8k_dist), all opt-in:
- trainer node: `--trainer_engine=maxtext` swaps PeftTrainer for MaxText's engine wired for replay, importing MaxText lazily and skipping the tunix actor model, which only knows the demo's dense architectures. `--maxtext_load_parameters_path` points it at the checkpoint; without one it warns, since random trainer weights make replayed routing meaningless.
- rollout node: `--return_routed_experts`, and `--load_rollout_weights` to load the real checkpoint instead of vLLM's dummy weights. With both sides on the same weights a first step is meaningful with no weight transfer at all.
- `launcher.sh` and `k8s_launcher.sh`: `ROUTER_REPLAY=1` sets the above; slices and meshes are now configurable rather than hardcoded.
- Dockerfile: opt-in `INSTALL_MAXTEXT` build arg, which also drops triton (GPU-only, and its native module aborts the process when MaxText imports on a TPU host).

Tests pin layout rather than mere presence, since the realistic failure is misalignment. The loss assertions are differential -- two different replays must disagree -- because a "loss is finite" check passes just as happily when the routing is dropped. Each was verified to fail against a mutation that disables what it covers.



**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [x] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
