### PR TITLE
Bootstrap rollout policy from target state

### DIFF
--- a/tests/experimental/orchestrator/distributed_rl_engine_test.py
+++ b/tests/experimental/orchestrator/distributed_rl_engine_test.py
@@ -51,6 +51,8 @@ class MockActorHandle(mock.MagicMock):
     self.save_checkpoint = mock.AsyncMock()
     self.restore_checkpoint = mock.AsyncMock()
     self.get_metrics = mock.AsyncMock(return_value={})
+    self.get_target_state = mock.AsyncMock(return_value={"params": 1})
+    self.set_target_state = mock.AsyncMock()
 
   async def asubmit(self, method_name: str, *args, **kwargs):
     method = getattr(self, method_name)
@@ -411,6 +413,41 @@ class DistributedRLEngineTest(absltest.TestCase):
       self.assertEqual(await engine.sync_weights(), 1)
       self.assertEqual(await engine.sync_weights(), 2)
       self.assertEqual(coordinator.calls, [1, 2])
+
+    asyncio.run(_run())
+
+  def test_prepare_rollout_policy_sets_target_state_and_bootstraps_sync(self):
+    async def _run():
+      class _FakeResult:
+        policy_version = 0
+
+      class _FakeCoordinator:
+
+        def __init__(self):
+          self.calls = []
+
+        async def sync(self, policy_version=0, **kwargs):
+          del kwargs
+          self.calls.append(policy_version)
+          _FakeResult.policy_version = policy_version
+          return _FakeResult
+
+      coordinator = _FakeCoordinator()
+      engine = distributed_rl_engine.DistributedRLEngine(
+          rollout_workers=[self.mock_rollout_1],
+          trainer_workers={datatypes.Role.ACTOR: self.mock_actor},
+          inference_workers={datatypes.Role.REFERENCE: self.mock_ref},
+          weight_sync_coordinator=coordinator,
+      )
+
+      version = await engine.prepare_rollout_policy()
+
+      self.assertEqual(version, 0)
+      self.mock_rollout_1.get_target_state.assert_called_once_with()
+      self.mock_actor.set_target_state.assert_called_once_with(
+          target_state={"params": 1}
+      )
+      self.assertEqual(coordinator.calls, [0])
 
     asyncio.run(_run())
 

--- a/tests/experimental/orchestrator/rl_program_test.py
+++ b/tests/experimental/orchestrator/rl_program_test.py
@@ -188,6 +188,7 @@ class RLProgramTest(absltest.TestCase):
       await asyncio.sleep(0.01)
       return []
 
+    self.mock_engine.prepare_rollout_policy = mock.AsyncMock(return_value=0)
     self.mock_engine.sync_weights = mock.AsyncMock(return_value=1)
     self.mock_engine.get_metrics = mock.AsyncMock(return_value=None)
     self.mock_engine.poll_rollouts = mock.AsyncMock(side_effect=_mock_poll)
@@ -306,6 +307,11 @@ class RLProgramTest(absltest.TestCase):
       self.assertEqual(program.step, 1)
       self.assertEqual(begin_steps, [0])
       self.assertEqual(end_steps, [(0, "step_done")])
