### PR TITLE
feat(rl): measure, mask and correct sampler-vs-trainer divergence

### DIFF
--- a/tests/rl/agentic/agentic_grpo_learner_test.py
+++ b/tests/rl/agentic/agentic_grpo_learner_test.py
@@ -44,6 +44,7 @@ from tunix.rl import common as rl_common
 from tunix.rl import function_registry
 from tunix.rl import rl_cluster as rl_engine_lib
 from tunix.rl.agentic import agentic_grpo_learner
+from tunix.rl.agentic.agents import agent_types
 from tunix.rl.agentic.agents.agent_types import Action, Step
 from tunix.rl.agentic.agents.base_agent import ConversationAgentBase
 from tunix.rl.agentic.environments.base_environment import BaseTaskEnv, EnvStepResult
@@ -2487,6 +2488,45 @@ class AgenticGrpoLearnerTest(parameterized.TestCase):
       )
     mock_warn.assert_called_once()
     self.assertIn("off_policy_steps", mock_warn.call_args[0][0])
+
+
+class OverlongVerdictTest(absltest.TestCase):
+  """The truncation verdict the learner reads off each trajectory."""
+
+  def test_serialised_status_matches_what_the_learner_compares_against(self):
+    """Pins the serialisation the `overlong` flag depends on.
+
+    `TrajectoryStatus` uses `auto()`, so `.value` is an opaque integer while
+    the collect engine serialises by `.name`. Comparing against the wrong one
+    silently yields `overlong = 0` everywhere -- no error, just a feature that
+    never fires -- so the two are pinned together here.
+    """
+    trajectory = agent_types.Trajectory(task={})
+    trajectory.status = agent_types.TrajectoryStatus.MAX_CONTEXT_LIMIT_REACHED
+    self.assertEqual(
+        trajectory.to_dict()["status"],
+        agent_types.TrajectoryStatus.MAX_CONTEXT_LIMIT_REACHED.name,
+    )
+    self.assertEqual(
+        trajectory.to_dict()["status"], "MAX_CONTEXT_LIMIT_REACHED"
+    )
+
+  def test_other_statuses_are_not_treated_as_truncation(self):
+    # `overlong` means "ran out of response budget", which is narrower than
+    # the engine's failure statuses; conflating them would drop samples that
+    # failed for unrelated reasons.
+    for status in (
+        agent_types.TrajectoryStatus.SUCCEEDED,
+        agent_types.TrajectoryStatus.MAX_STEPS_REACHED,
+        agent_types.TrajectoryStatus.TIMEOUT,
+        agent_types.TrajectoryStatus.FAILED,
+    ):
+      trajectory = agent_types.Trajectory(task={})
+      trajectory.status = status
+      self.assertNotEqual(
+          trajectory.to_dict()["status"],
+          agent_types.TrajectoryStatus.MAX_CONTEXT_LIMIT_REACHED.name,
+      )
 
 
 if __name__ == "__main__":

--- a/tests/rl/agentic/trajectory/trajectory_collect_engine_test.py
+++ b/tests/rl/agentic/trajectory/trajectory_collect_engine_test.py
@@ -207,6 +207,18 @@ class TrajectoryCollectEngineTest(absltest.TestCase):
     self.assertIsInstance(result_traj.reward_time, dict)
     self.assertGreaterEqual(result_traj.reward_time['reward_latency'], 0.0)
 
+    # model_time: one generate_latency entry per model_call, plus the episode
+    # total. env_time covers only reset/step/close, so these are the only
+    # signals that attribute an episode's wall clock to generation.
+    self.assertIsInstance(result_traj.model_time, dict)
+    self.assertLen(
+        result_traj.model_time['generate_latency'],
+        self.mock_model_call.call_count,
+    )
+    for latency in result_traj.model_time['generate_latency']:
+      self.assertGreaterEqual(latency, 0.0)
+    self.assertGreaterEqual(result_traj.model_time['episode_latency'], 0.0)
+
     # Check returns (gamma=0.9)
     # G_2 = 2.5
     # G_1 = 1.0 + 0.9 * 2.5 = 1.0 + 2.25 = 3.25
@@ -582,18 +594,25 @@ class TrajectoryCollectEngineTest(absltest.TestCase):
   def test_collect_timeout(self):
     self.mock_env.max_steps = 10
     with mock.patch.object(time, 'perf_counter') as mock_perf:
