### PR TITLE
[Tunix] Forward sampler argument in k8s and deepswe distributed launchers

### DIFF
--- a/tunix/experimental/examples/deepswe_dist/launcher.sh
+++ b/tunix/experimental/examples/deepswe_dist/launcher.sh
@@ -232,6 +232,7 @@ echo "Launching trainer node..."
     --eval_every_n_steps="$EVAL_EVERY_N_STEPS"
     --lora_rank="$LORA_RANK"
     --lora_alpha="$LORA_ALPHA"
+    --sampler="$SAMPLER"
   )
   if [[ "$USE_LORA" == "1" || "$USE_LORA" == "true" || "$USE_LORA" == "True" ]]; then
     TRAINER_CMD+=(--use_lora)

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -166,6 +166,7 @@ start_trainer() {
         --eval_every_n_steps=${EVAL_EVERY_N_STEPS} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
+        --sampler=${SAMPLER} \
         ${maxtext_args} \
         ${DEBUG:+--debug} \
     " \
@@ -208,6 +209,7 @@ start_rollout() {
         --tokenizer_path=${TOKENIZER_PATH} \
         --max_prompt_length=${MAX_PROMPT_LENGTH} \
         --max_response_length=${MAX_RESPONSE_LENGTH} \
+        --sampler=${SAMPLER} \
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
         --weight_sync_mode=${WEIGHT_SYNC_MODE} \


### PR DESCRIPTION
### Summary

Commit https://github.com/google/tunix/commit/878b9be6b1855e8285bd059786e2a9933f95c689 added `--sampler` support to `run_trainer_node.py` and `math_gsm8k_dist/launcher.sh`.

This PR addresses the remaining launcher entrypoints:
1. **`tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh`**:
   - Forward `--sampler=${SAMPLER}` to `start_trainer` container command.
   - Forward `--sampler=${SAMPLER}` to `start_rollout` container command.
2. **`tunix/experimental/examples/deepswe_dist/launcher.sh`**:
   - Forward `--sampler="$SAMPLER"` to `TRAINER_CMD` (matching the existing rollout configuration).

### Testing
- Verified unit tests pass via `python3 -m pytest tests/experimental/examples/math_gsm8k_dist/run_trainer_node_test.py`.