+      self.mock_engine.prepare_rollout_policy.assert_called_once_with(
+          role=datatypes.Role.ACTOR,
+          sync_weights=True,
+          policy_version=0,
+      )
       self.mock_engine.dispatch_rollouts.assert_called_once_with(
           [{"prompt": "prompt_data_0", "prompt_id": "prompt_0"}],
           group_size=2,
@@ -342,6 +348,7 @@ class RLProgramTest(absltest.TestCase):
 
       self.assertEqual(program.step, 1)
       self.mock_engine.save_checkpoint.assert_called_once()
+      self.mock_engine.prepare_rollout_policy.assert_not_called()
       self.mock_engine.sync_weights.assert_not_called()
       self.assertIsNotNone(program.last_step_result)
       self.assertEqual(program.last_step_result.policy_version, 0)

--- a/tests/experimental/worker/rollout_worker_test.py
+++ b/tests/experimental/worker/rollout_worker_test.py
@@ -15,6 +15,9 @@
 """Unit tests for RolloutWorker and lineage telemetry generation."""
 
 import asyncio
+import threading
+from unittest import mock
+
 from absl.testing import absltest
 import numpy as np
 from tunix.experimental.common import datatypes
@@ -112,6 +115,36 @@ class RolloutWorkerTest(absltest.TestCase):
     self.assertEqual(
         resp_ctx.events[0].attributes.get("worker_id"), "rollout_worker_42"
     )
+
+  def test_initialize_only_runs_sampler_once_under_concurrency(self):
+    enter_init = threading.Event()
+    release_init = threading.Event()
+
+    def _initialize():
+      enter_init.set()
+      release_init.wait(timeout=1.0)
+
+    responses = []
+
+    def _call_initialize():
+      responses.append(self.worker.initialize())
+
+    t1 = threading.Thread(target=_call_initialize)
+    t2 = threading.Thread(target=_call_initialize)
+    with mock.patch.object(self.sampler, "initialize", side_effect=_initialize) as init_mock:
+      t1.start()
+      self.assertTrue(enter_init.wait(timeout=1.0))
+      t2.start()
+      release_init.set()
+      t1.join(timeout=1.0)
+      t2.join(timeout=1.0)
+
+    self.assertFalse(t1.is_alive())
+    self.assertFalse(t2.is_alive())
+    self.assertEqual(init_mock.call_count, 1)
+    self.assertEqual(self.worker.state, datatypes.WorkerState.READY)
+    self.assertLen(responses, 2)
+    self.assertEqual(sum(bool(r.metadata.get("ready")) for r in responses), 1)
 
 
 if __name__ == "__main__":

--- a/tunix/experimental/orchestrator/distributed_rl_engine.py
+++ b/tunix/experimental/orchestrator/distributed_rl_engine.py
@@ -551,10 +551,42 @@ class DistributedRLEngine(rl_engine_interface.AbstractRLEngine):
         raise ValueError(f"No worker registered for role {role}")
       return await self._invoke_worker(worker, "get_metrics", **kwargs)
 
+  async def prepare_rollout_policy(
+      self,
+      role: datatypes.Role = datatypes.Role.ACTOR,
+      sync_weights: bool = True,
+      policy_version: int | None = None,
+  ) -> int | None:
+    """Bootstraps the rollout-visible policy state before step 0."""
+    trainer = self._trainer_workers.get(role)
+    if trainer is None:
+      raise ValueError(f"No trainer worker registered for role {role}")
+
+    if self._rollout_workers:
+      rollout = self._rollout_workers[0]
+      try:
+        target_state = await self._invoke_worker(rollout, "get_target_state")
+        await self._invoke_worker(
+            trainer, "set_target_state", target_state=target_state
+        )
+      except RuntimeError as exc:
+        if "AttributeError" not in str(exc):
+          raise
+
+    if not sync_weights:
+      return None
+    target_policy_version = (
+        self._policy_version if policy_version is None else policy_version
+    )
+    return await self.sync_weights(
+        role=role, policy_version=target_policy_version
+    )
+
   async def sync_weights(  # pyrefly: ignore[bad-override]
       self,
       role: datatypes.Role = datatypes.Role.ACTOR,
       target_roles: Sequence[datatypes.Role] | None = None,
+      policy_version: int | None = None,
   ) -> int:
     """Runs one weight sync round through the coordinator."""
     del role, target_roles
@@ -563,12 +595,13 @@ class DistributedRLEngine(rl_engine_interface.AbstractRLEngine):
           "sync_weights needs a coordinator; construct the engine with"
           " weight_sync_coordinator."
       )