-      # Reset: 3 calls
-      # Step 1: 3 calls
-      # Final reward: 2 calls
-      # Close: 2 calls
+      # One value per time.perf_counter() call, in order:
+      #   _reset:               2 (_run_with_timing) + 1 (_start_ts)
+      #   _one_step:            2 (model_call timing) + 1 (remaining_time)
+      #                       + 2 (_run_with_timing on env.step)
+      #                       + 1 (step_timed_out)
+      #   collect:              1 (episode_latency)
+      #   _append_final_reward: 2 (_run_with_timing)
+      #   _close:               2 (_run_with_timing)
       mock_perf.side_effect = [
           100.0,
           100.01,
-          100.02,  # _reset
+          100.02,  # _reset, _start_ts = 100.02
           100.03,
-          100.04,
-          100.2,  # _one_step: 100.2 - 100.02 = 0.18 > 0.1
-          100.21,
+          100.04,  # _one_step: model_call
+          100.05,  # _one_step: remaining_time = 0.1 - 0.03 = 0.07 > 0
+          100.06,
+          100.2,  # _one_step: env.step
+          100.2,  # _one_step: 100.2 - 100.02 = 0.18 > 0.1 -> TIMEOUT
+          100.21,  # collect: episode_latency
           100.22,
           100.23,  # _append_final_reward
           100.24,

--- a/tests/rl/algo_core_test.py
+++ b/tests/rl/algo_core_test.py
@@ -17,6 +17,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from tunix.rl import algo_core
+from tunix.rl import common
 
 
 class AlgoCoreTest(absltest.TestCase):
@@ -141,6 +142,573 @@ class AlgoCoreTest(absltest.TestCase):
       with self.subTest(loss_algo=loss_algo):
         np.testing.assert_allclose(lp, lu, rtol=1e-5, atol=1e-5)
         np.testing.assert_allclose(lp, -2.25, rtol=1e-4, atol=1e-4)
+
+
+class GrpoLooAdvantagesTest(absltest.TestCase):
+  """Leave-one-out group-relative advantages."""
+
+  def _reference(self, rewards, num_generations):
+    """Independent transcription of the intended formula, in matrix form.
+
+    Written from the definition rather than from the implementation, so it
+    fails if the implementation drifts toward something merely self-consistent.
+    """
+    r = np.asarray(rewards, dtype=np.float64)
+    out = np.zeros_like(r)
+    g = num_generations
+    for p in range(len(r) // g):
+      idx = slice(p * g, (p + 1) * g)
+      rr = r[idx]
+      others = 1 - np.eye(g)  # exclude self
+      n = np.float64(g - 1)
+      base = others @ rr / n
+      sq = others @ (rr**2) / n
+      with np.errstate(divide='ignore', invalid='ignore'):
+        std = np.nan_to_num(
+            np.sqrt((sq - base**2) * (n / (n - np.float64(1)))), nan=0.0
+        )
+      adv = rr - base
+      nz = std > 0
+      adv[nz] = adv[nz] / (std[nz] + 1e-6)
+      out[idx] = adv
+    return out
+
+  def test_matches_the_definition_across_group_sizes(self):
+    rng = np.random.default_rng(0)
+    for g in (2, 3, 4, 8, 16):
+      rewards = rng.random(g * 3)
+      with self.subTest(num_generations=g):
+        np.testing.assert_allclose(
+            algo_core.compute_grpo_loo_advantages(jnp.asarray(rewards), g),
+            self._reference(rewards, g),
+            rtol=1e-5,
+            atol=1e-6,
+        )
+
+  def test_binary_rewards(self):
+    # The realistic case: solved/unsolved within a group.
+    rewards = jnp.array([1.0, 0.0, 1.0, 0.0])
+    np.testing.assert_allclose(
+        algo_core.compute_grpo_loo_advantages(rewards, 4),
+        self._reference(np.asarray(rewards), 4),
+        rtol=1e-5,
+    )
+
+  def test_excludes_self_from_the_baseline(self):
+    # Including a sample in its own baseline shrinks its advantage by exactly
+    # 1 - 1/G. That factor is the whole reason this estimator exists.
+    grouped = np.arange(16, dtype=np.float64)
+    plain = grouped - grouped.mean()
+    loo_mean = (grouped.sum() - grouped) / 15
+    np.testing.assert_allclose(
+        plain / (grouped - loo_mean), np.full(16, 1 - 1 / 16), rtol=1e-6
+    )
+
+  def test_degenerate_groups(self):
+    # G=1: no other sample to form a baseline from.
+    np.testing.assert_array_equal(
+        algo_core.compute_grpo_loo_advantages(jnp.array([1.0, 2.0]), 1),
+        np.zeros(2),
+    )
+    # G=2: the leave-one-out set holds a single sample, so its variance is
+    # undefined; advantages stay as raw differences.
+    np.testing.assert_allclose(
+        algo_core.compute_grpo_loo_advantages(jnp.array([1.0, 0.0]), 2),
+        [1.0, -1.0],
+        rtol=1e-6,
+    )
+
+  def test_zero_variance_group_is_not_sharpened(self):
+    # All generations scored identically: advantages are 0 and must stay 0,
+    # not become large numbers from dividing rounding by rounding.
+    out = algo_core.compute_grpo_loo_advantages(jnp.full((8,), 0.7), 4)
+    np.testing.assert_allclose(out, np.zeros(8), atol=1e-6)
+
+  def test_groups_are_independent(self):
+    # Changing one group must not move another.
+    a = algo_core.compute_grpo_loo_advantages(
+        jnp.array([1.0, 0.0, 1.0, 0.0, 0.9, 0.8, 0.7, 0.6]), 4
+    )
+    b = algo_core.compute_grpo_loo_advantages(
+        jnp.array([1.0, 0.0, 1.0, 0.0, 0.1, 0.2, 0.3, 0.4]), 4
+    )
+    np.testing.assert_allclose(a[:4], b[:4], rtol=1e-6)
+
+
+class SequenceLossMaskTest(absltest.TestCase):
+  """Sequence-level loss masking, and the denominator behaviour it implies."""
+
+  def _mask(self, rows=4, tokens=5):
+    return jnp.ones((rows, tokens), dtype=jnp.float32)
+
+  def test_inactive_by_default(self):
+    # No source enabled -> unrestricted outputs, so callers can use them
+    # unconditionally and existing behaviour is unchanged.
+    completion_mask = self._mask()
+    result = algo_core.sequence_loss_mask(completion_mask)
+    np.testing.assert_array_equal(result.sample_mask, np.ones(4))
+    np.testing.assert_array_equal(result.loss_mask, completion_mask)
+    self.assertIsNone(result.mult_prob_error)
+
+  def test_overlong_ignored_unless_enabled(self):
+    completion_mask = self._mask()
+    result = algo_core.sequence_loss_mask(
+        completion_mask,
+        overlong=jnp.array([0.0, 1.0, 1.0, 0.0]),
+        mask_overlong=False,
+    )
+    np.testing.assert_array_equal(result.loss_mask, completion_mask)
+
+  def test_overlong_drops_whole_sequences(self):
+    result = algo_core.sequence_loss_mask(
+        self._mask(),
+        overlong=jnp.array([0.0, 1.0, 1.0, 0.0]),
+        mask_overlong=True,
+    )
+    np.testing.assert_array_equal(result.sample_mask, [1.0, 0.0, 0.0, 1.0])
+    np.testing.assert_array_equal(
+        result.loss_mask.sum(axis=-1), [5.0, 0.0, 0.0, 5.0]
+    )
+
+  def test_enabled_but_no_verdict_is_a_noop(self):
+    # The rollout engine may report no truncation; that must not silently drop
+    # everything or crash.
+    completion_mask = self._mask()
+    result = algo_core.sequence_loss_mask(
+        completion_mask, overlong=None, mask_overlong=True
+    )
+    np.testing.assert_array_equal(result.loss_mask, completion_mask)
+
+  def test_partial_completion_mask_is_preserved(self):
+    completion_mask = jnp.array(
+        [[1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+    )
+    result = algo_core.sequence_loss_mask(
+        completion_mask,
+        overlong=jnp.array([0.0, 0.0, 1.0]),
+        mask_overlong=True,
+    )
+    np.testing.assert_array_equal(
+        result.loss_mask, [[1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+    )
+
+  def test_dropped_sequences_leave_the_denominator(self):
+    """The load-bearing property: a drop must not scale the loss down.
+
+    Masking removes a sequence from numerator and denominator alike, so the
+    survivors keep their full gradient magnitude. Zeroing a weight removes it
+    from the numerator only, shrinking the loss by the drop fraction. Getting
+    this backwards is a silent learning-rate change, so it is asserted against
+    the real aggregators for every mode the loss can be configured with.
+    """
+    completion_mask = self._mask(rows=4, tokens=5)
+    # Identical per-token loss everywhere, so any change in the aggregate can
+    # only come from the denominator.
+    per_token_loss = jnp.full((4, 5), 0.25, dtype=jnp.float32)
+    result = algo_core.sequence_loss_mask(
+        completion_mask,
+        overlong=jnp.array([0.0, 1.0, 1.0, 0.0]),
+        mask_overlong=True,
+    )
+
+    for mode in ('token-mean', 'sequence-mean-token-mean'):
+      full = common.aggregate_loss(per_token_loss, completion_mask, mode)
+      masked = common.aggregate_loss(per_token_loss, result.loss_mask, mode)
+      self.assertAlmostEqual(
+          float(full.compute()),
+          float(masked.compute()),
+          places=5,
+          msg=f'{mode}: masking changed the aggregate loss',
+      )
+      # And the denominator really did shrink, i.e. the invariance above is
+      # numerator and denominator falling together, not the mask doing nothing.
+      self.assertAlmostEqual(
+          float(masked.denominator) * 2.0,
+          float(full.denominator),
+          places=5,
+          msg=f'{mode}: expected half the batch to leave the denominator',
+      )
+
+  def test_weight_zeroing_does_scale_the_loss_down(self):
+    """Contrast case, so the distinction above is pinned rather than assumed."""
+    completion_mask = self._mask(rows=4, tokens=5)
+    per_token_loss = jnp.full((4, 5), 0.25, dtype=jnp.float32)
+    keep = jnp.array([1.0, 0.0, 0.0, 1.0])[:, None]
+
+    full = common.aggregate_loss(per_token_loss, completion_mask, 'token-mean')
+    weighted = common.aggregate_loss(
+        per_token_loss * keep, completion_mask, 'token-mean'
+    )
+    self.assertAlmostEqual(
+        float(weighted.compute()), float(full.compute()) / 2.0, places=5
+    )
+
+
+class SequenceMultProbErrorTest(absltest.TestCase):
+  """The log-probability disagreement gate."""
+
+  def test_perfect_agreement_scores_one(self):
+    np.testing.assert_allclose(
+        algo_core.sequence_mult_prob_error(jnp.zeros((3, 4)), jnp.ones((3, 4))),
+        [1.0, 1.0, 1.0],
+    )
+
+  def test_absolute_value_prevents_cancellation(self):
+    # A sequence off by +d on half its tokens and -d on the other half has a
+    # geometric-mean ratio of exactly 1 and looks perfectly on-policy. This is
+    # a data-integrity check, so it must still see the disagreement.
+    d = 0.5
+    log_is = jnp.array([[d, -d, d, -d]])
+    mask = jnp.ones((1, 4))
+    self.assertAlmostEqual(
+        float(jnp.exp((log_is * mask).sum() / mask.sum())), 1.0, places=6
+    )
+    self.assertAlmostEqual(
+        float(algo_core.sequence_mult_prob_error(log_is, mask)[0]),
+        float(np.exp(d)),
+        places=5,
+    )
+
+  def test_masked_tokens_excluded(self):
+    # A huge disagreement on a masked token must not leak in, nor overflow
+    # through the exp.
+    self.assertAlmostEqual(
+        float(
+            algo_core.sequence_mult_prob_error(
+                jnp.array([[0.0, 0.0, 10.0]]), jnp.array([[1.0, 1.0, 0.0]])
+            )[0]
+        ),
+        1.0,
+        places=6,
+    )
+
+  def test_fully_masked_sequence_scores_zero(self):
+    # Must not divide by zero, and must not trip a threshold.
+    self.assertEqual(
+        float(
+            algo_core.sequence_mult_prob_error(
+                jnp.array([[1.0, 1.0]]), jnp.zeros((1, 2))
+            )[0]
+        ),
+        0.0,
+    )
+
+  def test_gate_drops_only_sequences_over_threshold(self):
+    # Row errors: exp(0)=1.0, exp(0.5)=1.649, exp(1.5)=4.482.
+    result = algo_core.sequence_loss_mask(
+        jnp.ones((3, 4), dtype=jnp.float32),
+        log_is=jnp.array([[0.0] * 4, [0.5] * 4, [1.5] * 4]),
+        mult_prob_error_threshold=2.0,
+    )
+    np.testing.assert_allclose(
+        result.mult_prob_error, [1.0, np.exp(0.5), np.exp(1.5)], rtol=1e-5
+    )
+    np.testing.assert_array_equal(result.sample_mask, [1.0, 1.0, 0.0])
+    np.testing.assert_array_equal(
+        result.loss_mask.sum(axis=-1), [4.0, 4.0, 0.0]
+    )
+
+  def test_gate_inactive_without_threshold_or_logps(self):
+    completion_mask = jnp.ones((2, 3), dtype=jnp.float32)
+    log_is = jnp.full((2, 3), 5.0)
+    for kwargs in (
+        {'log_is': log_is, 'mult_prob_error_threshold': None},
+        {'log_is': None, 'mult_prob_error_threshold': 2.0},
+    ):
+      result = algo_core.sequence_loss_mask(completion_mask, **kwargs)
+      np.testing.assert_array_equal(result.sample_mask, [1.0, 1.0])
+      np.testing.assert_array_equal(result.loss_mask, completion_mask)
+      self.assertIsNone(result.mult_prob_error)
+
+  def test_overlong_applies_before_the_gate(self):
+    # A truncated sequence contributes no tokens to its own error, so it
+    # scores 0.0 and passes the threshold -- but must stay dropped regardless.
+    result = algo_core.sequence_loss_mask(
+        jnp.ones((2, 4), dtype=jnp.float32),
+        overlong=jnp.array([1.0, 0.0]),
+        mask_overlong=True,
+        log_is=jnp.full((2, 4), 5.0),  # exp(5) >> threshold for both rows
+        mult_prob_error_threshold=2.0,
+    )
+    self.assertEqual(float(result.mult_prob_error[0]), 0.0)
+    np.testing.assert_array_equal(result.sample_mask, [0.0, 0.0])
+
+
+class TruncatedImportanceWeightsTest(absltest.TestCase):
+  """seq-mask-tis weights, and the denominator behaviour they imply."""
+
+  _BAND = dict(band_min=0.999, band_max=1.002)
+
+  def _call(self, log_is_raw, completion_mask=None, sample_mask=None):
+    log_is_raw = jnp.asarray(log_is_raw)
+    if completion_mask is None:
+      completion_mask = jnp.ones_like(log_is_raw)
+    if sample_mask is None:
+      sample_mask = jnp.ones(log_is_raw.shape[0])
+    log_is = jnp.nan_to_num(log_is_raw, nan=0.0, posinf=0.0, neginf=0.0)
+    geomean, valid = algo_core.sequence_geomean_ratio(log_is, completion_mask)
+    return algo_core.truncated_importance_weights(
+        log_is_raw, geomean, valid, sample_mask, **self._BAND
+    )
+
+  def test_agreement_gives_unit_weights_and_no_drops(self):
+    weights, oob = self._call(jnp.zeros((3, 4)))
+    np.testing.assert_allclose(weights, np.ones((3, 4)), rtol=1e-6)
+    self.assertAlmostEqual(float(oob), 0.0)
+
+  def test_sequence_outside_band_is_zeroed_entirely(self):
+    # Row 0 geomean exp(0.0005) = 1.0005 -> inside. Row 1 exp(0.01) -> outside.
+    weights, oob = self._call(jnp.array([[0.0005] * 4, [0.01] * 4]))
+    self.assertGreater(float(weights[0].min()), 0.0)
+    np.testing.assert_array_equal(weights[1], np.zeros(4))
+    self.assertAlmostEqual(float(oob), 0.5)
+
+  def test_kept_sequences_keep_raw_untruncated_weights(self):
+    # seq-mask-tis clips nothing inside the band: a token whose own ratio is
+    # far from 1 survives intact as long as its sequence average is fine.
+    log_is = jnp.array([[0.5, -0.5, 0.001, 0.001]])
+    weights, oob = self._call(log_is)
+    self.assertAlmostEqual(float(oob), 0.0)
+    np.testing.assert_allclose(
+        weights[0], np.exp(np.asarray(log_is[0])), rtol=1e-5
+    )
+
+  def test_infinite_ratio_becomes_zero_not_one(self):
+    """nan_to_num goes on the weight, after the exp -- not on the log.
+
+    Sanitising the log first would turn an infinite disagreement into log 0 and
+    a weight of 1, silently relabelling a catastrophic token as perfect
+    agreement. It has to become 0 so the token is discarded.
+    """
+    weights, _ = self._call(
+        jnp.array([[jnp.inf, 0.0], [-jnp.inf, 0.0], [jnp.nan, 0.0]])
+    )
+    np.testing.assert_array_equal(weights[:, 0], np.zeros(3))
+
+  def test_geomean_uses_completion_mask_not_padding(self):
+    # Padding must not drag a sequence's geometric mean toward 1 and rescue it.
+    weights, oob = self._call(
+        jnp.array([[0.01, 0.01, 99.0, 99.0]]),
+        completion_mask=jnp.array([[1.0, 1.0, 0.0, 0.0]]),
+    )
+    # Mean over the two real tokens is 0.01 -> outside the band -> dropped.
+    self.assertAlmostEqual(float(oob), 1.0)
+    np.testing.assert_array_equal(weights[0, :2], np.zeros(2))
+
+  def test_oob_ratio_normalises_over_valid_sequences_only(self):
+    # Sequences already dropped upstream leave both the numerator and the
+    # denominator of the reported rate.
+    _, oob = self._call(
+        jnp.array([[0.01] * 3, [0.0] * 3, [0.0] * 3]),
+        sample_mask=jnp.array([0.0, 1.0, 1.0]),  # row 0 already dropped
+    )
+    self.assertAlmostEqual(float(oob), 0.0)
+    # Normalising over everything would have called it 1/3.
+
+  def test_drop_scales_the_loss_down_unlike_a_loss_mask(self):
+    """The keep-mask multiplies weights, so the denominator is frozen.
+
+    This is the opposite of `sequence_loss_mask` and is the most consequential
+    semantic here: getting it backwards is a silent learning-rate change in one
+    direction or the other.
+    """
+    completion_mask = jnp.ones((2, 4), dtype=jnp.float32)
+    weights, _ = self._call(
+        jnp.array([[0.0] * 4, [0.01] * 4]),  # row 1 outside the band
+        completion_mask=completion_mask,
+    )
+    per_token_loss = jnp.full((2, 4), 0.25, dtype=jnp.float32)
+
+    full = common.aggregate_loss(per_token_loss, completion_mask, 'token-mean')
+    corrected = common.aggregate_loss(
+        per_token_loss * weights, completion_mask, 'token-mean'
+    )
+    # Half the sequences dropped -> half the loss, same denominator.
+    self.assertAlmostEqual(
+        float(corrected.compute()), float(full.compute()) / 2.0, places=5
+    )
+    self.assertAlmostEqual(
+        float(corrected.denominator), float(full.denominator), places=5
+    )
+
+
+class SamplerIsLengthScalingTest(absltest.TestCase):
+  """The offset's length-scaling diagnostic.
+
+  The statistic has to separate two hypotheses that look identical in a batch
+  average but imply opposite things at production sequence length: iid token
+  noise, where the per-sequence offset shrinks as 1/sqrt(T), and a systematic
+  within-sequence bias, where it does not shrink at all.
+  """
+
+  _EDGES = (256, 512, 1024)
+  _LENGTHS = (128, 384, 768, 2048)  # one per bucket, incl. the open-ended one
+  _N_PER_LENGTH = 400
+  _TOKEN_SIGMA = 0.018
+
+  def _synthesize(self, per_sequence_offset_sigma):
+    """A batch of mixed-length sequences under a known hypothesis.
+
+    Args:
+      per_sequence_offset_sigma: Scale of a constant offset added to every
+        token of a sequence. 0.0 gives pure iid token noise; a positive value
+        adds the systematic component that sqrt(T) averaging cannot remove.
+
+    Returns:
+      `(log_is, completion_mask)`, right-padded to the longest length.
+    """
+    rng = np.random.default_rng(0)
+    t_max = max(self._LENGTHS)
+    rows = len(self._LENGTHS) * self._N_PER_LENGTH
+    log_is = np.zeros((rows, t_max), dtype=np.float32)
+    mask = np.zeros_like(log_is)
+    for i, length in enumerate(self._LENGTHS):
+      sl = slice(i * self._N_PER_LENGTH, (i + 1) * self._N_PER_LENGTH)
+      tokens = rng.normal(
+          0.0, self._TOKEN_SIGMA, size=(self._N_PER_LENGTH, length)
+      )
+      if per_sequence_offset_sigma:
+        tokens += rng.normal(
+            0.0, per_sequence_offset_sigma, size=(self._N_PER_LENGTH, 1)
+        )
+      log_is[sl, :length] = tokens
+      mask[sl, :length] = 1.0
+    return jnp.asarray(log_is), jnp.asarray(mask)
+
+  def _bucket_sums(self, per_sequence_offset_sigma, overlong=None):
+    log_is, completion_mask = self._synthesize(per_sequence_offset_sigma)
+    seq_log_mean = (log_is * completion_mask).sum(axis=-1) / (
+        completion_mask.sum(axis=-1) + 1e-8
+    )
+    return algo_core.sampler_is_length_bucket_sums(
+        log_is,
+        seq_log_mean,
+        completion_mask,
+        jnp.ones_like(seq_log_mean),
+        self._EDGES,
+        overlong=overlong,
+    )
+
+  def _excess_per_bucket(self, per_sequence_offset_sigma):
+    """Applies the offline formulas documented on the emitting function."""
+    sums = self._bucket_sums(per_sequence_offset_sigma)
+    excess = []
+    for name in algo_core.sampler_is_length_bucket_names(self._EDGES):
+      prefix = f'{name}/complete'
+      count = float(sums[f'{prefix}/count'])
+      observed = np.sqrt(float(sums[f'{prefix}/logmean_sq_sum']) / count)
+      iid = np.sqrt(float(sums[f'{prefix}/iid_var_sum']) / count)
+      excess.append(observed / iid)
+    return excess
+
+  def test_bucket_names(self):
+    self.assertEqual(
+        algo_core.sampler_is_length_bucket_names((256, 1024)),
+        ['le256', 'le1024', 'gt1024'],
+    )
+    self.assertEqual(algo_core.sampler_is_length_bucket_names(None), [])
+    self.assertEqual(algo_core.sampler_is_length_bucket_names(()), [])
+
+  def test_buckets_partition_the_batch_by_length(self):
+    sums = self._bucket_sums(0.0)
+    names = algo_core.sampler_is_length_bucket_names(self._EDGES)
+    # Every sequence lands in exactly one bucket, and each bucket holds the
+    # length it was built from. With no truncation verdict supplied, all of
+    # them report as complete.
+    self.assertEqual(
+        [float(sums[f'{n}/complete/count']) for n in names],
+        [float(self._N_PER_LENGTH)] * len(names),
+    )
+    self.assertEqual(
+        [float(sums[f'{n}/truncated/count']) for n in names],
+        [0.0] * len(names),
+    )
+    for name, length in zip(names, self._LENGTHS):
+      self.assertAlmostEqual(
+          float(sums[f'{name}/complete/len_sum']) / self._N_PER_LENGTH,
+          length,
+          places=3,
+      )
+
+  def test_completion_status_split_is_disjoint_and_additive(self):
+    # Half the sequences marked truncated: the two series must partition the
+    # bucket, so summing them recovers the unsplit total.
+    n_rows = len(self._LENGTHS) * self._N_PER_LENGTH
+    overlong = jnp.asarray(np.tile([0.0, 1.0], n_rows // 2), dtype=jnp.float32)
+    split = self._bucket_sums(0.0, overlong=overlong)
+    unsplit = self._bucket_sums(0.0)
+    for name in algo_core.sampler_is_length_bucket_names(self._EDGES):
+      self.assertEqual(
+          float(split[f'{name}/complete/count']), self._N_PER_LENGTH / 2
+      )
+      self.assertEqual(
+          float(split[f'{name}/truncated/count']), self._N_PER_LENGTH / 2
+      )
+      for metric in algo_core.SAMPLER_IS_LENGTH_BUCKET_METRICS:
+        np.testing.assert_allclose(
+            float(split[f'{name}/complete/{metric}'])
+            + float(split[f'{name}/truncated/{metric}']),
+            float(unsplit[f'{name}/complete/{metric}']),
+            rtol=1e-5,
+            err_msg=f'{name}/{metric} is not additive across the split',
+        )
+
+  def test_metric_names_cover_what_the_sums_emit(self):
+    # The learner registers aggregators from the name list, so it must match
+    # the keys the loss actually produces, exactly.
+    self.assertCountEqual(
+        algo_core.sampler_is_length_bucket_metric_names(self._EDGES),
+        list(self._bucket_sums(0.0).keys()),
+    )
+    self.assertEmpty(algo_core.sampler_is_length_bucket_metric_names(None))
+
+  def test_iid_noise_gives_flat_unit_excess(self):
+    # Pure iid tokens: the observed per-sequence spread is exactly what
+    # 1/sqrt(T) averaging predicts, at every length.
+    for name, value in zip(
+        algo_core.sampler_is_length_bucket_names(self._EDGES),
+        self._excess_per_bucket(0.0),
+    ):
+      self.assertBetween(value, 0.9, 1.15, msg=f'bucket {name}')
+
+  def test_systematic_offset_gives_excess_growing_with_length(self):
+    # A per-sequence constant offset survives averaging, so the observed
+    # spread stays flat in T while the iid prediction keeps falling; their
+    # ratio must therefore grow with bucket length. This is the signature.
+    excess = self._excess_per_bucket(per_sequence_offset_sigma=0.005)
+    self.assertTrue(
+        all(a < b for a, b in zip(excess, excess[1:])),
+        msg=f'excess should increase with bucket length, got {excess}',
+    )
+    # 16x length range between the first and last bucket, so ~4x in sqrt(T).
+    self.assertGreater(excess[-1] / excess[0], 3.0)
+
+
+class SequenceGeomeanRatioTest(absltest.TestCase):
+
+  def test_agreement_is_one(self):
+    geomean, valid = algo_core.sequence_geomean_ratio(
+        jnp.zeros((2, 3)), jnp.ones((2, 3))
+    )
+    np.testing.assert_allclose(geomean, [1.0, 1.0], rtol=1e-6)
+    np.testing.assert_array_equal(valid, [1.0, 1.0])
+
+  def test_geometric_not_arithmetic(self):
+    # exp of the mean log, not the mean of the exps: for [+d, -d] those differ
+    # (1.0 vs cosh(d)), and the geometric one is what composes correctly.
+    d = 0.5
+    geomean, _ = algo_core.sequence_geomean_ratio(
+        jnp.array([[d, -d]]), jnp.ones((1, 2))
+    )
+    self.assertAlmostEqual(float(geomean[0]), 1.0, places=6)
+    self.assertGreater(float(np.cosh(d)), 1.0)
+
+  def test_empty_sequence_is_marked_invalid(self):
+    geomean, valid = algo_core.sequence_geomean_ratio(
+        jnp.zeros((2, 3)), jnp.array([[1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])
+    )
+    np.testing.assert_array_equal(valid, [1.0, 0.0])
+    self.assertTrue(np.isfinite(float(geomean[1])))
 
 
 if __name__ == '__main__':

--- a/tests/rl/algo_core_test.py
+++ b/tests/rl/algo_core_test.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 import numpy as np
 from tunix.rl import algo_core
 from tunix.rl import common
+from tunix.sft import utils as sft_utils
 
 
 class AlgoCoreTest(absltest.TestCase):
@@ -726,6 +727,82 @@ class SequenceGeomeanRatioTest(absltest.TestCase):
     )
     np.testing.assert_array_equal(valid, [1.0, 0.0])
     self.assertTrue(np.isfinite(float(geomean[1])))
+
+
+class EmptyMicroBatchMetricsTest(absltest.TestCase):
+  """Metrics must survive a micro-batch with no rows left in the loss.
+
+  One micro-batch is exactly one prompt group whenever
+  train_micro_batch_size == num_generations, so sequence-level masking can
+  empty one outright. Any per-micro-batch value that is degenerate there
+  (+/-inf, or a 0.0 below the metric's own floor) then propagates through the
+  cross-micro-batch reducer and destroys the step's number.
+  """
+
+  def test_weighted_mean_ignores_an_empty_micro_batch(self):
+    # Two micro-batches score 1.06; the third has nothing scored. The correct
+    # answer is 1.06, not 2/3 of it.
+    scored = sft_utils.WeightedMetric(
+        jnp.asarray(2 * 1.06), jnp.asarray(2.0), min_denom=1.0
+    )
+    empty = sft_utils.WeightedMetric(
+        jnp.asarray(0.0), jnp.asarray(0.0), min_denom=1.0
+    )
+    self.assertAlmostEqual(
+        float(common.global_weighted_mean([scored, empty])), 1.06, places=6
+    )
+    # The reducer this replaced is what produced the sub-1.0 readings.
+    self.assertLess(float(common.mean_of_means([scored, empty])), 1.0)
+
+  def test_all_empty_does_not_nan(self):
+    empty = sft_utils.WeightedMetric(
+        jnp.asarray(0.0), jnp.asarray(0.0), min_denom=1.0
+    )
+    self.assertTrue(np.isfinite(float(common.global_weighted_mean([empty]))))
+
+
+class GrpoLossMetricInertnessTest(absltest.TestCase):
+  """With every optional feature off, the new code paths must not fire.
+
+  tunix is not MLPerf-only: a caller that sets none of the sequence-masking or
+  importance-sampling options must see exactly the previous behaviour.
+  """
+
+  def test_adv_max_min_are_finite_when_a_row_is_empty(self):
+    # Directly exercise the reduction the loss performs. Row 1 is fully
+    # masked; the surviving row must set both extremes.
+    loss_mask = jnp.array([[1.0, 1.0, 0.0], [0.0, 0.0, 0.0]])
+    adv = jnp.broadcast_to(jnp.array([[2.0], [-5.0]]), (2, 3))
+    any_row = jnp.any(loss_mask > 0)
+    adv_max = jnp.where(
+        any_row, jnp.max(jnp.where(loss_mask > 0, adv, -jnp.inf)), 0.0
+    )
+    adv_min = jnp.where(
+        any_row, jnp.min(jnp.where(loss_mask > 0, adv, jnp.inf)), 0.0
+    )
+    self.assertEqual(float(adv_max), 2.0)
+    self.assertEqual(float(adv_min), 2.0)
+
+  def test_fully_empty_mask_falls_back_to_zero_not_inf(self):
+    loss_mask = jnp.zeros((2, 3))
+    adv = jnp.ones((2, 3))
+    any_row = jnp.any(loss_mask > 0)
+    adv_max = jnp.where(
+        any_row, jnp.max(jnp.where(loss_mask > 0, adv, -jnp.inf)), 0.0
+    )
+    self.assertTrue(np.isfinite(float(adv_max)))
+    self.assertEqual(float(adv_max), 0.0)
+
+  def test_unmasked_reduction_is_unchanged(self):
+    # The fallback must be invisible when nothing is masked: same value as the
+    # plain jnp.max it guards.
+    loss_mask = jnp.ones((2, 3))
+    adv = jnp.array([[1.0, 2.0, 3.0], [-1.0, 0.0, 4.0]])
+    any_row = jnp.any(loss_mask > 0)
+    guarded = jnp.where(
+        any_row, jnp.max(jnp.where(loss_mask > 0, adv, -jnp.inf)), 0.0
+    )
+    self.assertEqual(float(guarded), float(jnp.max(adv)))
 
 
 if __name__ == '__main__':

--- a/tests/rl/algo_core_test.py
+++ b/tests/rl/algo_core_test.py
@@ -354,6 +354,63 @@ class SequenceLossMaskTest(absltest.TestCase):
     )
 
 
+class TokenOutlierStatsTest(absltest.TestCase):
+  """Separating a few catastrophic tokens from broadly noisy ones."""
+
+  def test_uniform_small_noise_reports_no_outliers(self):
+    log_is = jnp.full((4, 100), 0.08)
+    absmax, frac, per_seq = algo_core.token_outlier_stats(
+        log_is, jnp.ones((4, 100)), 4.0
+    )
+    self.assertAlmostEqual(float(absmax), 0.08, places=5)
+    self.assertEqual(float(frac), 0.0)
+    self.assertEqual(float(per_seq), 0.0)
+
+  def test_one_catastrophic_token_per_sequence_is_counted(self):
+    # The case this metric exists for: a defect that fires once per
+    # conversation turn. Broad noise is small, but a few tokens are off by
+    # tens of nats and dominate the sequence geometric mean.
+    log_is = np.full((4, 100), 0.05, dtype=np.float32)
+    log_is[:, ::25] = -24.0  # four per sequence, as turn boundaries would be
+    absmax, frac, per_seq = algo_core.token_outlier_stats(
+        jnp.asarray(log_is), jnp.ones((4, 100)), 4.0
+    )
+    self.assertAlmostEqual(float(absmax), 24.0, places=4)
+    self.assertAlmostEqual(float(frac), 16 / 400, places=6)
+    self.assertAlmostEqual(float(per_seq), 4.0, places=5)
+
+  def test_absmean_alone_would_miss_it(self):
+    # Guards the premise. Both arrays have a similar mean |log_is|, but only
+    # one is pathological -- which is exactly why the mean cannot be the only
+    # thing reported.
+    spread = jnp.full((1, 100), 0.25)
+    spiky = np.zeros((1, 100), dtype=np.float32)
+    spiky[0, :1] = -25.0
+    spiky = jnp.asarray(spiky)
+    mask = jnp.ones((1, 100))
+    self.assertAlmostEqual(
+        float(jnp.abs(spread).mean()), float(jnp.abs(spiky).mean()), places=6
+    )
+    self.assertEqual(float(algo_core.token_outlier_stats(spread, mask, 1.0)[2]), 0.0)
+    self.assertEqual(float(algo_core.token_outlier_stats(spiky, mask, 1.0)[2]), 1.0)
+
+  def test_masked_tokens_are_ignored(self):
+    log_is = jnp.array([[0.0, 0.0, -30.0]])
+    mask = jnp.array([[1.0, 1.0, 0.0]])
+    absmax, frac, per_seq = algo_core.token_outlier_stats(log_is, mask, 1.0)
+    self.assertEqual(float(absmax), 0.0)
+    self.assertEqual(float(frac), 0.0)
+    self.assertEqual(float(per_seq), 0.0)
+
+  def test_fully_masked_batch_is_neutral(self):
+    absmax, frac, per_seq = algo_core.token_outlier_stats(
+        jnp.full((2, 3), -40.0), jnp.zeros((2, 3)), 1.0
+    )
+    self.assertEqual(float(absmax), 0.0)
+    self.assertEqual(float(frac), 0.0)
+    self.assertEqual(float(per_seq), 0.0)
+
+
 class SequenceMultProbErrorTest(absltest.TestCase):
   """The log-probability disagreement gate."""
 

--- a/tests/rl/algo_core_test.py
+++ b/tests/rl/algo_core_test.py
@@ -174,6 +174,15 @@ class GrpoLooAdvantagesTest(absltest.TestCase):
     return out
 
   def test_matches_the_definition_across_group_sizes(self):
+    # Tolerance is set for float32, not for the formula. The leave-one-out
+    # variance is E[x^2] - E[x]^2, which cancels: on a low-variance group those
+    # two terms agree to ~3 significant figures, so float32 keeps only ~4 of its
+    # 7 digits, and dividing by the resulting small std amplifies that into
+    # ~1e-5 relative error on the advantage. The reference below is float64, so
+    # the gap is expected. Every bug this guards against is orders larger --
+    # a self-inclusive baseline is 1/G (6.7% at G=16), a missing std divisor is
+    # O(1) -- and the exact semantics are pinned by the assertions below, which
+    # do not depend on tolerance at all.
     rng = np.random.default_rng(0)
     for g in (2, 3, 4, 8, 16):
       rewards = rng.random(g * 3)
@@ -181,7 +190,7 @@ class GrpoLooAdvantagesTest(absltest.TestCase):
         np.testing.assert_allclose(
             algo_core.compute_grpo_loo_advantages(jnp.asarray(rewards), g),
             self._reference(rewards, g),
-            rtol=1e-5,
+            rtol=1e-3,
             atol=1e-6,
         )
 
@@ -645,11 +654,19 @@ class SamplerIsLengthScalingTest(absltest.TestCase):
           float(split[f'{name}/truncated/count']), self._N_PER_LENGTH / 2
       )
       for metric in algo_core.SAMPLER_IS_LENGTH_BUCKET_METRICS:
+        # `atol` carries this, not `rtol`. `logmean_sum` adds ~400 signed
+        # per-sequence means that largely cancel, leaving a total some two
+        # orders smaller than the mass summed, so a relative tolerance on it
+        # measures float32 accumulation order rather than additivity. The
+        # absolute bound sits ~100x above that noise and ~1000x below the
+        # smallest real violation, which would be a whole sequence counted
+        # twice or not at all.
         np.testing.assert_allclose(
             float(split[f'{name}/complete/{metric}'])
             + float(split[f'{name}/truncated/{metric}']),
             float(unsplit[f'{name}/complete/{metric}']),
             rtol=1e-5,
+            atol=1e-6,
             err_msg=f'{name}/{metric} is not additive across the split',
         )
 

--- a/tests/rl/algorithm_config_test.py
+++ b/tests/rl/algorithm_config_test.py
@@ -158,5 +158,101 @@ class AlgorithmConfigTest(parameterized.TestCase):
     self.assertEqual(config.kl_clamp_value, value)
 
 
+class SamplerIsOptionsTest(parameterized.TestCase):
+  """Validation of the sampler-vs-trainer options."""
+
+  def test_all_off_by_default(self):
+    config = algorithm_config.AlgorithmConfig()
+    self.assertFalse(config.overlong_loss_masking)
+    self.assertIsNone(config.seq_logprob_error_threshold)
+    self.assertIsNone(config.truncated_importance_sampling_type)
+    self.assertIsNone(config.truncated_importance_sampling_ratio_min)
+    self.assertIsNone(config.truncated_importance_sampling_ratio)
+    self.assertEqual(config.sampler_is_report_bands, ())
+    self.assertIsNone(config.sampler_is_length_buckets)
+
+  def test_grpo_loo_is_a_valid_estimator(self):
+    config = algorithm_config.AlgorithmConfig(advantage_estimator="grpo-loo")
+    self.assertEqual(config.advantage_estimator, "grpo-loo")
+
+  @parameterized.parameters("rloo", "drgrpo")
+  def test_registered_estimators_are_selectable(self, name):
+    # These are implemented in the registry; the validator used to reject
+    # them, making them unreachable.
+    self.assertEqual(
+        algorithm_config.AlgorithmConfig(
+            advantage_estimator=name
+        ).advantage_estimator,
+        name,
+    )
+
+  def test_keep_band_must_be_complete(self):
+    for kwargs in (
+        {"truncated_importance_sampling_ratio_min": 0.999},
+        {"truncated_importance_sampling_ratio": 1.002},
+    ):
+      with self.assertRaisesRegex(ValueError, "must be set together"):
+        algorithm_config.AlgorithmConfig(**kwargs)
+
+  def test_keep_band_must_be_ordered(self):
+    with self.assertRaisesRegex(ValueError, "must not exceed"):
+      algorithm_config.AlgorithmConfig(
+          truncated_importance_sampling_ratio_min=1.002,
+          truncated_importance_sampling_ratio=0.999,
+      )
+
+  def test_correction_requires_a_band(self):
+    with self.assertRaisesRegex(ValueError, "requires a keep-band"):
+      algorithm_config.AlgorithmConfig(
+          truncated_importance_sampling_type="seq-mask-tis"
+      )
+
+  def test_unknown_correction_type_rejected(self):
+    with self.assertRaisesRegex(ValueError, "only supports 'seq-mask-tis'"):
+      algorithm_config.AlgorithmConfig(
+          truncated_importance_sampling_type="tis",
+          truncated_importance_sampling_ratio_min=0.5,
+          truncated_importance_sampling_ratio=5.0,
+      )
+
+  def test_correction_accepts_a_complete_band(self):
+    config = algorithm_config.AlgorithmConfig(
+        truncated_importance_sampling_type="seq-mask-tis",
+        truncated_importance_sampling_ratio_min=0.999,
+        truncated_importance_sampling_ratio=1.002,
+    )
+    self.assertEqual(
+        config.truncated_importance_sampling_type, "seq-mask-tis"
+    )
+
+  @parameterized.parameters(
+      ((0, 512),),  # non-positive edge
+      ((512, 512),),  # not strictly increasing
+      ((1024, 512),),  # decreasing
+      ((),),  # empty means "disabled", which is None, not ()
+  )
+  def test_invalid_length_buckets_rejected(self, edges):
+    with self.assertRaises(ValueError):
+      algorithm_config.AlgorithmConfig(sampler_is_length_buckets=edges)
+
+  def test_length_buckets_normalised_to_tuple(self):
+    # Config loaders hand us lists; bucket edges end up in metric names, so
+    # they need to be a stable, hashable tuple.
+    config = algorithm_config.AlgorithmConfig(
+        sampler_is_length_buckets=[512, 1024]
+    )
+    self.assertEqual(config.sampler_is_length_buckets, (512, 1024))
+
+  def test_report_bands_normalised_and_validated(self):
+    config = algorithm_config.AlgorithmConfig(
+        sampler_is_report_bands=[[0.99, 1.01]]
+    )
+    self.assertEqual(config.sampler_is_report_bands, ((0.99, 1.01),))
+    with self.assertRaisesRegex(ValueError, "ordered"):
+      algorithm_config.AlgorithmConfig(
+          sampler_is_report_bands=[(1.01, 0.99)]
+      )
+
+
 if __name__ == "__main__":
   absltest.main()

--- a/tests/rl/reward_manager_test.py
+++ b/tests/rl/reward_manager_test.py
@@ -264,6 +264,30 @@ class AgenticSequenceRewardManagerTest(parameterized.TestCase):
     self.assertIn("rewards/sum", log_metrics)
     self.assertIn("rewards/len_reward", log_metrics)
 
+  def test_sum_metric_reduces_with_sum_across_micro_batches(self):
+    """A /sum metric must reduce with np.sum, not np.mean.
+
+    Each call contributes one micro-batch of a step. Reducing a sum with
+    np.mean reports the average micro-batch sum, understating the step total
+    by the number of micro-batches.
+    """
+    manager = reward_manager.AgenticSequenceRewardManager(
+        reward_fns=None,
+        algo_config=self.test_algo_config,
+    )
+    micro_batch_values = []
+    reducer = None
+    for traj_rewards in ([1.0, 1.0], [1.0, 0.0]):
+      log_metrics = manager(
+          self.prompts, self.completions, trajectory_rewards=traj_rewards
+      )["log_metrics"]
+      value, reducer = log_metrics["trajectory_rewards/sum"]
+      micro_batch_values.append(value)
+
+    self.assertIs(reducer, np.sum)
+    # Step total is 3.0; reducing with np.mean would report 1.5.
+    self.assertEqual(reducer(micro_batch_values), 3.0)
+
   def test_log_metrics_non_interference_no_reward_fns(self):
     manager = reward_manager.AgenticSequenceRewardManager(
         reward_fns=None,

--- a/tests/sft/peft_trainer_test.py
+++ b/tests/sft/peft_trainer_test.py
@@ -2180,5 +2180,79 @@ class TrainStepGlobalWeightedTest(parameterized.TestCase):
     self.assertGreater(float(max_diff), 1e-3)
 
 
+class FrozenParameterOptStateTest(absltest.TestCase):
+  """Optimizer-state traversals must tolerate `optax.multi_transform`.
+
+  Freezing parameters -- e.g. a MoE router via MaxText's
+  `trainable_parameters_mask` -- is expressed with `optax.multi_transform`,
+  which writes `optax.MaskedNode()` into each sub-optimizer's state wherever a
+  parameter belongs to a different branch. Those sentinels are not arrays and
+  flatten to no leaves at all, which broke two traversals here: one read
+  `.dtype` off them, the other zipped the state against a partition-spec tree
+  and hit a structure mismatch.
+  """
+
+  def _frozen_optimizer(self):
+    class _Tiny(nnx.Module):
+
+      def __init__(self, rngs):
+        # `gate` stands in for the MoE router: the thing being frozen.
+        self.gate = nnx.Linear(8, 4, rngs=rngs)
+        self.mlp = nnx.Linear(8, 8, rngs=rngs)
+
+    model = _Tiny(nnx.Rngs(0))
+    freeze_gate = lambda params: jax.tree_util.tree_map_with_path(
+        lambda path, _: (
+            'frozen'
+            if 'gate'
+            in jax.tree_util.keystr(path, simple=True, separator='/')
+            else 'trainable'
+        ),
+        params,
+    )
+    tx = optax.multi_transform(
+        {'trainable': optax.adamw(1e-3), 'frozen': optax.set_to_zero()},
+        freeze_gate,
+    )
+    return nnx.Optimizer(model, tx, wrt=nnx.Param)
+
+  def test_state_really_contains_masked_sentinels(self):
+    # Guards the premise: if optax stops emitting these, the two tests below
+    # would pass vacuously.
+    optimizer = self._frozen_optimizer()
+    leaves = jax.tree_util.tree_leaves(
+        nnx.state(optimizer, nnx.optimizer.OptState),
+        is_leaf=peft_trainer._is_masked_node,  # pylint: disable=protected-access
+    )
+    self.assertTrue(any(peft_trainer._is_masked_node(v) for v in leaves))  # pylint: disable=protected-access
+
+  def test_opt_state_dtypes_skips_masked_nodes(self):
+    optimizer = self._frozen_optimizer()
+    dtypes = peft_trainer._opt_state_dtypes(optimizer)  # pylint: disable=protected-access
+    # Masked entries carry no dtype; real ones still do.
+    flat = jax.tree_util.tree_leaves(dtypes, is_leaf=lambda x: x is None)
+    self.assertIn(None, flat)
+    self.assertTrue(any(x is not None for x in flat))
+
+  def test_restore_dtypes_is_a_noop_on_masked_nodes(self):
+    optimizer = self._frozen_optimizer()
+    dtypes = peft_trainer._opt_state_dtypes(optimizer)  # pylint: disable=protected-access
+    peft_trainer._restore_opt_state_float_dtypes(optimizer, dtypes)  # pylint: disable=protected-access
+
+  def test_state_zips_against_its_partition_spec_tree(self):
+    # The shape of the failure in `_shard_optimizer`: a MaskedNode flattens to
+    # nothing, so without `is_leaf` the state tree is short exactly one leaf
+    # wherever the spec tree still has one.
+    optimizer = self._frozen_optimizer()
+    state = nnx.state(optimizer, nnx.optimizer.OptState)
+    pspecs = nnx.get_partition_spec(state)
+    jax.tree.map(
+        lambda x, _: x,
+        state,
+        pspecs,
+        is_leaf=peft_trainer._is_masked_node,  # pylint: disable=protected-access
+    )
+
+
 if __name__ == '__main__':
   absltest.main()

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -45,6 +45,7 @@ from tunix.rl import rl_cluster as rl_engine_lib
 from tunix.rl import utils as rl_utils
 from tunix.rl.agentic import agentic_rl_learner
 from tunix.rl.agentic import utils as agentic_utils
+from tunix.rl.agentic.agents import agent_types
 from tunix.rl.agentic.agents import base_agent
 from tunix.rl.agentic.agents import model_agent
 from tunix.rl.agentic.environments import base_environment
@@ -179,6 +180,20 @@ class GRPOConfig(agentic_rl_learner.AgenticRLConfig):
             self.off_policy_steps,
             self.off_policy_steps,
         )
+    # This override does not chain to `AlgorithmConfig.__post_init__`, so the
+    # shared sampler-vs-trainer validation has to be invoked explicitly.
+    self.validate_sampler_is_options()
+    if self.sampler_is is not None and (
+        self.truncated_importance_sampling_type is not None
+    ):
+      raise ValueError(
+          "sampler_is and truncated_importance_sampling_type are two"
+          " different importance-sampling corrections; enabling both applies"
+          f" both sets of weights to the same loss. Got"
+          f" sampler_is={self.sampler_is!r} and"
+          " truncated_importance_sampling_type="
+          f"{self.truncated_importance_sampling_type!r}."
+      )
 
 
 TGrpoConfig = TypeVar("TGrpoConfig", bound=GRPOConfig)
@@ -296,7 +311,37 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
             "algo_config": self.algo_config,
         }
     )
+    # Emitted by the loss only when the matching option is set, so register
+    # them conditionally to keep the two in step. The length-scaling
+    # diagnostic emits raw per-bucket sums, for which np.sum is the only
+    # correct aggregator; derived ratios are computed offline from those.
+    cfg = self.algo_config
+    optional_metrics: Dict[str, Any] = {
+        f"sampler_is/lenscale/{suffix}": np.sum
+        for suffix in algo_core.sampler_is_length_bucket_metric_names(
+            cfg.sampler_is_length_buckets
+        )
+    }
+    for low, high in cfg.sampler_is_report_bands or ():
+      name = f"sampler_is/would_drop_{algo_core.band_label(low, high)}"
+      optional_metrics[name] = common.mean_of_means
+    if cfg.truncated_importance_sampling_type is not None:
+      optional_metrics["tis/is_oob_ratio"] = common.mean_of_means
+    if cfg.seq_logprob_error_threshold is not None:
+      optional_metrics["sample_mask/mult_prob_error_mean"] = (
+          common.mean_of_means
+      )
+      optional_metrics["sample_mask/mult_prob_error_max"] = np.max
+
     self.rl_engine.actor_trainer.with_rl_metrics_to_log({  # pyrefly: ignore[bad-argument-type]
+        **optional_metrics,
+        "sample_mask/kept_frac": common.mean_of_means,
+        "sampler_is/token_logdiff_absmean": common.mean_of_means,
+        "sampler_is/token_weight_mean": common.mean_of_means,
+        "sampler_is/token_weight_max": np.max,
+        "sampler_is/seq_geomean_mean": common.mean_of_means,
+        "sampler_is/seq_geomean_min": np.min,
+        "sampler_is/seq_geomean_max": np.max,
         "kl": common.mean_of_means,
         "entropy": common.mean_of_means,
         "reduced_pg_loss": common.mean_of_means,
@@ -569,6 +614,7 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     policy_versions_list: List[int] = []
     trajectory_rewards_list: List[float] = []
     raw_completion_lengths: List[int] = []
+    overlong_flags: List[float] = []
     trajectories_to_log = []
 
     for item in trajectories:
@@ -593,6 +639,20 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         raise ValueError("policy_version is missing from trajectory task.")
       policy_versions_list.append(policy_version)
       trajectory_rewards_list.append(item.traj.get("trajectory_reward"))
+      # The collect engine's own verdict. "Overlong" here means the response
+      # budget was exhausted without an end-of-sequence token, i.e. a truncated
+      # prefix. Deliberately narrower than the engine's `filter_statuses`,
+      # which also covers agent and environment failures -- those are a
+      # different kind of invalid sample and should not be conflated.
+      # `.name`, because the collect engine serialises the status by name
+      # (`agent_types.py:142`, `trajectory_collect_engine.py:322`); the enum
+      # uses `auto()`, so `.value` is an opaque int that would never match.
+      overlong_flags.append(
+          1.0
+          if item.traj.get("status")
+          == agent_types.TrajectoryStatus.MAX_CONTEXT_LIMIT_REACHED.name
+          else 0.0
+      )
 
     # Log trajectory.
     if self._trajectory_logger and trajectories_to_log:
@@ -945,6 +1005,8 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         old_per_token_logps=old_per_token_logps,
         policy_version=policy_versions,
         sampler_is_weights=sampler_is_weights,
+        rollout_per_token_logps=rollout_per_token_logps,
+        overlong=jnp.asarray(overlong_flags, dtype=jnp.float32),
     )
     return [combined_batch]
 

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -328,8 +328,13 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     if cfg.truncated_importance_sampling_type is not None:
       optional_metrics["tis/is_oob_ratio"] = common.mean_of_means
     if cfg.seq_logprob_error_threshold is not None:
+      # global_weighted_mean, not mean_of_means: the latter divides each
+      # micro-batch before averaging, so a micro-batch with no scored sequence
+      # contributes a 0.0 and drags the result below the metric's own floor of
+      # 1.0. Summing numerators and denominators first gives such a
+      # micro-batch zero weight instead.
       optional_metrics["sample_mask/mult_prob_error_mean"] = (
-          common.mean_of_means
+          common.global_weighted_mean
       )
       optional_metrics["sample_mask/mult_prob_error_max"] = np.max
 

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -342,8 +342,14 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
         **optional_metrics,
         "sample_mask/kept_frac": common.mean_of_means,
         "sampler_is/token_logdiff_absmean": common.mean_of_means,
+        "sampler_is/token_logdiff_absmax": np.max,
+        "sampler_is/token_outlier_frac": common.mean_of_means,
+        # Already per-sequence within a micro-batch, so pooling is a mean of
+        # those means -- the same convention as the other per-sequence metrics.
+        "sampler_is/token_outliers_per_seq": common.mean_of_means,
         "sampler_is/token_weight_mean": common.mean_of_means,
         "sampler_is/token_weight_max": np.max,
+        "sampler_is/token_weight_min": np.min,
         "sampler_is/seq_geomean_mean": common.mean_of_means,
         "sampler_is/seq_geomean_min": np.min,
         "sampler_is/seq_geomean_max": np.max,

--- a/tunix/rl/agentic/agentic_grpo_learner.py
+++ b/tunix/rl/agentic/agentic_grpo_learner.py
@@ -955,8 +955,8 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
     )
     metrics_to_log.update(agreement_metrics)
 
-    # Extract time metrics (env_time and reward_time)
-    for time_key in ["env_time", "reward_time"]:
+    # Extract time metrics (env_time, reward_time and model_time)
+    for time_key in ["env_time", "reward_time", "model_time"]:
       prefix = f"trajectory/{time_key}"
       time_dicts = [item.traj.get(time_key, {}) for item in trajectories]
 
@@ -976,11 +976,15 @@ class GRPOLearner(agentic_rl_learner.AgenticRLLearner[TGrpoConfig]):
             f"{prefix}/{sub_key}/max": (np.max(flat_vals), np.max),
             f"{prefix}/{sub_key}/min": (np.min(flat_vals), np.min),
         })
-      self.rl_engine.buffer_metrics_async(
-          metrics_to_log,  # pyrefly: ignore[bad-argument-type]
-          mode=mode,
-          step=expected_step,  # pyrefly: ignore[bad-argument-type]
-      )
+
+    # Buffer once, after every time_key has contributed. This call used to sit
+    # inside the loop above, re-buffering the same accumulating dict on each
+    # iteration.
+    self.rl_engine.buffer_metrics_async(
+        metrics_to_log,  # pyrefly: ignore[bad-argument-type]
+        mode=mode,
+        step=expected_step,  # pyrefly: ignore[bad-argument-type]
+    )
 
     for metric_fn in self.metric_fns:
       user_defined_metric = metric_fn(

--- a/tunix/rl/agentic/agentic_rl_learner.py
+++ b/tunix/rl/agentic/agentic_rl_learner.py
@@ -1089,6 +1089,12 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
             if trainer_buf.losses:
               extras.append(f"loss={float(trainer_buf.loss):.4f}")
             am = trainer_buf.additional_metrics
+            # Absent keys are skipped below, so entries here that belong to an
+            # optional feature simply do not print when it is off. The two
+            # sequence-level rates are worth watching live because they move in
+            # opposite directions: `kept_frac` is the share still in the loss
+            # *and its denominator*, `is_oob` the share whose weights were
+            # zeroed while staying in the denominator.
             for key, label in (
                 ("grad_norm", "grad_norm"),
                 ("reduced_pg_loss", "reduced_pg_loss"),
@@ -1096,6 +1102,8 @@ class AgenticRLLearner(abc.ABC, Generic[TConfig]):
                 ("kl", "kl"),
                 ("log_ratio/abs_mean", "log_ratio_abs"),
                 ("pg_clipfrac", "clipfrac"),
+                ("sample_mask/kept_frac", "kept_frac"),
+                ("tis/is_oob_ratio", "is_oob"),
             ):
               if key in am:
                 vals, _ = am[key]

--- a/tunix/rl/agentic/agents/agent_types.py
+++ b/tunix/rl/agentic/agents/agent_types.py
@@ -117,6 +117,7 @@ class Trajectory:
     reward: Total episode reward (cumulative or final environment score).
     status: Status of the trajectory (e.g., "success", "truncated").
     env_time: Dictionary of environment latency metrics (reset_latency: float, step_latency: list[float] ordered by step index, close_latency: float).
+    model_time: Dictionary of generation latency metrics (generate_latency: list[float] ordered by step index, episode_latency: float measured over the span the episode timeout gates).
   """
 
   task: Any = None
@@ -125,6 +126,7 @@ class Trajectory:
   status: TrajectoryStatus = TrajectoryStatus.RUNNING
   env_time: dict[str, float] = dataclasses.field(default_factory=dict)
   reward_time: dict[str, float] = dataclasses.field(default_factory=dict)
+  model_time: dict[str, Any] = dataclasses.field(default_factory=dict)
 
   def to_dict(self) -> dict[str, Any]:
     """Convert trajectory to dictionary format for serialization.
@@ -142,6 +144,7 @@ class Trajectory:
         "status": self.status.name,
         "env_time": self.env_time,
         "reward_time": self.reward_time,
+        "model_time": self.model_time,
     }
 
 

--- a/tunix/rl/agentic/trajectory/trajectory_collect_engine.py
+++ b/tunix/rl/agentic/trajectory/trajectory_collect_engine.py
@@ -133,6 +133,16 @@ class TrajectoryCollectEngine:
             0.0
         ),  # Wall-clock time (Total real-world time elapsed)
     }
