### PR TITLE
[Tunix] Enforce strict formatting rewards and stop instruction in GSM8K demo

### DIFF
--- a/tests/experimental/examples/math_gsm8k_dist/gsm8k_test.py
+++ b/tests/experimental/examples/math_gsm8k_dist/gsm8k_test.py
@@ -70,6 +70,10 @@ class GSM8KTest(absltest.TestCase):
         "<answer>\\boxed{}</answer>",
         gsm8k.build_prompt("How many clips?"),
     )
+    self.assertIn(
+        "immediately end your response and stop generating",
+        gsm8k.build_prompt("How many clips?"),
+    )
 
   def test_agent_forwards_model_response_as_action(self):
     agent = gsm8k.GSM8KAgent()
@@ -167,7 +171,7 @@ class GSM8KTest(absltest.TestCase):
     )
     self.assertEqual(reward_fn(item2), 0.1)
 
-    # 3. Format incorrect, right answer -> reward 0.5
+    # 3. Format incorrect, right answer -> reward 0.0 (strict formatting)
     item3 = types.SimpleNamespace(
         metadata={
             "text": "The answer is \\boxed{42}",
@@ -175,7 +179,7 @@ class GSM8KTest(absltest.TestCase):
             "prompt_id": "p3",
         }
     )
-    self.assertEqual(reward_fn(item3), 0.5)
+    self.assertEqual(reward_fn(item3), 0.0)
 
     # 4. Format incorrect, wrong answer -> reward 0.0
     item4 = types.SimpleNamespace(

--- a/tunix/experimental/examples/math_gsm8k_dist/gsm8k.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/gsm8k.py
@@ -41,7 +41,8 @@ GSM8K_PROMPT_TEMPLATE = (
     "<reasoning>...</reasoning> tags.\n"
     "Then, put your final numerical answer inside "
     "<answer>\\boxed{{}}</answer> tags. Do not put anything else in the "
-    "answer tags.\n\n"
+    "answer tags.\n"
+    "After the closing </answer> tag, immediately end your response and stop generating.\n\n"
     "Problem: {}\n"
     "<reasoning>\n"
 )
@@ -175,8 +176,6 @@ def score_gsm8k_completion(
     reward = 1.0
   elif format_correct and not answer_correct:
     reward = 0.1
-  elif not format_correct and answer_correct:
-    reward = 0.5
   else:
     reward = 0.0
   return reward, {


### PR DESCRIPTION
### Summary
Improves trajectory completion and eliminates partial reward incentives for rambling generations past the numerical answer in the distributed GSM8K GRPO demo.

### Details
1. **Prompt Template Clarification**:
   Updated `GSM8K_PROMPT_TEMPLATE` to explicitly instruct the model:
   `"After the closing </answer> tag, immediately end your response and stop generating."`
2. **Strict Formatting Reward**:
   Updated `score_gsm8k_completion` to assign `0.0` (instead of `0.5`) when `not format_correct and answer_correct`. Without strict formatting enforcement, the model receives partial credit even when generating run-on tokens or failing to properly terminate at `</answer>`.
3. **Tests**:
   Updated `tests/experimental/examples/math_gsm8k_dist/gsm8k_test.py` to verify the stop instruction in `build_prompt` and assert the strict formatting reward behavior (`0.0` for malformed outputs).

### Verification
- Ran `python3 -m unittest tests/experimental/examples/math_gsm8k_dist/gsm8k_test.py`: all 9 unit tests passed.