+    next_policy_version = self._policy_version + 1 if policy_version is None else policy_version
     logging.info(
-        "Synchronizing weights (advancing to policy_version=%d)...",
-        self._policy_version + 1,
+        "Synchronizing weights (target policy_version=%d)...",
+        next_policy_version,
     )
     result = await self._weight_sync_coordinator.sync(
-        policy_version=self._policy_version + 1
+        policy_version=next_policy_version
     )
     self._policy_version = result.policy_version
     logging.info(

--- a/tunix/experimental/orchestrator/rl_engine_interface.py
+++ b/tunix/experimental/orchestrator/rl_engine_interface.py
@@ -135,10 +135,20 @@ class AbstractRLEngine(Protocol):
     """Retrieves step metrics from the worker for the specified role."""
     ...
 
+  async def prepare_rollout_policy(
+      self,
+      role: datatypes.Role = datatypes.Role.ACTOR,
+      sync_weights: bool = True,
+      **kwargs: Any,
+  ) -> int | None:
+    """Bootstraps rollout-facing policy state before step 0 dispatch begins."""
+    ...
+
   async def sync_weights(
       self,
       role: datatypes.Role = datatypes.Role.ACTOR,
       target_roles: Sequence[datatypes.Role] | None = None,
+      policy_version: int | None = None,
       **kwargs: Any,
   ) -> int:
     """Coordinates decentralized peer-to-peer weight sync across worker roles."""

--- a/tunix/experimental/orchestrator/rl_program.py
+++ b/tunix/experimental/orchestrator/rl_program.py
@@ -732,6 +732,13 @@ class StandardRLProgram(RLProgram):
     self.engine = engine
     logging.info("Starting StandardRLProgram concurrent stages...")
 
+    if self.sync_weights:
+      await engine.prepare_rollout_policy(
+          role=datatypes.Role.ACTOR,
+          sync_weights=True,
+          policy_version=self.policy_version,
+      )
+
     max_groups_ahead = self.mini_batch_size * (self.max_staleness + 1)
     self._dispatch_capacity = asyncio.Semaphore(max_groups_ahead)
 

--- a/tunix/experimental/rollout/manager.py
+++ b/tunix/experimental/rollout/manager.py
@@ -347,3 +347,9 @@ class RolloutManager:
     if self.sampler:
       return await self.sampler.get_weight_sync_metadata(**kwargs)
     return []
+
+  def get_target_state(self) -> Any:
+    """Returns the sampler target-state skeleton used for trainer conversion."""
+    if self.sampler is None:
+      raise RuntimeError("RolloutManager has no sampler configured.")
+    return self.sampler.get_target_state()

--- a/tunix/experimental/train/peft_trainer_v2.py
+++ b/tunix/experimental/train/peft_trainer_v2.py
@@ -430,7 +430,6 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
       perf_tracer: perf_trace.Tracer | None = None,
       perf_tracer_v2: perf_tracer_lib.Tracer | None = None,
       weight_sync_worker_factory: Callable[[], Any] | None = None,
-      target_state: Any = None,
       sampler_type: str = "inprocess_vllm",
   ):
     # TODO(noghabi): Implement sequence packing for SFT and remove this check.
@@ -522,7 +521,7 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
     self.data_hooks = None
     self._jit_cache = set()
     self._mini_batch_size = None
-    self._target_state = target_state
+    self._target_state = None
     self._sampler_type = sampler_type
     self._weight_sync_worker: Any = None
     self._weight_sync_worker_factory = weight_sync_worker_factory
@@ -532,6 +531,9 @@ class PeftTrainer(abstract_trainer.AbstractTrainer):
 
   def with_data_hooks(self, data_hooks: hooks.DataHooks):
     self.data_hooks = data_hooks