+    self.model_time = {
+        # Per-turn wall-clock time in model_call, ordered by step index. This
+        # is the generation cost; env_time covers only reset/step/close, so
+        # without it an episode's wall time is unattributable.
+        "generate_latency": [],
+        # Total wall-clock time of the episode, measured from the end of
+        # env.reset (self._start_ts) — the same clock self.timeout is
+        # enforced against.
+        "episode_latency": 0.0,
+    }
 
     if self.max_response_length is not None and not (
         self.tokenizer and self.chat_parser
@@ -217,6 +227,10 @@ class TrajectoryCollectEngine:
           self.agent.trajectory.status = agent_types.TrajectoryStatus.SUCCEEDED
         break
 
+    # Measured over the same span self.timeout gates, so this is directly
+    # comparable to the configured episode timeout.
+    self.model_time["episode_latency"] = time.perf_counter() - self._start_ts
+
     masked_out = (
         self.overlong_filter
         and self.agent.trajectory.status in self.filter_statuses
@@ -238,6 +252,7 @@ class TrajectoryCollectEngine:
     if mode == "Trajectory":
       self.agent.trajectory.env_time = self.env_time  # pyrefly: ignore[bad-assignment]
       self.agent.trajectory.reward_time = self.reward_time
+      self.agent.trajectory.model_time = self.model_time  # pyrefly: ignore[bad-assignment]
       return self.agent.trajectory
     elif mode == "Steps":
       return [
@@ -253,6 +268,7 @@ class TrajectoryCollectEngine:
               "mc_return": step.mc_return,
               "env_time": self.env_time,
               "reward_time": self.reward_time,
+              "model_time": self.model_time,
           }
           for step in self.agent.trajectory.steps
       ]
@@ -323,6 +339,7 @@ class TrajectoryCollectEngine:
           "trajectory_reward": self.agent.trajectory.reward,
           "env_time": self.env_time,
           "reward_time": self.reward_time,
+          "model_time": self.model_time,
           "old_logprobs": (
               np.concatenate(logprobs, axis=0) if logprobs else None
           ),
@@ -511,33 +528,41 @@ class TrajectoryCollectEngine:
             getattr(model_call_fn, "__call__")
         )
     )
