### PR TITLE
[Tunix] Pre-import Raiden delegate to prevent allocator conflict with in-process vLLM

### DIFF
--- a/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py
@@ -47,6 +47,14 @@ CHAT_PARSERS = {
 
 
 def _import_vllm_sampler():
+  # Pre-import raiden_weight_sync_delegate prior to loading vLLM to prevent
+  # allocator / static runtime conflicts between vLLM's C++ runtime and
+  # tpu_raiden_jax's C++ FFI.
+  try:
+    from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=unused-import,g-import-not-at-top
+    logging.info("Pre-imported raiden_weight_sync_delegate before vLLM.")
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass
   logging.info(
       "Importing tunix.generate.vllm_sampler before rollout adapters..."
   )

--- a/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
@@ -24,11 +24,22 @@ import numpy as np
 from tunix.experimental.rollout import sampler as base_sampler_lib
 from tunix.experimental.weight_sync import weight_sync
 
+# Pre-import raiden_weight_sync_delegate prior to any vLLM imports to avoid
+# allocator conflicts between vLLM's C++ runtime and tpu_raiden_jax's C++ FFI.
+try:
+  from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
+except Exception:  # pylint: disable=broad-exception-caught
+  raiden_weight_sync_delegate = None
+
 Sampler = base_sampler_lib.Sampler
 
 
 def _get_vllm_sampler_cls():
   """Lazy import of tunix.generate.vllm_sampler to avoid top-level vLLM import side-effects."""
+  try:
+    from tunix.experimental.weight_sync import raiden_weight_sync_delegate as _delegate_mod  # pylint: disable=unused-import,g-import-not-at-top
+  except Exception:  # pylint: disable=broad-exception-caught
+    pass
   from tunix.generate import vllm_sampler as generate_vllm_lib  # pylint: disable=g-import-not-at-top
   return generate_vllm_lib
 
@@ -72,11 +83,18 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
       )
 
       if self.raiden_sync_delegate is None:
-        from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
+        if raiden_weight_sync_delegate is not None:
+          self.raiden_sync_delegate = (
+              raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+          )
+        else:
+          from tunix.experimental.weight_sync import (  # pylint: disable=g-import-not-at-top
+              raiden_weight_sync_delegate as delegate_mod,
+          )
 
-        self.raiden_sync_delegate = (
-            raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
-        )
+          self.raiden_sync_delegate = (
+              delegate_mod.RaidenWeightSyncDelegate()
+          )
 
     if not self.enable_raiden and self.raiden_sync_delegate:
       logging.warning(


### PR DESCRIPTION
### Summary
Fixes an allocator collision (`src/tcmalloc.cc:304 Attempt to free invalid pointer` -> `SIGABRT`) when initializing `InprocessVllmSamplerAdapter` with Raiden weight synchronization.

### Cause
A conflict exists between vLLM's PyTorch C++ runtime and `tpu_raiden_jax`'s C++ FFI. When `raiden_weight_sync_delegate` was lazily imported inside `InprocessVllmSamplerAdapter.__init__` after vLLM had initialized, dynamic runtime and allocator ordering conflicts caused cross-allocator pointer deallocation.

### Changes
- Pre-import `raiden_weight_sync_delegate` prior to importing `tunix.generate.vllm_sampler` in `tunix/experimental/examples/math_gsm8k_dist/run_rollout_node.py`.
- Pre-import `raiden_weight_sync_delegate` at module level and prior to importing `vllm_sampler` in `tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py`.
- Reuse the pre-imported delegate module inside `InprocessVllmSamplerAdapter.__init__`.

### Verification
- Tested initialization in Python; verified that `InprocessVllmSamplerAdapter` initializes cleanly with `WeightSyncMode.RAIDEN` without crashing.
- Verified in live distributed GRPO run on Cloud TPU v7x: vLLM generated rollouts and Raiden synchronized weights across training steps.

### Reproduction:

standalone:
```
from tunix.generate import vllm_sampler
from tunix.experimental.weight_sync import raiden_weight_sync_delegate
delegate = raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
```

or running with 
```
SAMPLER=inprocess_vllm WEIGHT_SYNC_MODE=raiden
bash tunix/experimental/examples/math_gsm8k_dist/launcher.sh
```