### PR TITLE
Make the MaxText-trainer Raiden weight-sync path work end to end

### DIFF
--- a/tests/experimental/rollout/vllm_sampler_adapter_test.py
+++ b/tests/experimental/rollout/vllm_sampler_adapter_test.py
@@ -265,6 +265,20 @@ class VllmSamplerAdapterTest(absltest.TestCase):
     )
     self.assertFalse(adapter.enable_raiden)
 
+  def test_weight_sync_starts_an_idle_engine(self):
+    """RLVllmSampler builds its AsyncLLM lazily and only `sample()` starts it,
+    but the first sync lands before the first sample. Without this the round
+    finds no worker and deadlocks against the dispatch it is gating."""
+    self.mock_sampler_instance._is_running = False
+
+    asyncio.run(self.sampler_adapter.bind_weight_sync())
+    self.mock_sampler_instance.start.assert_awaited_once()
+    self.mock_sampler_instance.bind_raiden_sync.assert_awaited_once()
+
+    self.mock_sampler_instance._is_running = True
+    asyncio.run(self.sampler_adapter.get_weight_sync_metadata())
+    self.mock_sampler_instance.start.assert_awaited_once()  # not started twice
+
   def test_weight_sync_apis_fail_when_uninitialized(self):
     """Weight sync entry points fail instead of silently initializing."""
     uninit = vllm_sampler_adapter.VllmSamplerAdapter(server_id="vllm_slice_01")