-    if is_async:
-      try:
-        rollout_output = await model_call_fn(  # pytype: disable=bad-return-type
-            self.agent.chat_completions,
-            self.env,
-            max_generation_steps=max_generation_steps,
-            **self.model_call_kwargs,
-        )
-      except Exception as e:
-        logging.exception("Caught exception inside async model_call: %s", e)
-        raise
-    else:
-      def _safe_model_call():
+    generate_start = time.perf_counter()
+    try:
+      if is_async:
         try:
-          return model_call_fn(
+          rollout_output = await model_call_fn(  # pytype: disable=bad-return-type
               self.agent.chat_completions,
               self.env,
               max_generation_steps=max_generation_steps,
               **self.model_call_kwargs,
           )
         except Exception as e:
-          logging.exception("Caught exception inside model_call: %s", e)
+          logging.exception("Caught exception inside async model_call: %s", e)
           raise
+      else:
+        def _safe_model_call():
+          try:
+            return model_call_fn(
+                self.agent.chat_completions,
+                self.env,
+                max_generation_steps=max_generation_steps,
+                **self.model_call_kwargs,
+            )
+          except Exception as e:
+            logging.exception("Caught exception inside model_call: %s", e)
+            raise
 
-      rollout_output = await asyncio.get_running_loop().run_in_executor(
-          None,
-          _safe_model_call,
+        rollout_output = await asyncio.get_running_loop().run_in_executor(
+            None,
+            _safe_model_call,
+        )
+    finally:
+      # Recorded even when model_call raises, so a slow-then-failing turn is
+      # still visible in the latency distribution.
+      self.model_time["generate_latency"].append(
+          time.perf_counter() - generate_start
       )
     logging.debug("%s model_call done", self._debug_prefix)
 

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -14,7 +14,10 @@
 
 """Algorithm core implementations for RL and Agentic RL learners."""
 
+from collections.abc import Sequence
 import functools
+from typing import NamedTuple
+
 from flax import nnx
 import jax
 import jax.numpy as jnp
@@ -156,6 +159,374 @@ def masked_var(
   mask_sum = cast_mask.sum()
   bessel_corr = mask_sum / (mask_sum - 1)
   return variance * bessel_corr
+
+
+# ==============================================================================
+# Sampler-vs-trainer divergence
+#
+# The rollout engine that generates tokens and the trainer that scores them run
+# the same weights but different kernels, so their log-probabilities differ
+# slightly. The helpers below measure that divergence, drop sequences where it
+# is too large to train on, and correct for what remains. Every one of them is
+# inert unless explicitly configured.
+# ==============================================================================
+
+
+def band_label(low: float, high: float) -> str:
+  """Metric-name fragment for a keep-band, e.g. (0.99, 1.01) -> "0p99_1p01"."""
+  fmt = lambda v: f"{v:g}".replace(".", "p").replace("-", "neg")
+  return f"{fmt(low)}_{fmt(high)}"
+
+
+def sequence_geomean_ratio(
+    log_is: jax.Array,
+    completion_mask: jax.Array,
+    segment_ids: jax.Array | None = None,
+    num_segments: int | None = None,
+) -> tuple[jax.Array, jax.Array]:
+  """Per-sequence geometric mean of the sampler-to-trainer importance ratio.
+
+  One number per sequence summarising how far the two engines disagree over it:
+  1.0 is agreement, 1.01 means the trainer assigned the sequence about 1% more
+  probability than the sampler did. Geometric rather than arithmetic because
+  the per-token quantities are ratios that compose multiplicatively, which is
+  the same as averaging in log space.
+
+  Args:
+    log_is: Per-token trainer-minus-sampler log ratio, `[B, T]`.
+    completion_mask: Per-token mask over scored tokens, `[B, T]`.
+    segment_ids: Packing segment ids, or None when each row is one sequence.
+    num_segments: Static segment-bucket count; required with `segment_ids`.
+
+  Returns:
+    `(geomean, valid)` -- the per-sequence ratio and a 1.0/0.0 flag marking
+    entries backed by at least one scored token.
+  """
+  if segment_ids is None:
+    token_count = completion_mask.sum(axis=-1)
+    log_mean = (log_is * completion_mask).sum(axis=-1) / (token_count + 1e-8)
+  else:
+    seg_sum = common.segmented_sum(
+        log_is * completion_mask, segment_ids, num_segments
+    )
+    token_count = common.segmented_count(
+        segment_ids, num_segments, mask=completion_mask
+    )
+    log_mean = seg_sum / (token_count + 1e-8)
+  return jnp.exp(log_mean), (token_count > 0).astype(jnp.float32)
+
+
+def sequence_mult_prob_error(
+    log_is: jax.Array, mask: jax.Array
+) -> jax.Array:
+  """Per-sequence multiplicative probability error, `mean_t exp(|log_is_t|)`.
+
+  A scale-free measure of how far the sampler and trainer disagree: 1.0 is
+  perfect agreement, 2.0 means the typical token's probability differs by a
+  factor of two. Intended to catch plumbing or truncation faults rather than
+  the ordinary numerical drift between two differently optimised engines.
+
+  Takes the absolute value per token, so disagreements cannot cancel within a
+  sequence. That is what separates it from an importance ratio and is the whole
+  point: a sequence off by `+d` on half its tokens and `-d` on the other half
+  has a geometric-mean ratio of exactly 1 and looks perfectly on-policy, while
+  its multiplicative error is `exp(d)`.
+
+  Args:
+    log_is: Per-token trainer-minus-sampler log ratio, `[B, T]`.
+    mask: Tokens to include, `[B, T]`.
+
+  Returns:
+    `[B]`, and 0.0 for fully masked sequences so they can neither drag a
+    minimum statistic down nor trip a threshold spuriously.
+  """
+  denom = mask.sum(axis=-1)
+  # Masking inside the exp keeps padded positions at exp(0) = 1 before they are
+  # zeroed, so whatever occupies those slots cannot overflow.
+  num = (jnp.exp(jnp.abs(log_is) * mask) * mask).sum(axis=-1)
+  return jnp.where(denom > 0, num / jnp.clip(denom, 1.0, None), 0.0)
+
+
+class SequenceMask(NamedTuple):
+  """Result of `sequence_loss_mask`.
+
+  Attributes:
+    sample_mask: Per-sequence loss multiplier `[B]`; 1.0 to keep.
+    loss_mask: `completion_mask` restricted by `sample_mask`, `[B, T]`. What
+      the loss and its denominator should aggregate over.
+    mult_prob_error: Per-sequence multiplicative probability error `[B]`, or
+      None when no threshold was supplied. Reported for every sequence the
+      gate saw, kept or dropped, so the distribution is visible before anyone
+      tightens the threshold.
+  """
+
+  sample_mask: jax.Array
+  loss_mask: jax.Array
+  mult_prob_error: jax.Array | None
+
+
+def sequence_loss_mask(
+    completion_mask: jax.Array,
+    overlong: jax.Array | None = None,
+    mask_overlong: bool = False,
+    log_is: jax.Array | None = None,
+    mult_prob_error_threshold: float | None = None,
+) -> SequenceMask:
+  """Per-sequence loss multiplier, and the token mask it induces.
+
+  Two reasons a sequence may not belong in the update at all, applied in order:
+
+    truncated rollouts
+      A prefix of a trajectory rather than a trajectory, so the reward attached
+      to it is not the reward for the behaviour that produced it.
+    log-probability disagreement
+      Sampler and trainer disagree so much that treating them as the same
+      policy is unsound. See `sequence_mult_prob_error`.
+
+  Dropping a sequence is not the same as down-weighting it. A dropped sequence
+  must leave the loss *denominator* too, so the survivors keep their full
+  gradient magnitude and only the effective batch size shrinks. Returning a
+  token mask rather than a weight is what achieves that: callers aggregate over
+  `loss_mask`, so dropped tokens vanish from numerator and denominator alike.
+  Contrast `truncated_importance_weights`, which multiplies per-token weights
+  and deliberately leaves the denominator alone.
+
+  Args:
+    completion_mask: Per-token mask over scored tokens, `[B, T]`.
+    overlong: 1.0 for sequences the rollout engine truncated, `[B]`, or None
+      when the engine reports no truncation verdict.
+    mask_overlong: Whether to drop truncated sequences from the update.
+    log_is: Per-token trainer-minus-sampler log ratio `[B, T]`, or None when
+      the rollout engine returned no log-probabilities.
+    mult_prob_error_threshold: Drop sequences whose multiplicative probability
+      error exceeds this. None disables the gate.
+
+  Returns:
+    A `SequenceMask`. Every field takes its unrestricted value when no source
+    is active, so callers can use them unconditionally.
+  """
+  batch = completion_mask.shape[0]
+  sample_mask = jnp.ones((batch,), dtype=jnp.float32)
+  if mask_overlong and overlong is not None:
+    sample_mask = sample_mask * (1.0 - jnp.astype(overlong, jnp.float32))
+
+  mult_prob_error = None
+  if mult_prob_error_threshold is not None and log_is is not None:
+    # Measured over the already-truncation-restricted mask. A sequence dropped
+    # above contributes no tokens here, scores 0.0 and passes the threshold,
+    # and stays dropped either way -- so ordering does not change the outcome,
+    # but it keeps the reported error free of tokens nobody is training on.
+    mult_prob_error = sequence_mult_prob_error(
+        log_is, completion_mask * sample_mask[:, None]
+    )
+    sample_mask = sample_mask * jnp.astype(
+        mult_prob_error <= mult_prob_error_threshold, jnp.float32
+    )
+
+  return SequenceMask(
+      sample_mask=sample_mask,
+      loss_mask=completion_mask * sample_mask[:, None],
+      mult_prob_error=mult_prob_error,
+  )
+
+
+def truncated_importance_weights(
+    log_is_raw: jax.Array,
+    seq_geomean: jax.Array,
+    seq_valid: jax.Array,
+    sample_mask: jax.Array,
+    band_min: float,
+    band_max: float,
+) -> tuple[jax.Array, jax.Array]:
+  """Sequence-masked truncated importance sampling (`seq-mask-tis`) weights.
+
+  Corrects for the residual mismatch between the rollout sampler -- the
+  behaviour policy that actually produced the tokens -- and the trainer, the
+  target policy being updated. Each token is weighted by its raw importance
+  ratio `exp(log pi_trainer - log pi_sampler)`, and any sequence whose
+  geometric-mean ratio falls outside `[band_min, band_max]` has its weights
+  zeroed entirely. Sequences inside the band keep raw, unclipped weights.
+
+  Two details carry the semantics and are each easy to invert:
+
+  `nan_to_num` is applied to the weight, *after* the exp, not to the log ratio
+  before it. An infinite log ratio therefore becomes a weight of 0 -- the token
+  is discarded -- rather than a log of 0 and a weight of 1, which would
+  silently relabel a catastrophic disagreement as perfect agreement.
+
+  The keep-mask multiplies the *weights*, never the loss mask, so dropped
+  sequences remain in the loss denominator and the loss scales down with the
+  drop fraction. That is deliberate and is the opposite of
+  `sequence_loss_mask`: this reduces gradient magnitude, that reduces effective
+  batch size. Watch the reported out-of-band ratio accordingly -- a high value
+  here is a learning-rate change, not merely a smaller batch.
+
+  Args:
+    log_is_raw: Per-token trainer-minus-sampler log ratio **before** any
+      `nan_to_num`, `[B, T]`.
+    seq_geomean: Per-sequence geometric-mean ratio `[B]`, from
+      `sequence_geomean_ratio`.
+    seq_valid: 1.0 for entries backed by at least one scored token, `[B]`.
+    sample_mask: Per-sequence validity `[B]`, used only to normalise the
+      reported out-of-band ratio over sequences that are actually training.
+    band_min: Lower end of the keep-band, on the geometric-mean ratio.
+    band_max: Upper end of the keep-band.
+
+  Returns:
+    `(weights, oob_ratio)` -- per-token weights `[B, T]` to multiply into the
+    per-token loss before aggregation, and the fraction of valid sequences the
+    band rejected.
+  """
+  weights = jnp.nan_to_num(
+      jnp.exp(log_is_raw), nan=0.0, posinf=0.0, neginf=0.0
+  )
+  keep = jnp.astype(
+      (seq_geomean >= band_min) & (seq_geomean <= band_max), jnp.float32
+  )
+  counted = sample_mask * seq_valid
+  oob_ratio = 1.0 - (keep * counted).sum() / jnp.maximum(counted.sum(), 1.0)
+  return weights * keep[:, None], oob_ratio
+
+
+# Metric suffixes emitted per (length bucket, completion status). Raw sums, so
+# that pooling across micro-batches, shards and steps is exact -- and so that
+# the two statuses add back to the bucket total, losing nothing to the split.
+SAMPLER_IS_LENGTH_BUCKET_METRICS = (
+    "count",
+    "len_sum",
+    "logmean_sum",
+    "logmean_sq_sum",
+    "iid_var_sum",
+)
+
+# Buckets are split by truncation status because truncated sequences all pile
+# up at the response-length cap; without the split the longest bucket is really
+# "the truncated ones" and no length trend can be read from it.
+SAMPLER_IS_COMPLETION_STATUSES = ("complete", "truncated")
+
+
+def sampler_is_length_bucket_names(
+    bucket_edges: Sequence[int] | None,
+) -> list[str]:
+  """Bucket names for the length-scaling diagnostic.
+
+  Args:
+    bucket_edges: Inclusive upper bounds on completion length, in tokens,
+      strictly increasing; one open-ended bucket is appended. None or empty
+      disables the diagnostic.
+
+  Returns:
+    One name per bucket, e.g. (256, 1024) -> ["le256", "le1024", "gt1024"].
+  """
+  if not bucket_edges:
+    return []
+  return [f"le{e}" for e in bucket_edges] + [f"gt{bucket_edges[-1]}"]
+
+
+def sampler_is_length_bucket_metric_names(
+    bucket_edges: Sequence[int] | None,
+) -> list[str]:
+  """Every metric-name suffix the length-scaling diagnostic emits.
+
+  Args:
+    bucket_edges: As `sampler_is_length_bucket_names`.
+
+  Returns:
+    Suffixes of the form `<bucket>/<status>/<metric>`, for the learner to
+    register and the loss to prefix.
+  """
+  return [
+      f"{bucket}/{status}/{metric}"
+      for bucket in sampler_is_length_bucket_names(bucket_edges)
+      for status in SAMPLER_IS_COMPLETION_STATUSES
+      for metric in SAMPLER_IS_LENGTH_BUCKET_METRICS
+  ]
+
+
+def sampler_is_length_bucket_sums(
+    log_is: jax.Array,
+    seq_log_mean: jax.Array,
+    completion_mask: jax.Array,
+    seq_valid: jax.Array,
+    bucket_edges: Sequence[int],
+    overlong: jax.Array | None = None,
+) -> dict[str, jax.Array]:
+  """Length-bucketed sums for the offset's scaling behaviour.
+
+  Distinguishes two explanations for a per-sequence sampler-vs-trainer offset
+  that have opposite consequences at production sequence lengths:
+
+    iid token noise
+      The per-sequence mean is an average of T independent terms, so its spread
+      falls as 1/sqrt(T). Longer sequences fix the offset on their own.
+    systematic within-sequence bias
+      Every token in a sequence leans the same way, nothing cancels, and the
+      spread is flat in T. Longer sequences do not help, and a fixed keep-band
+      stays unreachable at any scale.
+
+  Both are measurable inside a single batch, by bucketing the sequences already
+  present by their own length. Raw sums are returned rather than ratios so that
+  pooling across micro-batches and shards is exact -- a plain sum, not an
+  average of averages. Per bucket, offline:
+
+      observed_rms = sqrt(logmean_sq_sum / count)   # spread actually seen
+      iid_rms      = sqrt(iid_var_sum   / count)    # spread iid noise allows
+      excess       = observed_rms / iid_rms
+
+  `excess ~= 1` in every bucket means iid, and the offset shrinks like
+  1/sqrt(T). `excess` rising with bucket length means systematic, and it does
+  not.
+
+  `iid_var_sum` is built from the *within-sequence* scatter of the per-token
+  log ratio about that sequence's own mean, which is the correct null model: it
+  is what the per-sequence spread would be if those same tokens were
+  independent. Using it rather than a batch-wide noise estimate keeps the
+  comparison valid even when per-token scatter itself varies with length.
+
+  Args:
+    log_is: Per-token trainer-minus-sampler log ratio, `[B, T]`.
+    seq_log_mean: Its per-sequence masked mean, `[B]`.
+    completion_mask: Per-token mask over scored tokens, `[B, T]`.
+    seq_valid: 1.0 for rows holding a scored sequence, `[B]`.
+    bucket_edges: Inclusive upper bounds on completion length, in tokens.
+    overlong: 1.0 for truncated sequences `[B]`. When None every sequence is
+      reported as `complete` and the `truncated` series is empty, which is how
+      a missing verdict announces itself.
+
+  Returns:
+    Metric name (`<bucket>/<status>/<metric>`) to scalar sum.
+  """
+  seq_len = completion_mask.sum(axis=-1)
+  seq_len_safe = jnp.maximum(seq_len, 1.0)
+  centered = (log_is - seq_log_mean[:, None]) * completion_mask
+  within_var = (centered**2).sum(axis=-1) / seq_len_safe
+
+  truncated = (
+      jnp.zeros_like(seq_valid)
+      if overlong is None
+      else jnp.astype(overlong, jnp.float32)
+  )
+  by_status = {"complete": 1.0 - truncated, "truncated": truncated}
+
+  sums = {}
+  lowers = (0,) + tuple(bucket_edges)
+  uppers = tuple(bucket_edges) + (None,)
+  for name, lower, upper in zip(
+      sampler_is_length_bucket_names(bucket_edges), lowers, uppers
+  ):
+    in_bucket = seq_len > lower
+    if upper is not None:
+      in_bucket = in_bucket & (seq_len <= upper)
+    in_bucket = in_bucket.astype(jnp.float32) * seq_valid
+    for status, status_mask in by_status.items():
+      m = in_bucket * status_mask
+      prefix = f"{name}/{status}"
+      sums[f"{prefix}/count"] = m.sum()
+      sums[f"{prefix}/len_sum"] = (m * seq_len).sum()
+      sums[f"{prefix}/logmean_sum"] = (m * seq_log_mean).sum()
+      sums[f"{prefix}/logmean_sq_sum"] = (m * seq_log_mean**2).sum()
+      sums[f"{prefix}/iid_var_sum"] = (m * within_var / seq_len_safe).sum()
+  return sums
 
 
 # ==============================================================================
@@ -410,6 +781,57 @@ def grpo_loss_fn(
   segment_ids = getattr(train_example, "segment_ids", None)
   num_segments = getattr(train_example, "num_segments", None)
 
+  # Sampler-vs-trainer options, resolved up front so an unsupported
+  # combination fails before any compute. All three act per sequence and are
+  # applied once `per_token_logps` exists.
+  mask_overlong = getattr(algo_config, "overlong_loss_masking", False)
+  mult_prob_error_threshold = getattr(
+      algo_config, "seq_logprob_error_threshold", None
+  )
+  tis_type = getattr(algo_config, "truncated_importance_sampling_type", None)
+  tis_band_min = getattr(
+      algo_config, "truncated_importance_sampling_ratio_min", None
+  )
+  tis_band_max = getattr(
+      algo_config, "truncated_importance_sampling_ratio", None
+  )
+  if tis_type is not None:
+    if tis_type != "seq-mask-tis":
+      raise ValueError(
+          "truncated_importance_sampling_type only supports 'seq-mask-tis'."
+          f" Received: {tis_type!r}"
+      )
+    if tis_band_min is None or tis_band_max is None:
+      raise ValueError(
+          "truncated_importance_sampling_type is set but its keep-band is"
+          " not. Set truncated_importance_sampling_ratio_min and"
+          " truncated_importance_sampling_ratio."
+      )
+  # `pack_sequences` carries only the fields it knows about, so under packing
+  # the rollout log-probs and truncation verdict never reach the loss. Refuse
+  # rather than let a correctness feature silently disable itself.
+  if segment_ids is not None and (
+      mask_overlong or mult_prob_error_threshold is not None or tis_type
+  ):
+    raise ValueError(
+        "overlong_loss_masking, seq_logprob_error_threshold and"
+        " truncated_importance_sampling_type are not supported with sequence"
+        " packing: they act per sequence, and the inputs they need are not"
+        " carried through packing. Disable packing or these options."
+    )
+  # Both compare the sampler against the trainer, so both need the rollout
+  # engine's log-probabilities. Refuse rather than let a correctness feature
+  # quietly do nothing because the engine returned none.
+  if (
+      mult_prob_error_threshold is not None or tis_type is not None
+  ) and getattr(train_example, "rollout_per_token_logps", None) is None:
+    raise ValueError(
+        "seq_logprob_error_threshold and"
+        " truncated_importance_sampling_type require the rollout engine's"
+        " per-token log-probabilities, which this batch does not carry."
+        " Enable them on the rollout config, or unset these options."
+    )
+
   # TODO(tsbao): split can be avoided with updated peft_trainer model handling.
   graphdef, state = nnx.split(model)
   per_token_logps, token_entropy = common.compute_per_token_logps(
@@ -428,6 +850,35 @@ def grpo_loss_fn(
       routed_experts=getattr(train_example, "routed_experts", None),
   )
   per_token_logps = jnp.astype(per_token_logps, jnp.float32)
+
+  # Per-token trainer-minus-sampler log ratio, computed once and shared by the
+  # gate, the correction and the diagnostics, so none of them can disagree
+  # about what the disagreement is. `log_is_raw` keeps the infinities, because
+  # the importance weights need exp() to collapse them to 0 and discard the
+  # token; `log_is` is the sanitised version used everywhere an infinity would
+  # otherwise poison a whole sequence's average.
+  rollout_logps = getattr(train_example, "rollout_per_token_logps", None)
+  log_is_raw = None
+  log_is = None
+  if rollout_logps is not None:
+    log_is_raw = jax.lax.stop_gradient(per_token_logps) - jnp.astype(
+        rollout_logps, jnp.float32
+    )
+    log_is = jnp.nan_to_num(log_is_raw, nan=0.0, posinf=0.0, neginf=0.0)
+
+  # `loss_mask` is `completion_mask` with dropped sequences removed and is what
+  # the loss and its denominator aggregate over. `completion_mask` remains the
+  # full scored-token set and is what the diagnostics measure, so a drop cannot
+  # quietly change what they report. With no source enabled the two are
+  # identical and every aggregation below is unchanged.
+  sample_mask, loss_mask, seq_mult_prob_error = sequence_loss_mask(
+      completion_mask,
+      overlong=getattr(train_example, "overlong", None),
+      mask_overlong=mask_overlong,
+      log_is=log_is,
+      mult_prob_error_threshold=mult_prob_error_threshold,
+  )
+
   # TODO(tsbao): We should handle token level advantages.
   advantages = jnp.astype(train_example.advantages, jnp.float32)
 
@@ -440,8 +891,8 @@ def grpo_loss_fn(
 
   seq_importance_ratio = per_token_logps - old_per_token_logps
   # Record KL divergence before clipping.
-  token_denom = jnp.sum(completion_mask)
-  unreduced_ppo_kl = jnp.sum(-seq_importance_ratio * completion_mask)
+  token_denom = jnp.sum(loss_mask)
+  unreduced_ppo_kl = jnp.sum(-seq_importance_ratio * loss_mask)
 
   seq_importance_ratio = jnp.clip(seq_importance_ratio, max=20.0, min=-20.0)
 
@@ -490,7 +941,7 @@ def grpo_loss_fn(
   per_token_loss = jnp.maximum(pg_loss_1, pg_loss_2).astype(jnp.float32)
 
   unreduced_clip_frac = jnp.sum(
-      jnp.greater(pg_loss_2, pg_loss_1).astype(jnp.float32) * completion_mask
+      jnp.greater(pg_loss_2, pg_loss_1).astype(jnp.float32) * loss_mask
   )
 
   # dual-clip ppo loss
@@ -507,7 +958,7 @@ def grpo_loss_fn(
   ).astype(jnp.float32)
   pg_clipfrac_lower = common.aggregate_loss(
       per_token_pg_clipfrac_lower,
-      completion_mask,
+      loss_mask,
       loss_aggregation_mode,
       segment_ids=segment_ids,
       num_segments=num_segments,
@@ -521,7 +972,28 @@ def grpo_loss_fn(
   # upstream (already detached and threshold-clipped) and applied per token
   # BEFORE loss aggregation so they affect the gradient through the loss
   # magnitude only, not as a stop-gradient bias on the ratio.
+  # Per-sequence agreement, shared by the correction and the diagnostics.
+  seq_geomean = None
+  seq_valid = None
+  if log_is is not None:
+    seq_geomean, seq_valid = sequence_geomean_ratio(
+        log_is, completion_mask, segment_ids, num_segments
+    )
+
   sampler_is_weights = getattr(train_example, "sampler_is_weights", None)
+  # Truncated importance sampling, computed here rather than upstream: the
+  # trainer log-probabilities it needs are this forward pass, so it costs no
+  # extra pass and there is no cross-pass batching difference to explain away.
+  tis_oob_ratio = None
+  if tis_type is not None and log_is_raw is not None:
+    sampler_is_weights, tis_oob_ratio = truncated_importance_weights(
+        log_is_raw,
+        seq_geomean,
+        seq_valid,
+        sample_mask,
+        band_min=tis_band_min,
+        band_max=tis_band_max,
+    )
   if sampler_is_weights is not None:
     per_token_loss = per_token_loss * sampler_is_weights.astype(jnp.float32)
 
@@ -530,36 +1002,36 @@ def grpo_loss_fn(
   #   reduced   (eager per-sequence mean, pre-CL form) — metric only
   unreduced_pg_loss = common.aggregate_loss(
       per_token_loss,
-      completion_mask,
+      loss_mask,
       loss_aggregation_mode,
       segment_ids=segment_ids,
       num_segments=num_segments,
   )
   reduced_pg_loss = common.reduced_loss_agg(
       per_token_loss,
-      completion_mask,
+      loss_mask,
       loss_aggregation_mode,
       segment_ids=segment_ids,
       num_segments=num_segments,
   )
   total_loss = unreduced_pg_loss  # KL added below when beta != 0; feeds gradient
   # Per-token diagnostics — log only over assistant tokens (completion_mask).
-  is_ratio_mean = masked_mean(is_ratio, completion_mask)
-  is_ratio_max = jnp.max(jnp.where(completion_mask > 0, is_ratio, 0.0))
+  is_ratio_mean = masked_mean(is_ratio, loss_mask)
+  is_ratio_max = jnp.max(jnp.where(loss_mask > 0, is_ratio, 0.0))
   is_ratio_min = jnp.min(
-      jnp.where(completion_mask > 0, is_ratio, jnp.inf)
+      jnp.where(loss_mask > 0, is_ratio, jnp.inf)
   )
   log_ratio_abs_mean = masked_mean(
-      jnp.abs(seq_importance_ratio), completion_mask
+      jnp.abs(seq_importance_ratio), loss_mask
   )
-  pg_loss_1_mean = masked_mean(pg_loss_1, completion_mask)
-  pg_loss_2_mean = masked_mean(pg_loss_2, completion_mask)
+  pg_loss_1_mean = masked_mean(pg_loss_1, loss_mask)
+  pg_loss_2_mean = masked_mean(pg_loss_2, loss_mask)
   adv_broadcast = jnp.broadcast_to(adv, completion_mask.shape)
-  adv_abs_mean = masked_mean(jnp.abs(adv_broadcast), completion_mask)
-  adv_max = jnp.max(jnp.where(completion_mask > 0, adv_broadcast, -jnp.inf))
-  adv_min = jnp.min(jnp.where(completion_mask > 0, adv_broadcast, jnp.inf))
+  adv_abs_mean = masked_mean(jnp.abs(adv_broadcast), loss_mask)
+  adv_max = jnp.max(jnp.where(loss_mask > 0, adv_broadcast, -jnp.inf))
+  adv_min = jnp.min(jnp.where(loss_mask > 0, adv_broadcast, jnp.inf))
   nonzero_adv_frac = masked_mean(
-      (jnp.abs(adv_broadcast) > 1e-8).astype(jnp.float32), completion_mask
+      (jnp.abs(adv_broadcast) > 1e-8).astype(jnp.float32), loss_mask
   )
   aux = {
       "kl": sft_utils.WeightedMetric(jnp.array(0.0), jnp.array(1.0)),
@@ -585,7 +1057,98 @@ def grpo_loss_fn(
       "advantage/max": adv_max,
       "advantage/min": adv_min,
       "advantage/nonzero_frac": nonzero_adv_frac,
+      # Fraction of sequences still contributing. 1.0 when no sequence-level
+      # masking source is enabled. Unlike an importance-sampling keep-rate, a
+      # drop here also leaves the denominator, so this reports lost effective
+      # batch size rather than lost gradient magnitude.
+      "sample_mask/kept_frac": jnp.mean(sample_mask),
   }
+  if seq_mult_prob_error is not None:
+    # Over every sequence the gate saw, kept or dropped, so the distribution is
+    # visible before anyone tightens the threshold.
+    aux["sample_mask/mult_prob_error_mean"] = masked_mean(
+        seq_mult_prob_error, (seq_mult_prob_error > 0).astype(jnp.float32)
+    )
+    aux["sample_mask/mult_prob_error_max"] = jnp.max(seq_mult_prob_error)
+  if tis_oob_ratio is not None:
+    # Normalised over sequences that are actually training. The reported
+    # `sampler_is/would_drop_*` below normalise over every sequence instead,
+    # which is why the two diverge once sequence-level masking is active.
+    aux["tis/is_oob_ratio"] = tis_oob_ratio
+
+  # ---- Sampler-vs-trainer diagnostics (reported only) ---------------------
+  # How far the behaviour policy that produced the tokens has drifted from the
+  # target policy being updated. Nothing here affects the loss.
+  #
+  # Emitted unconditionally, with neutral values when the rollout engine
+  # returned no log-probabilities, because whether it does is a runtime
+  # property the learner cannot know when it registers metric aggregators --
+  # and a registered metric that is missing from `aux` raises.
+  report_bands = tuple(getattr(algo_config, "sampler_is_report_bands", ()) or ())
+  bucket_edges = getattr(algo_config, "sampler_is_length_buckets", None)
+  if log_is is None:
+    aux["sampler_is/token_logdiff_absmean"] = jnp.float32(0.0)
+    aux["sampler_is/token_weight_mean"] = jnp.float32(1.0)
+    aux["sampler_is/token_weight_max"] = jnp.float32(1.0)
+    aux["sampler_is/seq_geomean_mean"] = jnp.float32(1.0)
+    aux["sampler_is/seq_geomean_min"] = jnp.float32(1.0)
+    aux["sampler_is/seq_geomean_max"] = jnp.float32(1.0)
+    for low, high in report_bands:
+      aux[f"sampler_is/would_drop_{band_label(low, high)}"] = jnp.float32(0.0)
+    for suffix in sampler_is_length_bucket_metric_names(bucket_edges):
+      aux[f"sampler_is/lenscale/{suffix}"] = jnp.float32(0.0)
+  else:
+    is_w = jnp.nan_to_num(jnp.exp(log_is), nan=0.0, posinf=0.0, neginf=0.0)
+    n_seq = jnp.maximum(seq_valid.sum(), 1.0)
+    has_seq = seq_valid.sum() > 0
+    aux["sampler_is/token_logdiff_absmean"] = masked_mean(
+        jnp.abs(log_is), completion_mask
+    )
+    aux["sampler_is/token_weight_mean"] = masked_mean(is_w, completion_mask)
+    aux["sampler_is/token_weight_max"] = jnp.max(
+        jnp.where(completion_mask > 0, is_w, 0.0)
+    )
+    aux["sampler_is/seq_geomean_mean"] = (seq_geomean * seq_valid).sum() / n_seq
+    aux["sampler_is/seq_geomean_min"] = jnp.where(
+        has_seq, jnp.min(jnp.where(seq_valid > 0, seq_geomean, jnp.inf)), 1.0
+    )
+    aux["sampler_is/seq_geomean_max"] = jnp.where(
+        has_seq, jnp.max(jnp.where(seq_valid > 0, seq_geomean, -jnp.inf)), 1.0
+    )
+
+    # Would-be drop rate at each reported band, so a band can be chosen from
+    # data before it is switched on. No band is assumed: these come from
+    # config, and the list is empty by default.
+    for low, high in report_bands:
+      kept = (
+          jnp.astype((seq_geomean >= low) & (seq_geomean <= high), jnp.float32)
+          * seq_valid
+      )
+      aux[f"sampler_is/would_drop_{band_label(low, high)}"] = (
+          1.0 - kept.sum() / n_seq
+      )
+
+    # Does the per-sequence offset shrink as sequences get longer (iid noise,
+    # which scales away) or not (systematic bias, which never will)? See
+    # `sampler_is_length_bucket_sums`. Per-sequence, so packing has no scatter
+    # path yet.
+    if bucket_edges and segment_ids is not None:
+      # Diagnostic only, so degrade to zeros rather than refuse the step. The
+      # buckets are per-sequence and packing has no scatter path yet; emitting
+      # the keys keeps them in step with what the learner registered.
+      for suffix in sampler_is_length_bucket_metric_names(bucket_edges):
+        aux[f"sampler_is/lenscale/{suffix}"] = jnp.float32(0.0)
+    elif bucket_edges:
+      seq_log_mean = jnp.log(seq_geomean)
+      for key, value in sampler_is_length_bucket_sums(
+          log_is,
+          seq_log_mean,
+          completion_mask,
+          seq_valid,
+          bucket_edges,
+          overlong=getattr(train_example, "overlong", None),
+      ).items():
+        aux[f"sampler_is/lenscale/{key}"] = value
   if sampler_is_weights is not None:
     sis = sampler_is_weights.astype(jnp.float32)
     aux["sampler_is/weight_mean"] = masked_mean(sis, completion_mask)
@@ -655,6 +1218,64 @@ def compute_advantages(rewards: np.ndarray, num_generations: int) -> np.ndarray:
   mean_grouped_rewards = mean_grouped_rewards.repeat(num_generations)
   std_grouped_rewards = std_grouped_rewards.repeat(num_generations)
   return (rewards - mean_grouped_rewards) / (std_grouped_rewards + 1e-6)
+
+
+@function_registry.register_advantage_estimator("grpo-loo")
+def compute_grpo_loo_advantages(
+    rewards: jax.Array, num_generations: int
+) -> jax.Array:
+  """Group-relative advantages with a leave-one-out baseline and scale.
+
+  Differs from `compute_advantages` in excluding each sample from the
+  statistics used to judge it: both the baseline and the standard deviation
+  come from the *other* generations for the same prompt. Including a sample in
+  its own baseline shrinks its advantage by exactly `1 - 1/G` -- a systematic
+  under-scaling of every gradient, ~6.7% at G=16, and entirely avoidable.
+
+  Differs from `compute_rloo_advantages` in dividing by the leave-one-out
+  standard deviation, so advantages are comparable across prompts of differing
+  difficulty rather than letting high-variance prompts dominate the update.
+
+  Sequences are grouped positionally: `rewards` must be laid out with each
+  prompt's generations contiguous, `[p0g0, p0g1, ..., p1g0, ...]`, which is
+  what the rollout engines produce. Interleaved input would silently merge
+  prompts into one group and destroy the normalisation rather than fail.
+
+  Args:
+    rewards: Per-sequence rewards, `[num_prompts * num_generations]`.
+    num_generations: Generations per prompt.
+
+  Returns:
+    Advantages with the same shape as `rewards`.
+  """
+  if num_generations < 2:
+    # No other sample to form a baseline from.
+    return jnp.zeros_like(rewards)
+
+  grouped = rewards.reshape(-1, num_generations)
+  n_others = num_generations - 1
+  loo_mean = (grouped.sum(axis=-1, keepdims=True) - grouped) / n_others
+  advantages = grouped - loo_mean
+
+  # The leave-one-out set holds `n_others` samples, so an unbiased variance
+  # needs at least two of them. At num_generations == 2 the variance is
+  # undefined and no scaling is applied.
+  if n_others >= 2:
+    loo_mean_sq = (
+        jnp.square(grouped).sum(axis=-1, keepdims=True) - jnp.square(grouped)
+    ) / n_others
+    loo_var = (loo_mean_sq - jnp.square(loo_mean)) * (
+        n_others / (n_others - 1)
+    )
+    loo_std = jnp.sqrt(jnp.clip(loo_var, min=0.0))
+    # Leave groups with no spread alone rather than sharpening them: dividing a
+    # near-zero numerator by a near-zero scale manufactures large advantages
+    # out of rounding.
+    advantages = jnp.where(
+        loo_std > 0, advantages / (loo_std + 1e-6), advantages
+    )
+
+  return advantages.flatten()
 
 
 @function_registry.register_advantage_estimator("rloo")

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -330,6 +330,43 @@ def sequence_loss_mask(
   )
 
 
+def token_outlier_stats(
+    log_is: jax.Array,
+    completion_mask: jax.Array,
+    n_seq: jax.Array | float,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+  """Extreme-value statistics of the sampler-trainer per-token disagreement.
+
+  `token_logdiff_absmean` is a mean, and a mean cannot tell "every token
+  disagrees slightly" apart from "a few tokens disagree categorically". Those
+  have different causes -- the first is numerics, the second is an alignment or
+  tokenisation defect -- and different fixes, so the diagnostic has to separate
+  them. A handful of tokens off by tens of nats can dominate a sequence's
+  geometric mean while leaving the per-token mean looking unremarkable.
+
+  Args:
+    log_is: Per-token trainer-minus-sampler log ratio, `[B, T]`.
+    completion_mask: Per-token mask over scored tokens, `[B, T]`.
+    n_seq: Sequence count to divide the per-sequence count by; already floored
+      away from zero by the caller.
+
+  Returns:
+    `(absmax, outlier_frac, outliers_per_seq)` -- the largest single
+    disagreement in nats, the share of scored tokens beyond
+    `TOKEN_LOGDIFF_OUTLIER_NATS`, and the mean number of such tokens per
+    sequence. The last is the useful one when a defect fires once per
+    conversation turn, since the count is then meaningful on its own.
+  """
+  abs_log_is = jnp.abs(log_is)
+  scored = completion_mask > 0
+  absmax = jnp.where(
+      scored.any(), jnp.max(jnp.where(scored, abs_log_is, 0.0)), 0.0
+  )
+  outliers = (abs_log_is > TOKEN_LOGDIFF_OUTLIER_NATS) * completion_mask
+  outlier_frac = outliers.sum() / jnp.maximum(completion_mask.sum(), 1.0)
+  return absmax, outlier_frac, outliers.sum() / n_seq
+
+
 def truncated_importance_weights(
     log_is_raw: jax.Array,
     seq_geomean: jax.Array,
@@ -387,6 +424,13 @@ def truncated_importance_weights(
   oob_ratio = 1.0 - (keep * counted).sum() / jnp.maximum(counted.sum(), 1.0)
   return weights * keep[:, None], oob_ratio
 
+
+# |log pi_trainer - log pi_sampler| above which a token counts as an outlier for
+# the reported diagnostic. Well clear of any plausible numerical disagreement --
+# a well-matched stack sits three orders of magnitude below it -- so a non-zero
+# count means a token the two engines disagree about categorically, not
+# imprecisely. Reporting only; nothing keys off this value.
+TOKEN_LOGDIFF_OUTLIER_NATS = 10.0
 
 # Metric suffixes emitted per (length bucket, completion status). Raw sums, so
 # that pooling across micro-batches, shards and steps is exact -- and so that
@@ -1112,8 +1156,12 @@ def grpo_loss_fn(
   bucket_edges = getattr(algo_config, "sampler_is_length_buckets", None)
   if log_is is None:
     aux["sampler_is/token_logdiff_absmean"] = jnp.float32(0.0)
+    aux["sampler_is/token_logdiff_absmax"] = jnp.float32(0.0)
+    aux["sampler_is/token_outlier_frac"] = jnp.float32(0.0)
+    aux["sampler_is/token_outliers_per_seq"] = jnp.float32(0.0)
     aux["sampler_is/token_weight_mean"] = jnp.float32(1.0)
     aux["sampler_is/token_weight_max"] = jnp.float32(1.0)
+    aux["sampler_is/token_weight_min"] = jnp.float32(1.0)
     aux["sampler_is/seq_geomean_mean"] = jnp.float32(1.0)
     aux["sampler_is/seq_geomean_min"] = jnp.float32(1.0)
     aux["sampler_is/seq_geomean_max"] = jnp.float32(1.0)
@@ -1125,6 +1173,7 @@ def grpo_loss_fn(
     is_w = jnp.nan_to_num(jnp.exp(log_is), nan=0.0, posinf=0.0, neginf=0.0)
     n_seq = jnp.maximum(seq_valid.sum(), 1.0)
     has_seq = seq_valid.sum() > 0
+    has_tok = completion_mask.sum() > 0
     aux["sampler_is/token_logdiff_absmean"] = masked_mean(
         jnp.abs(log_is), completion_mask
     )
@@ -1132,6 +1181,19 @@ def grpo_loss_fn(
     aux["sampler_is/token_weight_max"] = jnp.max(
         jnp.where(completion_mask > 0, is_w, 0.0)
     )
+    # Minimum weight, i.e. the single worst token the trainer thought the
+    # sampler should never have emitted. `token_weight_max` alone cannot see
+    # these: a catastrophic disagreement in that direction is a weight near
+    # zero, not a large one.
+    aux["sampler_is/token_weight_min"] = jnp.where(
+        has_tok, jnp.min(jnp.where(completion_mask > 0, is_w, jnp.inf)), 1.0
+    )
+    absmax, outlier_frac, outliers_per_seq = token_outlier_stats(
+        log_is, completion_mask, n_seq
+    )
+    aux["sampler_is/token_logdiff_absmax"] = absmax
+    aux["sampler_is/token_outlier_frac"] = outlier_frac
+    aux["sampler_is/token_outliers_per_seq"] = outliers_per_seq
     aux["sampler_is/seq_geomean_mean"] = (seq_geomean * seq_valid).sum() / n_seq
     aux["sampler_is/seq_geomean_min"] = jnp.where(
         has_seq, jnp.min(jnp.where(seq_valid > 0, seq_geomean, jnp.inf)), 1.0

--- a/tunix/rl/algo_core.py
+++ b/tunix/rl/algo_core.py
@@ -1028,8 +1028,19 @@ def grpo_loss_fn(
   pg_loss_2_mean = masked_mean(pg_loss_2, loss_mask)
   adv_broadcast = jnp.broadcast_to(adv, completion_mask.shape)
   adv_abs_mean = masked_mean(jnp.abs(adv_broadcast), loss_mask)
-  adv_max = jnp.max(jnp.where(loss_mask > 0, adv_broadcast, -jnp.inf))
-  adv_min = jnp.min(jnp.where(loss_mask > 0, adv_broadcast, jnp.inf))
+  # +/-inf as the neutral element makes the reduction correct while anything
+  # survives, and poisonous when nothing does: the aggregate across
+  # micro-batches is a plain max/min, so one fully-masked micro-batch turns the
+  # whole step into -inf. Fall back to 0.0 there. A micro-batch can lose every
+  # row whenever train_micro_batch_size == num_generations, since one
+  # micro-batch is then exactly one prompt group.
+  any_loss_row = jnp.any(loss_mask > 0)
+  adv_max = jnp.where(
+      any_loss_row, jnp.max(jnp.where(loss_mask > 0, adv_broadcast, -jnp.inf)), 0.0
+  )
+  adv_min = jnp.where(
+      any_loss_row, jnp.min(jnp.where(loss_mask > 0, adv_broadcast, jnp.inf)), 0.0
+  )
   nonzero_adv_frac = masked_mean(
       (jnp.abs(adv_broadcast) > 1e-8).astype(jnp.float32), loss_mask
   )
@@ -1037,8 +1048,10 @@ def grpo_loss_fn(
       "kl": sft_utils.WeightedMetric(jnp.array(0.0), jnp.array(1.0)),
       "kl_loss": sft_utils.WeightedMetric(jnp.array(0.0), jnp.array(1.0)),
       "reduced_pg_loss": reduced_pg_loss,
-      # TODO(yuxzhang): equal to reduced_pg_loss today; diverges once sequence
-      # packing lands (reduced -> segment-aware metric; unreduced -> global).
+      # Aggregates differently from reduced_pg_loss across micro-batches
+      # (mean_of_means vs global_weighted_mean). The two coincide only when
+      # every micro-batch carries the same denominator, so they agree with no
+      # sequence-level masking and diverge once any of it is on.
       "unreduced_pg_loss": unreduced_pg_loss,
       "pg_clipfrac": sft_utils.WeightedMetric(
           unreduced_clip_frac, token_denom, min_denom=1.0
@@ -1066,8 +1079,19 @@ def grpo_loss_fn(
   if seq_mult_prob_error is not None:
     # Over every sequence the gate saw, kept or dropped, so the distribution is
     # visible before anyone tightens the threshold.
-    aux["sample_mask/mult_prob_error_mean"] = masked_mean(
-        seq_mult_prob_error, (seq_mult_prob_error > 0).astype(jnp.float32)
+    #
+    # Weighted rather than pre-averaged: `sequence_mult_prob_error` scores a
+    # fully-masked row 0.0, and the metric is >= 1 by construction on any real
+    # row, so a micro-batch with nothing left must contribute no weight rather
+    # than a 0.0 that drags the cross-micro-batch mean below its own floor.
+    # That happens routinely whenever train_micro_batch_size == num_generations,
+    # where one micro-batch is one prompt group and the whole group can be
+    # dropped at once.
+    scored = (seq_mult_prob_error > 0).astype(seq_mult_prob_error.dtype)
+    aux["sample_mask/mult_prob_error_mean"] = sft_utils.WeightedMetric(
+        jnp.sum(seq_mult_prob_error * scored),
+        jnp.sum(scored),
+        min_denom=1.0,
     )
     aux["sample_mask/mult_prob_error_max"] = jnp.max(seq_mult_prob_error)
   if tis_oob_ratio is not None:

--- a/tunix/rl/algorithm_config.py
+++ b/tunix/rl/algorithm_config.py
@@ -38,6 +38,110 @@ class AlgorithmConfig:
   # for the rest of the step.
   kl_clamp_value: float | None = None
 
+  # --- Sampler-vs-trainer divergence -----------------------------------------
+  # The rollout engine and the trainer run the same weights through different
+  # kernels, so their log-probabilities differ slightly. Everything below is
+  # off by default and reproduces prior behaviour exactly when unset. All of it
+  # requires the rollout engine to return log-probabilities, and none of it is
+  # supported under sequence packing.
+  #
+  # Drop rollout-truncated sequences from the update. They are a prefix of a
+  # trajectory rather than a trajectory, so the reward attached to them is not
+  # the reward for the behaviour that produced them. Removes them from the loss
+  # AND its denominator, so survivors keep their full gradient magnitude and
+  # only the effective batch size shrinks.
+  overlong_loss_masking: bool = False
+  # Drop sequences whose multiplicative probability error --
+  # `mean_t exp(|log trainer_t - log sampler_t|)` -- exceeds this. 1.0 is
+  # perfect agreement; 2.0 means the typical token's probability differs by a
+  # factor of two, which indicates a fault rather than ordinary drift. Read
+  # `sample_mask/mult_prob_error_{mean,max}` before choosing a value.
+  seq_logprob_error_threshold: float | None = None
+  # Apply a truncated importance-sampling correction rather than only reporting
+  # the divergence. "seq-mask-tis" weights each token by its raw
+  # sampler-to-trainer ratio and zeroes the weights of any sequence whose
+  # geometric-mean ratio leaves the band below.
+  #
+  # NOTE dropped sequences stay in the loss denominator, so the loss -- and the
+  # gradient -- scale down with the drop fraction. That is the opposite of
+  # `overlong_loss_masking`. Watch `tis/is_oob_ratio`: a high value there is a
+  # silent learning-rate cut, not merely a smaller batch.
+  truncated_importance_sampling_type: str | None = None
+  truncated_importance_sampling_ratio_min: float | None = None
+  truncated_importance_sampling_ratio: float | None = None
+  # Keep-bands to report a would-be drop rate for, without applying them, as
+  # `sampler_is/would_drop_<lo>_<hi>`. Lets a band be chosen from data before
+  # it is switched on. No band is assumed; empty disables the reporting.
+  sampler_is_report_bands: tuple[tuple[float, float], ...] = ()
+  # Inclusive upper bounds, in completion tokens, of the length buckets used by
+  # the `sampler_is/lenscale/*` diagnostic; one open-ended bucket is appended.
+  # Bucketing the sequences already in a batch by their own length measures how
+  # the per-sequence sampler-vs-trainer offset scales with sequence length,
+  # which distinguishes iid token noise (shrinks as 1/sqrt(T)) from a
+  # systematic within-sequence bias (does not). Choose edges that split the
+  # completion-length distribution into comparably populated bins.
+  sampler_is_length_buckets: tuple[int, ...] | None = None
+
+  def validate_sampler_is_options(self):
+    """Validates the sampler-vs-trainer options above.
+
+    A separate method rather than inline in `__post_init__` because subclasses
+    override `__post_init__` without chaining to it, so inline validation would
+    silently not run for them.
+
+    Raises:
+      ValueError: If an option is set to an unsupported or incomplete value.
+    """
+    lo = self.truncated_importance_sampling_ratio_min
+    hi = self.truncated_importance_sampling_ratio
+    if (lo is None) != (hi is None):
+      raise ValueError(
+          "truncated_importance_sampling_ratio_min and"
+          " truncated_importance_sampling_ratio must be set together (a"
+          f" keep-band needs both ends). Got min={lo}, max={hi}."
+      )
+    if lo is not None and hi is not None and lo > hi:
+      raise ValueError(
+          "truncated_importance_sampling_ratio_min must not exceed"
+          f" truncated_importance_sampling_ratio. Got min={lo}, max={hi}."
+      )
+    if self.truncated_importance_sampling_type is not None:
+      if self.truncated_importance_sampling_type != "seq-mask-tis":
+        raise ValueError(
+            "truncated_importance_sampling_type only supports 'seq-mask-tis'."
+            f" Received: {self.truncated_importance_sampling_type!r}"
+        )
+      if lo is None:
+        raise ValueError(
+            "truncated_importance_sampling_type requires a keep-band. Set"
+            " truncated_importance_sampling_ratio_min and"
+            " truncated_importance_sampling_ratio."
+        )
+    for band in self.sampler_is_report_bands or ():
+      if len(band) != 2 or band[0] > band[1]:
+        raise ValueError(
+            "each entry of sampler_is_report_bands must be an ordered"
+            f" (min, max) pair. Received: {band!r}"
+        )
+    if self.sampler_is_length_buckets is not None:
+      edges = tuple(self.sampler_is_length_buckets)
+      if not edges:
+        raise ValueError(
+            "sampler_is_length_buckets must be non-empty when set; use None"
+            " to disable the length-scaling diagnostic."
+        )
+      if any(e <= 0 for e in edges) or any(
+          b <= a for a, b in zip(edges, edges[1:])
+      ):
+        raise ValueError(
+            "sampler_is_length_buckets must be strictly increasing positive"
+            f" token counts. Received: {edges}"
+        )
+      self.sampler_is_length_buckets = edges
+    if self.sampler_is_report_bands:
+      self.sampler_is_report_bands = tuple(
+          tuple(b) for b in self.sampler_is_report_bands
+      )
 
   def __post_init__(self):
     valid_algo_variants = [
@@ -46,7 +150,11 @@ class AlgorithmConfig:
         "ppo",
         "dapo",
     ]
-    valid_advantage_estimators = ["grpo", "gae"]
+    # "rloo" and "drgrpo" are registered estimators that this list previously
+    # rejected, so they were unreachable on any config that runs this
+    # validation. Widening the list only permits what the registry already
+    # implements.
+    valid_advantage_estimators = ["grpo", "grpo-loo", "rloo", "drgrpo", "gae"]
     valid_policy_loss_fns = ["grpo", "ppo"]
     if self.algo_variant not in valid_algo_variants:
       raise ValueError(
@@ -63,6 +171,7 @@ class AlgorithmConfig:
           f"policy_loss_fn must be one of {valid_policy_loss_fns}."
           f" Received: {self.policy_loss_fn}"
       )
+    self.validate_sampler_is_options()
 
     # Automatically prints configuration upon initialization.
     self.print_config()

--- a/tunix/rl/common.py
+++ b/tunix/rl/common.py
@@ -123,6 +123,19 @@ class TrainExample:
   # to dampen positions where the trainer's recomputed log-probability
   # diverges from the rollout sampler's. ``None`` disables the correction.
   sampler_is_weights: ArrayType | None = None
+  # Per-token log-probabilities the rollout engine reported for the tokens it
+  # generated -- the *behaviour* policy. Distinct from ``old_per_token_logps``,
+  # which is whatever policy the surrogate ratio is taken against: the two
+  # coincide in the common case but diverge when the ratio is taken against a
+  # trainer recompute or pinned to 1.0. Kept separate so a correction can
+  # always reference the policy that actually produced the samples. ``None``
+  # when the rollout engine does not return log-probabilities.
+  rollout_per_token_logps: ArrayType | None = None
+  # `[B]`, 1.0 where the rollout engine exhausted the response budget without
+  # emitting an end-of-sequence token, i.e. the sample is a truncated prefix of
+  # a trajectory rather than a trajectory. ``None`` when the engine reports no
+  # truncation verdict.
+  overlong: ArrayType | None = None
   # `[B, P + C, num_layers, top_k]` MoE experts the rollout routed through,
   # laid out over the same `[prompt | completion]` padding as the token ids.
   # When set, a model that accepts `forced_routed_experts` replays these

--- a/tunix/rl/reward_manager.py
+++ b/tunix/rl/reward_manager.py
@@ -34,8 +34,12 @@ def _calculate_scalar_reward_log_metrics(
     axis: int = 1,
 ) -> Dict[str, Any]:
   """Helper to calculate sum, mean, min, and max log metrics for rewards."""
+  # The second element of each tuple reduces the per-micro-batch values into
+  # the step-level metric. A sum must reduce with np.sum: reducing it with
+  # np.mean reports the *average* micro-batch sum, understating the true total
+  # by the number of micro-batches (e.g. 22.5 instead of 90.0 across four).
   return {
-      f"{prefix}/sum": (np.nansum(rewards, axis=axis), np.mean),
+      f"{prefix}/sum": (np.nansum(rewards, axis=axis), np.sum),
       f"{prefix}/mean": (np.nanmean(rewards, axis=axis), np.mean),
       f"{prefix}/min": (np.min(rewards, axis=axis), np.min),
       f"{prefix}/max": (np.max(rewards, axis=axis), np.max),

--- a/tunix/sft/peft_trainer.py
+++ b/tunix/sft/peft_trainer.py
@@ -171,12 +171,39 @@ def _zero_safe_reciprocal(denom: jax.Array) -> jax.Array:
   return jnp.where(denom == 0, jnp.zeros_like(denom), 1.0 / denom)
 
 
+def _is_masked_node(value: Any) -> bool:
+  """True for the sentinel `optax.multi_transform` leaves in a partitioned state.
+
+  `optax.multi_transform` builds every sub-optimizer over the whole parameter
+  tree and writes `optax.MaskedNode()` wherever a parameter belongs to another
+  branch. Freezing parameters -- e.g. a MoE router via
+  `trainable_parameters_mask` -- therefore puts sentinels in the optimizer
+  state that are neither arrays nor `nnx.Variable`s, so every traversal here
+  has to tolerate them. A `MaskedNode` also flattens to *no* leaves, which is
+  why callers zipping it against a partition-spec tree need it treated as a
+  leaf rather than expanded.
+  """
+  return isinstance(value, optax.MaskedNode)
+
+
 def _opt_state_dtypes(optimizer: nnx.Optimizer) -> Any:
-  """Returns the array dtype of every optimizer-state variable."""
+  """Returns the array dtype of every optimizer-state variable.
+
+  Masked sentinels map to `None`, which `_restore_opt_state_float_dtypes`
+  skips.
+  """
+
+  def _dtype_of(value):
+    array = value.get_value() if hasattr(value, "get_value") else value
+    if _is_masked_node(array):
+      return None
+    return array.dtype
+
   return jax.tree_util.tree_map(
-      lambda value: value.get_value().dtype,
+      _dtype_of,
       nnx.state(optimizer, nnx.optimizer.OptState),
-      is_leaf=lambda value: isinstance(value, nnx.Variable),
+      is_leaf=lambda value: isinstance(value, nnx.Variable)
+      or _is_masked_node(value),
   )
 
 
@@ -186,7 +213,11 @@ def _restore_opt_state_float_dtypes(
   """Restores floating optimizer-state leaves to their pre-update dtypes."""
 
   def _restore(value, dtype):
-    array = value.get_value()
+    if dtype is None:
+      return
+    array = value.get_value() if hasattr(value, "get_value") else value
+    if _is_masked_node(array):
+      return
     if jnp.issubdtype(array.dtype, jnp.floating) and array.dtype != dtype:
       value.set_value(array.astype(dtype))
 
@@ -194,7 +225,8 @@ def _restore_opt_state_float_dtypes(
       _restore,
       nnx.state(optimizer, nnx.optimizer.OptState),
       dtypes,
-      is_leaf=lambda value: isinstance(value, nnx.Variable),
+      is_leaf=lambda value: isinstance(value, nnx.Variable)
+      or _is_masked_node(value),
   )
 
 
@@ -659,8 +691,12 @@ class PeftTrainer:
 
     optimizer_state = nnx.state(self.optimizer, nnx.optimizer.OptState)
     optimizer_pspecs = nnx.get_partition_spec(optimizer_state)
+    # `is_leaf` so a MaskedNode pairs with its partition spec instead of
+    # flattening to nothing: it has no children, so without this the state tree
+    # is missing a leaf exactly where the spec tree still has one and the zip
+    # fails with a structure error. `_shard` returns non-arrays untouched.
     optimizer_sharded_state = jax.tree.map(
-        _shard, optimizer_state, optimizer_pspecs
+        _shard, optimizer_state, optimizer_pspecs, is_leaf=_is_masked_node
     )
     nnx.update(self.optimizer, optimizer_sharded_state)
 


### PR DESCRIPTION
[WIP]

The rollout engine that generates tokens and the trainer that scores them run the same weights through different kernels, so their log-probabilities differ slightly. GRPO reads that disagreement as evidence the policy has changed, when it has not. This adds the means to measure the divergence, to drop sequences where it is too large to train on, and to correct for what remains.

Everything is off by default and reproduces current behaviour exactly when unset. Options live on `AlgorithmConfig`, so both the agentic and non-agentic learners can use them.

Enabling plumbing
  `TrainExample` gains `rollout_per_token_logps` (the behaviour policy's own
  log-probabilities, distinct from `old_per_token_logps`, which is whatever
  the surrogate ratio is taken against) and `overlong` (the rollout engine's
  truncation verdict). Both were previously locals in the learner, so the loss
  could not see them.

Measurement (reported only)
  Per-token and per-sequence agreement, would-be drop rates at
  caller-supplied keep-bands, and a length-scaling diagnostic that separates
  iid token noise -- whose per-sequence spread falls as 1/sqrt(T) -- from a
  systematic within-sequence bias, which does not shrink at any length. The
  latter emits raw sums rather than ratios so pooling across micro-batches,
  shards and steps is exact, and splits each bucket by truncation status
  because truncated sequences all sit at the response-length cap and would
  otherwise masquerade as the long bucket.

Masking: `overlong_loss_masking`, `seq_logprob_error_threshold`
  Drops a sequence from the loss AND its denominator, so survivors keep their
  full gradient magnitude and only the effective batch size shrinks. The
  log-probability gate uses `mean_t exp(|.|)`, taking the absolute value per
  token so disagreements cannot cancel: a sequence off by +d on half its
  tokens and -d on the rest has a geometric-mean ratio of exactly 1 and looks
  perfectly on-policy, while its multiplicative error is exp(d).

Correction: `truncated_importance_sampling_type="seq-mask-tis"`
  Weights each token by its raw importance ratio and zeroes the weights of
  sequences whose geometric-mean ratio leaves the band. Deliberately the
  opposite of masking: dropped sequences stay in the denominator, so the loss
  scales down with the drop fraction. One reduces gradient magnitude, the
  other reduces batch size; both directions are asserted against the real
  aggregators so they cannot be confused later. `nan_to_num` is applied to the
  weight after the exp, not to the log before it, so an infinite disagreement
  becomes a weight of 0 rather than 1.

Advantages: `advantage_estimator="grpo-loo"`
  Leave-one-out baseline and leave-one-out scale. Excluding a sample from its
  own baseline removes a systematic `1 - 1/G` under-scaling of every gradient;
  dividing by the leave-one-out standard deviation makes advantages comparable
  across prompts of differing difficulty, which `rloo` does not do. Also
  widens the estimator allowlist to cover `rloo` and `drgrpo`, which the
  registry already implements but validation rejected.

Failure modes are loud rather than silent: sequence packing and absent rollout log-probabilities both raise for the correctness features, since either would otherwise leave them quietly doing nothing. Diagnostics degrade to neutral values instead, so registered metrics are always emitted.

Resolves #\<issue_number_goes_here\>

> It's a good idea to open an issue first for discussion.

<!--- Describe your changes in detail. -->

**Reference**
<!--- Link to the reference implementation, research paper, and GitHub issue. -->

**Colab Notebook**
<!-- If adding any new API, attach a Colab notebook showing the high-level usage.-->

**Checklist**
<!--- Please make sure all checkboxes are ticked before submitting this PR for review. -->

- [ ] I have added all the necessary unit tests for my change.
- [ ] I have verified that my change does not break existing code and all unit tests pass.
- [ ] I have added all appropriate doc-strings/documentation.
- [ ] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [ ] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [ ] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).

> **Note**: Standard CPU unit tests, package builds, and documentation checks will run automatically on pull requests. Once the PR is approved and ready for submission, maintainers will add the `ready-to-submit` label to trigger full TPU testing.