+
+  def set_target_state(self, target_state: Any) -> None:
+    self._target_state = target_state
 
   def clear_jit_cache(self):
     """Clears the JIT cache of the train and eval step functions.

--- a/tunix/experimental/worker/rollout_worker.py
+++ b/tunix/experimental/worker/rollout_worker.py
@@ -15,6 +15,7 @@
 """Top-level RolloutWorker abstractions (Service vs Client Driver)."""
 
 import dataclasses
+import threading
 from typing import Any, AsyncIterator, Callable, List, Optional, Sequence, Union
 import numpy as np
 from tunix.experimental.common import datatypes
@@ -79,6 +80,7 @@ class RolloutWorker(abstract_worker.Worker):
     self.config = config
     self._policy_version = 0
     self._state = datatypes.WorkerState.PENDING
+    self._init_lock = threading.Lock()
     self._sync_round = {"req_id": None, "uuid": 0, "phase": "idle"}
     if tokenizer is None or chat_parser is None:
       raise ValueError(
@@ -114,18 +116,29 @@ class RolloutWorker(abstract_worker.Worker):
     )
 
   def initialize(self) -> datatypes.Response:
-    self.state = WorkerState.INITIALIZING
-    self.sampler.initialize()
-    try:
-      return datatypes.Response(
+    with self._init_lock:
+      if self.state == WorkerState.READY:
+        return datatypes.Response(
           metadata={
-              "worker_id": self.worker_id,
-              "state": self.state.value,
-              "policy_version": self._policy_version,
+            "worker_id": self.worker_id,
+            "state": self.state.value,
+            "policy_version": self._policy_version,
+            "initialized": True,
+            "ready": True,
           }
-      )
-    finally:
-      self.state = WorkerState.READY
+        )
+      self.state = WorkerState.INITIALIZING
+      self.sampler.initialize()
+      try:
+        return datatypes.Response(
+            metadata={
+                "worker_id": self.worker_id,
+                "state": self.state.value,
+                "policy_version": self._policy_version,
+            }
+        )
+      finally:
+        self.state = WorkerState.READY
 
   def compile(self, dummy_data: Any) -> datatypes.Response:
     if self.state == WorkerState.PENDING:
@@ -173,6 +186,12 @@ class RolloutWorker(abstract_worker.Worker):
         inflight=len(self.manager._active_tasks),  # pylint: disable=protected-access
         queue_depth=self.manager._completed_queue.qsize(),  # pylint: disable=protected-access
     )
+
+  def get_target_state(self) -> Any:
+    """Returns rollout-side target-state skeleton for trainer-side conversion."""
+    if self.state == WorkerState.PENDING:
+      self.initialize()
+    return self.manager.get_target_state()
 
   def _left_pad_prompt_token_ids(
       self, prompt_token_ids: Sequence[np.ndarray]
@@ -483,7 +502,14 @@ class RolloutWorker(abstract_worker.Worker):
     metadata = kwargs.pop("metadata", None)
     request = sync_request if sync_request is not None else metadata
     result = await self.manager.weight_sync(request, **kwargs)
-    self._policy_version += 1
+    if isinstance(result, int):
+      self._policy_version = result
+    else:
+      version = getattr(request, "policy_version", None)
+      if version is not None:
+        self._policy_version = version
+      else:
+        self._policy_version += 1
     self._record_round(request, "h2d_done")
     return result
 

--- a/tunix/experimental/worker/trainer_worker.py
+++ b/tunix/experimental/worker/trainer_worker.py
@@ -72,7 +72,7 @@ class TrainerWorker(abstract_worker.Worker):
   def initialize(self) -> datatypes.Response:
     """Initializes the worker and the underlying trainer."""
     if self.state == WorkerState.READY:
-      return self._response(initialized=True, already_ready=True)
+      return self._response(initialized=True, ready=True)
     self.state = WorkerState.INITIALIZING
     try:
       return self._response(initialized=True)
@@ -145,6 +145,16 @@ class TrainerWorker(abstract_worker.Worker):
     """Sets the last-mile adapter mapping a payload to the loss fn's kwargs."""
     self._trainer.with_gen_model_input_fn(gen_model_input_fn)
     return self._response(gen_model_input_fn_configured=True)
+
+  def set_target_state(self, target_state: Any) -> datatypes.Response:
+    """Stores rollout target_state so trainer-side weight sync can convert."""
+    setter = getattr(self._trainer, "set_target_state", None)
+    if not callable(setter):
+      raise AttributeError(
+          f"{type(self._trainer).__name__} does not support set_target_state"
+      )
+    setter(target_state)
+    return self._response(target_state_configured=True)
 
   def fwd_bwd(
       self,


### PR DESCRIPTION
This PRs plumbs through the RL system transfer target state metadata from sampler -> rollout -> orchestrator -> trainer. We also need to sync weights once at step 0 to align the trainer and rollout policy.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