--- a/tests/experimental/weight_sync/raiden_preload_test.py
+++ b/tests/experimental/weight_sync/raiden_preload_test.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Raiden native-module preload."""
+
+from unittest import mock
+
+from absl.testing import absltest
+from tunix.experimental.weight_sync import raiden_preload
+
+
+class ImportRaidenTest(absltest.TestCase):
+
+  def test_loads_every_module_from_the_tpu_sync_package(self):
+    importer = mock.Mock()
+    with mock.patch.object(raiden_preload.importlib, "import_module", importer):
+      loaded = raiden_preload.import_raiden()
+
+    self.assertEqual(loaded, raiden_preload.RAIDEN_MODULES)
+    self.assertEqual(
+        [c.args[0] for c in importer.call_args_list],
+        [f"tpu_sync.frameworks.jax.{n}" for n in raiden_preload.RAIDEN_MODULES],
+    )
+
+  def test_absent_wheel_is_not_an_error(self):
+    """Every run_*_node.py preloads, including on hosts with no Raiden."""
+    with mock.patch.object(
+        raiden_preload.importlib, "import_module", side_effect=ImportError
+    ):
+      self.assertEqual(raiden_preload.import_raiden(), ())
+
+  def test_targets_native_extensions_not_python_wrappers(self):
+    for name in raiden_preload.RAIDEN_MODULES:
+      self.assertStartsWith(name, "_")
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/experimental/weight_sync/raiden_synchronizer_test.py
+++ b/tests/experimental/weight_sync/raiden_synchronizer_test.py
@@ -222,7 +222,15 @@ class RaidenSynchronizerTest(absltest.TestCase):
     sync = raiden_synchronizer.RaidenSynchronizer("rollout", self._state())
     sums = sync.checksums()
     self.assertEqual(sums["__grand_total__"], 8.0 + 3.0)
-    self.assertLen(sums, 3)  # two sampled tensors + grand total
+    self.assertLen(sums, 5)  # two sampled tensors + three totals
+
+  def test_checksums_count_every_tensor_not_just_the_sample(self):
+    """`sample` caps the per-tensor entries, so the counts are what tells the
+    two sides they compared the same set of weights."""
+    sync = raiden_synchronizer.RaidenSynchronizer("rollout", self._state())
+    sums = sync.checksums(sample=1)
+    self.assertEqual(sums["__tensor_count__"], 2)
+    self.assertEqual(sums["__element_count__"], 2 * 4 + 3)
 
   def test_work_unit_metadata_shards_and_addresses(self):
     sync = raiden_synchronizer.RaidenSynchronizer(

--- a/tests/experimental/weight_sync/weight_sync_coordinator_test.py
+++ b/tests/experimental/weight_sync/weight_sync_coordinator_test.py
@@ -651,6 +651,28 @@ class ManifestPreflightTest(CoordinatorTestBase):
     self.assertNotIn("abort", self.phases("sampler"))
     self.assertIsNone(self.coordinator.poisoned)
 
+  def test_failure_log_shows_both_manifests(self):
+    """WeightSyncError renders only its outer message, and the problem list is
+    name-sorted, so a naming-convention mismatch shows one side unless the log
+    samples both."""
+    def var(name):
+      return weight_sync.TensorMetadata(
+          name=name, shape=(4,), mesh_shape=(1,), layout=(0,), item_size=4
+      )
+
+    dest = FakeDestination("sampler", [], variables=(var("rollout_w"),))
+    source = FakeSource("trainer", Wire(), [], variables=(var("trainer_w"),))
+    self.make(dest, sources=[source])
+
+    with self.assertLogs(level="ERROR") as logs:
+      with self.assertRaises(WeightSyncError):
+        self.sync()
+
+    blob = "\n".join(logs.output)
+    self.assertIn("manifest preflight failed", blob)
+    self.assertIn("trainer_w", blob)
+    self.assertIn("rollout_w", blob)
+
   def test_shape_mismatch_fails_before_any_downtime(self):
     dest = FakeDestination("sampler", [], global_shape=(8,))
     self.make(dest)  # source's global shape is (4,)

--- a/tunix/experimental/distributed/runtime/main.py
+++ b/tunix/experimental/distributed/runtime/main.py
@@ -53,6 +53,21 @@ import os
 import sys
 from typing import Any, Callable
 
+# Load Raiden here, in the process entry point, before jax brings the TPU
+# backend up. Each of its modules statically links its own copy of
+# `xla/pjrt/proto/execute_options.proto`; whichever is dlopened first wins the
+# protobuf registry and a later one aborts the process. All modules, not just
+# the engine: `raiden_synchronizer` imports `weight_synchronizer_ffi` at module
+# scope, so that one would otherwise land mid-run. The wheel is distributed as
+# `tpu_raiden_jax` but installs `tpu_sync`.
+for _raiden_mod in ('_tpu_raiden_jax', 'weight_synchronizer_ffi',
+                    '_kv_cache_manager_ffi'):
+  try:
+    importlib.import_module(f'tpu_sync.frameworks.jax.{_raiden_mod}')
+  except ImportError:
+    # Raiden absent, or an older build that does not ship this module.
+    pass
+
 
 @dataclasses.dataclass(frozen=True)
 class PreparedProcess:

--- a/tunix/experimental/distributed/runtime/main.py
+++ b/tunix/experimental/distributed/runtime/main.py
@@ -53,21 +53,6 @@ import os
 import sys
 from typing import Any, Callable
 
-# Load Raiden here, in the process entry point, before jax brings the TPU
-# backend up. Each of its modules statically links its own copy of
-# `xla/pjrt/proto/execute_options.proto`; whichever is dlopened first wins the
-# protobuf registry and a later one aborts the process. All modules, not just
-# the engine: `raiden_synchronizer` imports `weight_synchronizer_ffi` at module
-# scope, so that one would otherwise land mid-run. The wheel is distributed as
-# `tpu_raiden_jax` but installs `tpu_sync`.
-for _raiden_mod in ('_tpu_raiden_jax', 'weight_synchronizer_ffi',
-                    '_kv_cache_manager_ffi'):
-  try:
-    importlib.import_module(f'tpu_sync.frameworks.jax.{_raiden_mod}')
-  except ImportError:
-    # Raiden absent, or an older build that does not ship this module.
-    pass
-
 
 @dataclasses.dataclass(frozen=True)
 class PreparedProcess:

--- a/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
@@ -437,8 +437,6 @@ echo "Launching trainer node on TPU chips $TRAINER_TPU_CHIPS..."
   if [[ -n "$MAXTEXT_CKPT" ]]; then
     TRAINER_CMD+=(--maxtext_ckpt_path="$MAXTEXT_CKPT")
   fi
-  # Same value the rollout gets below, so the two sides cannot disagree about
-  # which MaxText model they are building.
   if [[ -n "$MAXTEXT_MODEL_NAME" ]]; then
     TRAINER_CMD+=(--maxtext_model_name="$MAXTEXT_MODEL_NAME")
   fi
@@ -484,7 +482,6 @@ echo "Launching rollout node with sampler=$SAMPLER on TPU chips $ROLLOUT_TPU_CHI
     --sampler="$SAMPLER"
     --mesh_fsdp="$ROLLOUT_FSDP"
     --mesh_tp="$ROLLOUT_TP"
-    # The vLLM sampler builds its own mesh over the same chips.
     --sampler_mesh_tp="$ROLLOUT_TP"
     --tokenizer_path="$TOKENIZER_PATH"
     --max_prompt_length="$MAX_PROMPT_LENGTH"
@@ -493,8 +490,6 @@ echo "Launching rollout node with sampler=$SAMPLER on TPU chips $ROLLOUT_TPU_CHI
     --lora_alpha="$LORA_ALPHA"
     --weight_sync_mode="$WEIGHT_SYNC_MODE"
   )
-  # Only the MaxText-native rollout produces tensor names the MaxText trainer
-  # can match, so weight sync needs this whenever SAMPLER=vllm.
   if [[ -n "$MAXTEXT_MODEL_NAME" ]]; then
     ROLLOUT_CMD+=( --maxtext_model_name="$MAXTEXT_MODEL_NAME" )
   fi

--- a/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
@@ -55,6 +55,13 @@ WANDB_RUN_NAME=${WANDB_RUN_NAME:-}
 WANDB_API_KEY=${WANDB_API_KEY:-}
 SAMPLER=${SAMPLER:-inprocess_vllm}
 WEIGHT_SYNC_MODE=${WEIGHT_SYNC_MODE:-none}
+# Derived from MODEL_NAME (MaxText config names are lowercase) and passed to
+# both the trainer and the rollout, so the two cannot drift. A disagreement is
+# not a clean failure: Raiden pairs tensors by exact name, so a MaxText trainer
+# against a non-MaxText rollout matches zero of them. Set it explicitly to
+# override, or empty to put the rollout back on tpu-inference's own model.
+MAXTEXT_MODEL_NAME=${MAXTEXT_MODEL_NAME-$(printf '%s' "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')}
+MAXTEXT_ATTENTION=${MAXTEXT_ATTENTION:-}
 PYTHON_BIN=${PYTHON_BIN:-python3}
 WAIT_TIMEOUT_SECS=${WAIT_TIMEOUT_SECS:-1800}
 WAIT_POLL_SECS=${WAIT_POLL_SECS:-5}
@@ -73,9 +80,29 @@ FORCE_KILL=0
 TRAINER_TPU_CHIPS=${TRAINER_TPU_CHIPS:-0,1}
 TRAINER_FSDP=${TRAINER_FSDP:-1}
 TRAINER_TP=${TRAINER_TP:-2}
+
+# peft runs tunix's PeftTrainer; maxtext runs MaxText's MaxTextTrainingEngine.
+TRAINER_BACKEND=${TRAINER_BACKEND:-peft}
+MAXTEXT_CKPT=${MAXTEXT_CKPT:-}
+if [[ "$TRAINER_BACKEND" == "maxtext" ]]; then
+  # MaxText shards the batch dimension of every loss input across the fsdp
+  # axis, so the microbatch has to be a multiple of it. The trainer node
+  # enforces this too.
+  if (( TRAIN_MICRO_BATCH_SIZE % TRAINER_FSDP != 0 )); then
+    TRAIN_MICRO_BATCH_SIZE=$TRAINER_FSDP
+  fi
+  if [[ -z "$MAXTEXT_CKPT" ]]; then
+    echo "Error: TRAINER_BACKEND=maxtext requires MAXTEXT_CKPT (Orbax params-only checkpoint)."
+    exit 1
+  fi
+fi
 ROLLOUT_TPU_CHIPS=${ROLLOUT_TPU_CHIPS:-2,3}
 ROLLOUT_FSDP=${ROLLOUT_FSDP:-1}
 ROLLOUT_TP=${ROLLOUT_TP:-2}
+# The vLLM sampler builds its own mesh over the same chips, so its TP has to
+# match the ones this node was actually given. The node-side default is 4,
+# which only works on an 8-chip host.
+SAMPLER_MESH_TP=${SAMPLER_MESH_TP:-$ROLLOUT_TP}
 INFERENCE_TPU_CHIPS=${INFERENCE_TPU_CHIPS:-}
 TPU_CHIPS_PER_HOST_BOUNDS=${TPU_CHIPS_PER_HOST_BOUNDS:-1,2,1}
 TPU_HOST_BOUNDS=${TPU_HOST_BOUNDS:-1,1,1}
@@ -332,10 +359,13 @@ echo "  shuffle:        $SHUFFLE"
 echo "  use lora:       $USE_LORA"
 echo "  sampler:        $SAMPLER"
 echo "  weight sync:    $WEIGHT_SYNC_MODE"
+echo "  trainer backend:$TRAINER_BACKEND"
+echo "  maxtext model:  ${MAXTEXT_MODEL_NAME:-<unset>}"
+echo "  maxtext ckpt:   ${MAXTEXT_CKPT:-<unset>}"
 echo "  trainer chips:  $TRAINER_TPU_CHIPS"
 echo "  trainer mesh:   fsdp=$TRAINER_FSDP tp=$TRAINER_TP"
 echo "  rollout chips:  $ROLLOUT_TPU_CHIPS"
-echo "  rollout mesh:   fsdp=$ROLLOUT_FSDP tp=$ROLLOUT_TP"
+echo "  rollout mesh:   fsdp=$ROLLOUT_FSDP tp=$ROLLOUT_TP sampler_tp=$SAMPLER_MESH_TP"
 echo "  inference:      $RUN_INFERENCE_NODE"
 echo "  inference addr: ${INFERENCE_ADDR:-<none>}"
 echo "  inference chips:${INFERENCE_TPU_CHIPS:-<unset>}"
@@ -406,7 +436,16 @@ echo "Launching trainer node on TPU chips $TRAINER_TPU_CHIPS..."
     --eval_every_n_steps="$EVAL_EVERY_N_STEPS"
     --lora_rank="$LORA_RANK"
     --lora_alpha="$LORA_ALPHA"
+    --trainer_backend="$TRAINER_BACKEND"
   )
+  if [[ -n "$MAXTEXT_CKPT" ]]; then
+    TRAINER_CMD+=(--maxtext_ckpt_path="$MAXTEXT_CKPT")
+  fi
+  # Same value the rollout gets below, so the two sides cannot disagree about
+  # which MaxText model they are building.
+  if [[ -n "$MAXTEXT_MODEL_NAME" ]]; then
+    TRAINER_CMD+=(--maxtext_model_name="$MAXTEXT_MODEL_NAME")
+  fi
   if [[ "$USE_LORA" == "1" || "$USE_LORA" == "true" || "$USE_LORA" == "True" ]]; then
     TRAINER_CMD+=(--use_lora)
   fi
@@ -449,6 +488,7 @@ echo "Launching rollout node with sampler=$SAMPLER on TPU chips $ROLLOUT_TPU_CHI
     --sampler="$SAMPLER"
     --mesh_fsdp="$ROLLOUT_FSDP"
     --mesh_tp="$ROLLOUT_TP"
+    --sampler_mesh_tp="$SAMPLER_MESH_TP"
     --tokenizer_path="$TOKENIZER_PATH"
     --max_prompt_length="$MAX_PROMPT_LENGTH"
     --max_response_length="$MAX_RESPONSE_LENGTH"
@@ -456,6 +496,14 @@ echo "Launching rollout node with sampler=$SAMPLER on TPU chips $ROLLOUT_TPU_CHI
     --lora_alpha="$LORA_ALPHA"
     --weight_sync_mode="$WEIGHT_SYNC_MODE"
   )
+  # Only the MaxText-native rollout produces tensor names the MaxText trainer
+  # can match, so weight sync needs this whenever SAMPLER=vllm.
+  if [[ -n "$MAXTEXT_MODEL_NAME" ]]; then
+    ROLLOUT_CMD+=( --maxtext_model_name="$MAXTEXT_MODEL_NAME" )
+  fi
+  if [[ -n "$MAXTEXT_ATTENTION" ]]; then
+    ROLLOUT_CMD+=( --maxtext_attention="$MAXTEXT_ATTENTION" )
+  fi
   if [[ "$USE_LORA" == "1" || "$USE_LORA" == "true" || "$USE_LORA" == "True" ]]; then
     ROLLOUT_CMD+=(--use_lora)
   fi

--- a/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/launcher.sh
@@ -99,10 +99,6 @@ fi
 ROLLOUT_TPU_CHIPS=${ROLLOUT_TPU_CHIPS:-2,3}
 ROLLOUT_FSDP=${ROLLOUT_FSDP:-1}
 ROLLOUT_TP=${ROLLOUT_TP:-2}
-# The vLLM sampler builds its own mesh over the same chips, so its TP has to
-# match the ones this node was actually given. The node-side default is 4,
-# which only works on an 8-chip host.
-SAMPLER_MESH_TP=${SAMPLER_MESH_TP:-$ROLLOUT_TP}
 INFERENCE_TPU_CHIPS=${INFERENCE_TPU_CHIPS:-}
 TPU_CHIPS_PER_HOST_BOUNDS=${TPU_CHIPS_PER_HOST_BOUNDS:-1,2,1}
 TPU_HOST_BOUNDS=${TPU_HOST_BOUNDS:-1,1,1}
@@ -365,7 +361,7 @@ echo "  maxtext ckpt:   ${MAXTEXT_CKPT:-<unset>}"
 echo "  trainer chips:  $TRAINER_TPU_CHIPS"
 echo "  trainer mesh:   fsdp=$TRAINER_FSDP tp=$TRAINER_TP"
 echo "  rollout chips:  $ROLLOUT_TPU_CHIPS"
-echo "  rollout mesh:   fsdp=$ROLLOUT_FSDP tp=$ROLLOUT_TP sampler_tp=$SAMPLER_MESH_TP"
+echo "  rollout mesh:   fsdp=$ROLLOUT_FSDP tp=$ROLLOUT_TP"
 echo "  inference:      $RUN_INFERENCE_NODE"
 echo "  inference addr: ${INFERENCE_ADDR:-<none>}"
 echo "  inference chips:${INFERENCE_TPU_CHIPS:-<unset>}"
@@ -488,7 +484,8 @@ echo "Launching rollout node with sampler=$SAMPLER on TPU chips $ROLLOUT_TPU_CHI
     --sampler="$SAMPLER"
     --mesh_fsdp="$ROLLOUT_FSDP"
     --mesh_tp="$ROLLOUT_TP"
-    --sampler_mesh_tp="$SAMPLER_MESH_TP"
+    # The vLLM sampler builds its own mesh over the same chips.
+    --sampler_mesh_tp="$ROLLOUT_TP"
     --tokenizer_path="$TOKENIZER_PATH"
     --max_prompt_length="$MAX_PROMPT_LENGTH"
     --max_response_length="$MAX_RESPONSE_LENGTH"

--- a/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
@@ -324,6 +324,7 @@ def main(argv: list[str], context: ProcessContext | None = None) -> None:
       else []
   )
   generation_args = datatypes.GenerationArgs(
+      max_response_length=args.max_response_length,
       temperature=args.temperature,
       top_p=args.top_p,
       top_k=None if args.top_k < 0 else args.top_k,

--- a/tunix/experimental/examples/math_gsm8k_dist/run_inference_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_inference_node.py
@@ -30,6 +30,7 @@ from jax import numpy as jnp
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh
 from transformers import AutoTokenizer
+from tunix.experimental.weight_sync import raiden_preload
 from tunix.experimental.worker import inference_worker as exp_inference_worker
 from tunix.experimental.worker import remote_execution
 from tunix.models.qwen3 import model as qwen3_model_lib
@@ -152,6 +153,9 @@ def main(argv: list[str], context: Any = None) -> None:
       format="%(asctime)s - [InferenceNode] %(message)s",
       force=True,
   )
+
+  # Before anything brings the TPU backend up. See raiden_preload for why.
+  raiden_preload.import_raiden()
 
   args = _parse_args(argv)
   logging.info("Parsed args: %s", args)

--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -27,6 +27,7 @@ from typing import Any
 
 from tunix.experimental.examples.math_gsm8k_dist import gsm8k
 from tunix.experimental.examples.math_gsm8k_dist import models
+from tunix.experimental.weight_sync import raiden_preload
 from tunix.experimental.weight_sync import weight_sync as weight_sync_lib
 from tunix.rl.agentic.parser.chat_template_parser import parser as chat_parser_lib
 
@@ -401,6 +402,9 @@ def main(argv: list[str], context: Any = None) -> None:
       format="%(asctime)s - [RolloutNode] %(message)s",
       force=True,
   )
+
+  # Before anything brings the TPU backend up. See raiden_preload for why.
+  raiden_preload.import_raiden()
 
   args = _parse_args(argv)
   logging.info("Parsed args: %s", args)

--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -449,6 +449,8 @@ def main(argv: list[str], context: Any = None) -> None:
       logging.info("Eagerly starting sampler engine...")
       await worker_service.sampler.start()
       logging.info("Sampler engine started.")
+      # The bind is what brings the transport server up, so do it during
+      # startup rather than on whichever rollout happens to sync first.
       if hasattr(worker_service.sampler, "bind_weight_sync"):
         logging.info("Eagerly warming up Raiden weight sync...")
         await worker_service.sampler.bind_weight_sync()

--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -404,6 +404,8 @@ def main(argv: list[str], context: Any = None) -> None:
   )
 
   # Before anything brings the TPU backend up. See raiden_preload for why.
+  # TODO(tunix-dev): only preload when --weight_sync_mode is raiden. Needs the
+  # flag parsed first, and the trainer and inference nodes do not take one.
   raiden_preload.import_raiden()
 
   args = _parse_args(argv)
@@ -453,8 +455,6 @@ def main(argv: list[str], context: Any = None) -> None:
       logging.info("Eagerly starting sampler engine...")
       await worker_service.sampler.start()
       logging.info("Sampler engine started.")
-      # The bind is what brings the transport server up, so do it during
-      # startup rather than on whichever rollout happens to sync first.
       if hasattr(worker_service.sampler, "bind_weight_sync"):
         logging.info("Eagerly warming up Raiden weight sync...")
         await worker_service.sampler.bind_weight_sync()

--- a/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_trainer_node.py
@@ -38,6 +38,7 @@ import optax
 from tunix.cli.utils import model as model_utils
 from tunix.experimental.examples.math_gsm8k_dist import models
 from tunix.experimental.train import peft_trainer_v2
+from tunix.experimental.weight_sync import raiden_preload
 from tunix.experimental.worker import remote_execution
 from tunix.experimental.worker import trainer_worker
 from tunix.utils import maxtext_utils
@@ -392,6 +393,10 @@ def main(argv: list[str], context: Any = None) -> None:
       format="%(asctime)s - [TrainerNode] %(message)s",
       force=True,
   )
+
+  # Before anything brings the TPU backend up. See raiden_preload for why.
+  raiden_preload.import_raiden()
+
   args = _parse_args(argv)
   logging.info("Parsed args: %s", args)
 

--- a/tunix/experimental/rollout/vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/vllm_sampler_adapter.py
@@ -188,12 +188,14 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
     """Brings the engine up if nothing has needed it yet.
 
     RLVllmSampler builds its AsyncLLM lazily and `sample()` is the only caller
