### PR TITLE
fix: handle JSON-string finish arguments in ToolEnvironment._extract_llm_answer

### DIFF
--- a/tests/rl/agentic/environments/tool_environment_test.py
+++ b/tests/rl/agentic/environments/tool_environment_test.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from absl.testing import absltest
+from tunix.rl.agentic.environments import tool_environment
+
+ToolEnvironment = tool_environment.ToolEnvironment
+
+
+class ExtractLlmAnswerTest(absltest.TestCase):
+
+  def test_plain_string_action(self):
+    self.assertEqual(ToolEnvironment._extract_llm_answer("42"), "42")
+
+  def test_finish_with_dict_arguments(self):
+    action = [
+        {"function": {"name": "finish", "arguments": {"response": "42"}}}
+    ]
+    self.assertEqual(ToolEnvironment._extract_llm_answer(action), "42")
+
+  def test_finish_with_json_string_arguments(self):
+    # ToolAgent.update_from_model serializes parsed tool-call arguments with
+    # json.dumps, so an explicit finish tool call emitted by the model (e.g.
+    # <tool_call>{"name": "finish", ...}</tool_call>) arrives here with
+    # `arguments` as a JSON string rather than a dict.
+    action = [{
+        "function": {
+            "name": "finish",
+            "arguments": json.dumps({"response": "42"}),
+        }
+    }]
+    self.assertEqual(ToolEnvironment._extract_llm_answer(action), "42")
+
+  def test_finish_with_non_json_string_arguments(self):
+    action = [{"function": {"name": "finish", "arguments": "plain text"}}]
+    self.assertEqual(
+        ToolEnvironment._extract_llm_answer(action), "plain text"
+    )
+
+
+class ToolEnvironmentStepTest(absltest.TestCase):
+
+  def test_step_with_json_string_finish_computes_reward(self):
+    env = ToolEnvironment(
+        task={"question": "q"},
+        tool_map={},
+        reward_fn=lambda task, action: 1.0 if action == "42" else 0.0,
+        max_steps=3,
+    )
+    env.reset()
+
+    _, reward, done, _ = env.step([{
+        "function": {
+            "name": "finish",
+            "arguments": json.dumps({"response": "42"}),
+        }
+    }])
+
+    self.assertTrue(done)
+    self.assertEqual(reward, 1.0)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/rl/agentic/environments/tool_environment_test.py
+++ b/tests/rl/agentic/environments/tool_environment_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,9 +26,7 @@ class ExtractLlmAnswerTest(absltest.TestCase):
     self.assertEqual(ToolEnvironment._extract_llm_answer("42"), "42")
 
   def test_finish_with_dict_arguments(self):
-    action = [
-        {"function": {"name": "finish", "arguments": {"response": "42"}}}
-    ]
+    action = [{"function": {"name": "finish", "arguments": {"response": "42"}}}]
     self.assertEqual(ToolEnvironment._extract_llm_answer(action), "42")
 
   def test_finish_with_json_string_arguments(self):
@@ -46,9 +44,7 @@ class ExtractLlmAnswerTest(absltest.TestCase):
 
   def test_finish_with_non_json_string_arguments(self):
     action = [{"function": {"name": "finish", "arguments": "plain text"}}]
-    self.assertEqual(
-        ToolEnvironment._extract_llm_answer(action), "plain text"
-    )
+    self.assertEqual(ToolEnvironment._extract_llm_answer(action), "plain text")
 
 
 class ToolEnvironmentStepTest(absltest.TestCase):

--- a/tunix/rl/agentic/environments/tool_environment.py
+++ b/tunix/rl/agentic/environments/tool_environment.py
@@ -180,6 +180,13 @@ class ToolEnvironment(base_environment.BaseTaskEnv):
       for call in action:
         if call.get("function", {}).get("name") == "finish":
           args = call["function"].get("arguments", {})
+          if isinstance(args, str):
+            # ToolAgent serializes parsed tool-call arguments with json.dumps,
+            # so explicit finish tool calls arrive as a JSON string.
+            try:
+              args = json.loads(args)
+            except json.JSONDecodeError:
+              return args
           return args.get("response", "")
     # Fallback: convert action to string representation.
     return str(action)


### PR DESCRIPTION
## Summary

`ToolEnvironment._extract_llm_answer` raises `AttributeError: 'str' object has no attribute 'get'` when the model ends an episode with an **explicit** `finish` tool call (e.g. Qwen-format `<tool_call>{"name": "finish", "arguments": {"response": "..."}}</tool_call>`) instead of plain text.

## Root cause

The two code paths in `ToolAgent.update_from_model` produce inconsistent types for `function.arguments`:

- Fallback path (no tool call parsed → synthetic `finish`): `arguments` is a **dict** (`{"response": response}`).
- Parser path (tool call parsed from model text): `arguments` is **`json.dumps`-stringified**:

```python
# tunix/rl/agentic/agents/tool_agent.py
args = tool_call.arguments
if isinstance(args, dict):
    args = json.dumps(args)
```

`_extract_llm_answer` only handles the dict shape:

```python
args = call["function"].get("arguments", {})
return args.get("response", "")   # AttributeError when args is a JSON string
```

So any model that learned to emit `finish` through the documented tool-call format crashes the rollout during reward computation. (The episode-termination check just above, `name == "finish"`, matches fine — only the answer extraction breaks.)

## Fix

Make `_extract_llm_answer` tolerant of the stringified form: parse JSON-string arguments, and fall back to returning the raw string when it isn't valid JSON. Changing `ToolAgent` to stop stringifying was considered, but other consumers may rely on the string form, so this is the narrower fix.

## Testing

Added `tests/rl/agentic/environments/tool_environment_test.py` covering:

- dict arguments (existing behavior, still passes)
- JSON-string arguments (regression: crashed before this fix)
- non-JSON string arguments
- an end-to-end `env.step()` with a JSON-string `finish` call producing the correct reward

```
5 passed in 1.20s
```

Fixes https://github.com/google/tunix/issues/2050