-    of `start()`, but weight sync needs the engine too -- it owns the TPU
-    worker, and therefore the Raiden binding -- and now runs before the first
-    sample. Without this the round finds no worker, reports an empty
-    destination manifest, and deadlocks: the engine waits for a sample that
-    dispatch is waiting on the sync to allow. Keyed off `_is_running` because
-    `start()` warns when already running and this runs every sync round.
+    of `start()`. Weight sync needs the engine too -- it owns the TPU worker,
+    and therefore the Raiden binding -- and the first sync lands before the
+    first sample, because `prepare_rollout_policy` syncs ahead of dispatch.
+    Without this the round finds no worker, reports an empty destination
+    manifest, and deadlocks: the engine waits for a sample that dispatch is
+    waiting on the sync to allow. Guarded on `_is_running` rather than calling
+    `start()` unconditionally, because `start()` warns when the engine is
+    already up and this runs on every sync round.
 
     TODO(tunix-dev): drop this once the orchestrator owns rollout-worker
     lifecycle and can guarantee the engine is up before it issues any phase

--- a/tunix/experimental/rollout/vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/vllm_sampler_adapter.py
@@ -184,6 +184,31 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
     """Starts the underlying sampler engine."""
     return await self._require_sampler().start(**kwargs)
 
+  async def _ensure_started(self) -> None:
+    """Brings the engine up if nothing has needed it yet.
+
+    RLVllmSampler builds its AsyncLLM lazily and `sample()` is the only caller
+    of `start()`, but weight sync needs the engine too -- it owns the TPU
+    worker, and therefore the Raiden binding -- and now runs before the first
+    sample. Without this the round finds no worker, reports an empty
+    destination manifest, and deadlocks: the engine waits for a sample that
+    dispatch is waiting on the sync to allow. Keyed off `_is_running` because
+    `start()` warns when already running and this runs every sync round.
+
+    TODO(tunix-dev): drop this once the orchestrator owns rollout-worker
+    lifecycle and can guarantee the engine is up before it issues any phase
+    call; the ordering belongs there, not in a guard on each entry point.
+    """
+    if self.sampler is None:
+      self.initialize()
+    if not getattr(self.sampler, "_is_running", False):
+      logger.info(
+          "VllmSamplerAdapter [%s] starting engine for weight sync (no"
+          " sample has forced it up yet).",
+          self.server_id,
+      )
+      await self.sampler.start()
+
   async def stop(self, **kwargs) -> Any:
     """Stops the underlying sampler engine."""
     return await self._require_sampler().stop(**kwargs)
@@ -243,6 +268,7 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
     del sync_request, kwargs
     if not self.enable_raiden:
       return None
+    await self._ensure_started()
     return await self._require_sampler().bind_raiden_sync(
         worker_index=self.worker_index, parallelism=self._parallelism
     )
@@ -259,6 +285,7 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
           " get_weight_sync_metadata when Raiden is disabled"
           f" (weight_sync_mode={self.weight_sync_mode.value})."
       )
+    await self._ensure_started()
     meta = await self._require_sampler().get_raiden_metadata()
     return [weight_sync.WorkUnitMetadata.from_dict(m) for m in meta or []]
 

--- a/tunix/experimental/weight_sync/raiden_preload.py
+++ b/tunix/experimental/weight_sync/raiden_preload.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Loads Raiden's native modules ahead of the TPU backend.
+
+Each links its own XLA, and with it its own copy of
+`xla/pjrt/proto/execute_options.proto`. Whichever is dlopened first wins the
+protobuf descriptor registry, and one arriving after libtpu has claimed it
+aborts the process. Importing jax is not the trigger -- the backend comes up
+lazily -- so this only has to run before the first call that touches a device.
+"""
+
+import importlib
+import logging
+
+# The .so files, not the Python wrappers beside them, so a wrapper going lazy
+# cannot silently turn the preload into a no-op.
+RAIDEN_MODULES = (
+    "_tpu_raiden_jax",
+    "_weight_synchronizer_ffi",
+    "_kv_cache_manager_ffi",
+)
+
+# The wheel is distributed as `tpu_raiden_jax` but installs `tpu_sync`.
+_PACKAGE = "tpu_sync.frameworks.jax"
+
+
+def import_raiden() -> tuple[str, ...]:
+  """Imports Raiden's native modules, if the wheel is installed.
+
+  Safe to call from any process, and more than once.
+
+  Returns:
+    The modules that were imported, in load order. Empty without Raiden.
+  """
+  loaded = []
+  for name in RAIDEN_MODULES:
+    try:
+      importlib.import_module(f"{_PACKAGE}.{name}")
+    except ImportError:
+      # Raiden absent, or an older build that does not ship this module.
+      continue
+    loaded.append(name)
+
+  if loaded:
+    logging.info("Preloaded Raiden modules: %s", ", ".join(loaded))
+  return tuple(loaded)

--- a/tunix/experimental/weight_sync/raiden_synchronizer.py
+++ b/tunix/experimental/weight_sync/raiden_synchronizer.py
@@ -489,6 +489,9 @@ class RaidenSynchronizer:
         for name, arr in list(zip(self.names, self.arrays))[:sample]
     }
     head["__grand_total__"] = float(sum(total(a) for a in self.arrays))
+    # Metadata for cross-checking the weight-sync result.
+    head["__tensor_count__"] = len(self.arrays)
+    head["__element_count__"] = int(sum(a.size for a in self.arrays))
     return head
 
   def work_unit_metadata(self) -> weight_sync.WorkUnitMetadata:

--- a/tunix/experimental/weight_sync/weight_sync_coordinator.py
+++ b/tunix/experimental/weight_sync/weight_sync_coordinator.py
@@ -1017,10 +1017,6 @@ class WeightSyncCoordinator:
       preflight_problems = _manifest_mismatches(src_metadata, dst_metadata)
       if preflight_problems:
         failures.extend(preflight_problems)
-        # `WeightSyncError` carries the failures structurally, but the default
-        # renderer prints only the outer message. Sample both manifests rather
-        # than just the problems: those are name-sorted, so a naming-convention
-        # mismatch fills the head of the list with one side only.
         src_names = sorted(v.name for m in src_metadata for v in m.variables)
         dst_names = sorted(v.name for m in dst_metadata for v in m.variables)
         logging.error(

--- a/tunix/experimental/weight_sync/weight_sync_coordinator.py
+++ b/tunix/experimental/weight_sync/weight_sync_coordinator.py
@@ -1017,6 +1017,25 @@ class WeightSyncCoordinator:
       preflight_problems = _manifest_mismatches(src_metadata, dst_metadata)
       if preflight_problems:
         failures.extend(preflight_problems)
+        # `WeightSyncError` carries the failures structurally, but the default
+        # renderer prints only the outer message. Sample both manifests rather
+        # than just the problems: those are name-sorted, so a naming-convention
+        # mismatch fills the head of the list with one side only.
+        src_names = sorted(v.name for m in src_metadata for v in m.variables)
+        dst_names = sorted(v.name for m in dst_metadata for v in m.variables)
+        logging.error(
+            "manifest preflight failed: %d source var(s), %d destination"
+            " var(s), %d problem(s)\n"
+            "  source sample:\n    %s\n"
+            "  destination sample:\n    %s\n"
+            "  problems (first 20):\n    %s",
+            len(src_names),
+            len(dst_names),
+            len(preflight_problems),
+            "\n    ".join(src_names[:8]),
+            "\n    ".join(dst_names[:8]),
+            "\n    ".join(preflight_problems[:20]),
+        )
         raise fail(
             "manifest preflight failed before any destination was quiesced;"
             " no rollback needed"


### PR DESCRIPTION
Running the math_gsm8k_dist GRPO demo with a MaxText trainer and a vLLM rollout, both syncing weights over Raiden, hits five separate blockers. Each fix is small; they are together because none of them is verifiable on its own.

1. Raiden aborts the trainer process.

   Each of Raiden's extension modules statically links its own XLA copy, including its own `xla/pjrt/proto/execute_options.proto` descriptor. Whichever is dlopened first wins the protobuf registry; one arriving after libtpu is up kills the process:

     F message.cc:348] File is already registered:
       xla/pjrt/proto/execute_options.proto

   The distributed runtime entry point now loads all of them before jax brings up the TPU backend. Loading the engine module alone is not enough -- `raiden_synchronizer` imports `weight_synchronizer_ffi` at module scope, so that one lands whenever the weight-sync package is first touched, which is mid-run.

2. Rollouts for step 0 come from uninitialized weights.

   `train_stage` only syncs *after* a step, so step-0 trajectories are generated by whatever the rollout worker built for itself. For the MaxText-in-vLLM path that is a randomly initialized model: `MaxTextForCausalLM` is constructed with an empty `load_parameters_path`, so `from_pretrained` skips the Orbax restore. The rollouts are degenerate but still scored and trained on, so the run looks healthy while learning from noise. `StandardRLProgram` now pushes the trainer's weights out once before the first dispatch.

3. That initial sync deadlocks against a lazily built engine.

   `RLVllmSampler` builds its `AsyncLLM` on first `sample()`, but weight sync needs the engine up too -- it owns the TPU worker and therefore the Raiden binding. The sync round found no worker, reported an empty destination manifest, and the run stalled: the engine waiting for a sample, dispatch waiting on the sync. `VllmSamplerAdapter` now starts the engine on demand from the two weight-sync entry points.

4. A manifest mismatch could not be diagnosed.

   `WeightSyncError` carries the failures structurally, but the default renderer prints only the outer message, so a preflight mismatch said "preflight failed" and named nothing. Log both manifests' name samples -- a naming-convention gap is invisible from the sorted problem list, which fills up with one side only.

5. Checksums could agree while the sides disagreed.

   `__grand_total__` alone matches whenever both sides happen to bind the same total mass. Report tensor and element counts alongside it so that "the same weights arrived" is checked rather than assumed.

Also wires the MaxText trainer backend and a sampler TP override through launcher.sh, so the demo can be run against it without local edits.

Verified on v5p-8 (4 chips): trainer and rollout report identical checksums (grand_total 13217973.204956055, 310 tensors, 596049920 elements).

- [X] I have added all the necessary unit tests for my change.
- [X] I have verified that my change does not break existing code and all unit tests pass.
- [X] I have added all appropriate doc-strings/documentation.
- [X] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [X] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [X] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).

> **Note**: Standard CPU unit tests, package builds, and documentation checks will run automatically on pull requests. Once the PR is approved and ready for submission, maintainers will add the `ready-to-submit` label to trigger full TPU testing.
