### PR TITLE
feat(generate): add jax-inference sampling backend and math evaluation support

### DIFF
--- a/.github/workflows/tpu-tests.yml
+++ b/.github/workflows/tpu-tests.yml
@@ -103,7 +103,8 @@ jobs:
           --ignore=tests/generate/vllm_driver_test.py \
           --ignore=tests/generate/tokenizer_adapter_test.py \
           --ignore=tests/generate/sglang_jax_sampler_test.py \
-          --ignore=tests/generate/sglang_jax_lora_test.py
+          --ignore=tests/generate/sglang_jax_lora_test.py \
+          --ignore=tests/generate/jax_inference_sampler_test.py
 
     - name: Run tunix SFT tests
       run: |

--- a/examples/deepscaler/math_eval_nb.py
+++ b/examples/deepscaler/math_eval_nb.py
@@ -37,6 +37,8 @@ except Exception:
 with cm:
   from tunix.models.qwen2 import model as qwen2_lib
   from tunix.models.qwen2 import params as qwen2_params_lib
+  from tunix.models.qwen3 import model as qwen3_lib
+  from tunix.models.qwen3 import params as qwen3_params_lib
   from tunix.generate import sampler as sampler_lib
   from tunix.utils import math_utils
 # %%
@@ -196,7 +198,7 @@ class Qwen25MathEvaluator:
       mesh_config=None,
       max_prompt_length: int = 1024,  # Increased from 512
       max_generation_steps: int = 1024,  # Increased from 512
-      sampler_type: str = "vanilla",  # vanilla, vllm, or sglang-jax
+      sampler_type: str = "vanilla",  # vanilla, vllm, sglang-jax, or jax_inference
   ):
     self.model_config = model_config
     self.model_version = model_version
@@ -204,7 +206,7 @@ class Qwen25MathEvaluator:
     self.dataset = dataset
     self.max_prompt_length = max_prompt_length
     self.max_generation_steps = max_generation_steps
-    self.sampler_type = sampler_type
+    self.sampler_type = os.environ.get("SAMPLER_TYPE", sampler_type)
 
     if mesh_config is None:
       # Default: 4-way tensor parallelism
@@ -216,15 +218,21 @@ class Qwen25MathEvaluator:
 
     print(f"Initializing {self.model_version} evaluator")
     print(f"Model path: {model_path}")
+    print(f"Sampler type: {self.sampler_type}")
     print(f"Mesh config: {mesh_config}")
     print(f"Available devices: {jax.devices()}")
 
   def model_from_safe_tensors(self):
     print("Loading model from safe tensors...")
     with self.mesh:
-      self.model = qwen2_params_lib.create_model_from_safe_tensors(
-          file_dir=self.model_path, config=self.model_config, mesh=self.mesh
-      )
+      if isinstance(self.model_config, qwen3_lib.ModelConfig):
+        self.model = qwen3_params_lib.create_model_from_safe_tensors(
+            file_dir=self.model_path, config=self.model_config, mesh=self.mesh
+        )
+      else:
+        self.model = qwen2_params_lib.create_model_from_safe_tensors(
+            file_dir=self.model_path, config=self.model_config, mesh=self.mesh
+        )
 
   def model_from_orbax_ckpt(self):
     print(f"Loading model from orbax checkpoint {self.model_path}...")
@@ -267,9 +275,9 @@ class Qwen25MathEvaluator:
 
     print("Loading tokenizer...")
 
-    # Huggingface API doesn't work with gcs, OSS loads from model directly
+    # Use local model_path if available for offline loading
     tokenizer_source = (
-        self.model_version if NOTEBOOK_ENV != "g3" else self.model_path
+        self.model_path if os.path.exists(self.model_path) else self.model_version
     )
     self.tokenizer = AutoTokenizer.from_pretrained(
         tokenizer_source, trust_remote_code=True
@@ -277,8 +285,14 @@ class Qwen25MathEvaluator:
 
     print("Setting up model config...")
 
+    is_moe = bool(getattr(self.model_config, "num_experts", None))
     if has_safetensors(self.model_path):
-      self.model_from_safe_tensors()
+      if is_moe and self.sampler_type in ("jax_inference", "jax-inference"):
+        # For large MoE FP8 models in jax_inference, skip redundant Tunix model loading
+        # to conserve memory; jax_inference loads and shards the checkpoint directly.
+        pass
+      else:
+        self.model_from_safe_tensors()
     else:
       self.model_from_orbax_ckpt()
     print("Model loaded successfully!")
@@ -296,19 +310,19 @@ class Qwen25MathEvaluator:
           tokenizer=self.tokenizer,
           cache_config=cache_config,
       )
-    elif self.sampler_type == "sglang_jax":
-      from tunix.generate import sglang_jax_sampler  # pylint: disable=g-import-not-at-top
+    elif self.sampler_type in ("sglang-jax", "sglang_jax"):
+      from tunix.generate import sglang_sampler  # pylint: disable=g-import-not-at-top
 
       mapping_config = mappings.MappingConfig.build(
           mapping_obj=None,
           model=self.model,
           backend="sglang_jax",
       )
-      self.sampler_sglang = sglang_jax_sampler.SglangJaxSampler(  # pyrefly: ignore[bad-instantiation]
+      self.sampler_sglang = sglang_sampler.SglangSampler(  # pyrefly: ignore[bad-instantiation]
           tokenizer=self.tokenizer,
-          config=sglang_jax_sampler.SglangJaxConfig(
+          config=sglang_sampler.SglangConfig(
               mesh=self.mesh,
-              context_length=self.max_prompt_length
+              max_model_len=self.max_prompt_length
               + self.max_generation_steps
               + 100,
               model_version=self.model_version,
@@ -350,6 +364,33 @@ class Qwen25MathEvaluator:
       # sync weights from self.model to the sampler's internal model
       print("Syncing model weights to VLLM sampler...")
       self.sampler_vllm.update_params(nnx.state(self.model))
+    elif self.sampler_type in ("jax_inference", "jax-inference"):
+      from tunix.generate import jax_inference_sampler  # pylint: disable=g-import-not-at-top
+
+      mapping_config = None
+      if self.model is not None:
+        mapping_config = mappings.MappingConfig.build(
+            mapping_obj=None,
+            model=self.model,
+            backend="jax_inference",
+        )
+      model_target = (
+          self.model_path if os.path.exists(self.model_path) else self.model_version
+      )
+      self.sampler_jax_inference = jax_inference_sampler.JaxInferenceSampler(
+          tokenizer=self.tokenizer,
+          config=jax_inference_sampler.JaxInferenceConfig(
+              mesh=self.mesh,
+              model_name=model_target,
+              quantization=None,
+              enable_expert_parallel=is_moe,
+              init_with_random_weights=False,
+              mapping_config=mapping_config,
+          ),
+      )
+      if self.model is not None:
+        print("Syncing model weights to JAX-Inference sampler...")
+        self.sampler_jax_inference.update_params(nnx.state(self.model))
     else:
       raise ValueError(f"Unsupported sampler type: {self.sampler_type}")
 
@@ -372,15 +413,19 @@ class Qwen25MathEvaluator:
           "data_source": "math",
           }
 
-    with file_open(self.dataset, "rb") as test_f:
-      if self.dataset.endswith("jsonl"):
-        test_df = pd.read_json(test_f, lines=True)
-      elif self.dataset.endswith("json"):
-        test_df = pd.read_json(test_f)
-      else:
-        test_df = pd.read_parquet(test_f)
-
-    test_ds = Dataset.from_pandas(test_df).map(preprocess_fn, with_indices=True)
+    if not self.dataset.startswith("gs://") and not os.path.exists(self.dataset):
+      import datasets as hf_datasets  # pylint: disable=g-import-not-at-top
+      hf_ds = hf_datasets.load_dataset(self.dataset, split=split)
+      test_ds = hf_ds.map(preprocess_fn, with_indices=True)
+    else:
+      with file_open(self.dataset, "rb") as test_f:
+        if self.dataset.endswith("jsonl"):
+          test_df = pd.read_json(test_f, lines=True)
+        elif self.dataset.endswith("json"):
+          test_df = pd.read_json(test_f)
+        else:
+          test_df = pd.read_parquet(test_f)
+      test_ds = Dataset.from_pandas(test_df).map(preprocess_fn, with_indices=True)
 
     print(f"Loaded {len(test_ds)} examples")
     print("Example data:")
@@ -443,12 +488,15 @@ class Qwen25MathEvaluator:
 
     # Generate
     if self.sampler_type == "vanilla":
+      effective_top_p = top_p if temperature > 0.0 else None
+      effective_top_k = top_k if temperature > 0.0 else None
       out_data = self.sampler_vanilla(
           input_strings=prompts,
           max_generation_steps=safe_gen_length,
+          max_prompt_length=self.max_prompt_length,
           temperature=temperature,
-          top_k=top_k,
-          top_p=top_p,
+          top_k=effective_top_k,
+          top_p=effective_top_p,
           echo=False,
           eos_tokens=[stop_token_id],
           seed=jax.random.PRNGKey(seed) if seed is not None else None,  # pyrefly: ignore[bad-argument-type]
@@ -474,6 +522,18 @@ class Qwen25MathEvaluator:
           top_p=top_p,
           top_k=top_k,
           seed=None,
+          echo=False,
+          pad_output=True,
+      )
+    elif self.sampler_type in ("jax_inference", "jax-inference"):
+      out_data = self.sampler_jax_inference(
+          input_strings=prompts,
+          max_generation_steps=safe_gen_length,
+          max_prompt_length=self.max_prompt_length,
+          temperature=temperature,
+          top_p=top_p,
+          top_k=top_k,
+          seed=seed,
           echo=False,
           pad_output=True,
       )
@@ -638,103 +698,174 @@ else:
 MATH_500_DATA_PATH = os.path.join(DATA_PATH_PREFIX, "MATH-500/test.jsonl")
 AIME_2024_DATA_PATH = os.path.join(DATA_PATH_PREFIX, "HuggingFaceH4/aime_2024/train-00000-of-00001.parquet")
 
+def _resolve_model_path(repo_id: str, default_path: str) -> str:
+  if os.path.exists(default_path):
+    return default_path
+  repo_cache = os.path.expanduser(
+      f"~/.cache/huggingface/hub/models--{repo_id.replace('/', '--')}/snapshots"
+  )
+  if os.path.exists(repo_cache):
+    snapshots = os.listdir(repo_cache)
+    if snapshots:
+      return os.path.join(repo_cache, snapshots[0])
+  return default_path
+
 MODEL_MAPPING = {
     "Qwen/Qwen2.5-1.5B-Instruct": (
         qwen2_lib.ModelConfig.qwen2p5_1p5b(),
-        os.path.join(MODEL_PATH_PREFIX, "qwen2_5/torch/1.5b-it"),
+        _resolve_model_path(
+            "Qwen/Qwen2.5-1.5B-Instruct",
+            os.path.join(MODEL_PATH_PREFIX, "qwen2_5/torch/1.5b-it"),
+        ),
     ),
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": (
         qwen2_lib.ModelConfig.deepseek_r1_distill_qwen_1p5b(),
-        os.path.join(MODEL_PATH_PREFIX, "DeepSeek-R1-Distill-Qwen-1.5B"),
+        _resolve_model_path(
+            "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+            os.path.join(MODEL_PATH_PREFIX, "DeepSeek-R1-Distill-Qwen-1.5B"),
+        ),
     ),
     "agentica-org/DeepScaleR-1.5B-Preview": (
         qwen2_lib.ModelConfig.deepseek_r1_distill_qwen_1p5b(),
-        os.path.join(MODEL_PATH_PREFIX, "DeepScaleR-1.5B-Preview"),
+        _resolve_model_path(
+            "agentica-org/DeepScaleR-1.5B-Preview",
+            os.path.join(MODEL_PATH_PREFIX, "DeepScaleR-1.5B-Preview"),
+        ),
+    ),
+    "Qwen/Qwen3-1.7B-base": (
+        qwen3_lib.ModelConfig.qwen3_1p7b_base(),
+        _resolve_model_path(
+            "Qwen/Qwen3-1.7B-base",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3-1.7B-base"),
+        ),
+    ),
+    "Qwen/Qwen3-1.7B": (
+        qwen3_lib.ModelConfig.qwen3_1p7b(),
+        _resolve_model_path(
+            "Qwen/Qwen3-1.7B",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3-1.7B"),
+        ),
+    ),
+    "Qwen/Qwen3-8B": (
+        qwen3_lib.ModelConfig.qwen3_8b(),
+        _resolve_model_path(
+            "Qwen/Qwen3-8B",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3-8B"),
+        ),
+    ),
+    "Qwen/Qwen3.5-8B": (
+        qwen3_lib.ModelConfig.qwen3_8b(),
+        _resolve_model_path(
+            "Qwen/Qwen3-8B",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3-8B"),
+        ),
+    ),
+    "Qwen/Qwen3.5-35B-A3B-FP8": (
+        qwen3_lib.ModelConfig.qwen3p5_35b_a3b(),
+        _resolve_model_path(
+            "Qwen/Qwen3.5-35B-A3B-FP8",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3.5-35B-A3B-FP8"),
+        ),
+    ),
+    "Qwen/Qwen3.5-35B": (
+        qwen3_lib.ModelConfig.qwen3p5_35b_a3b(),
+        _resolve_model_path(
+            "Qwen/Qwen3.5-35B-A3B-FP8",
+            os.path.join(MODEL_PATH_PREFIX, "Qwen3.5-35B-A3B-FP8"),
+        ),
     ),
 }
 
-mesh_config = [[1, 2], ["fsdp", "tp"]]  # 2-way tensor parallelism
-# %%
-# MATH-500
-num_batches_env = os.environ.get("NUM_BATCHES")
-num_batches = int(num_batches_env) if num_batches_env and int(num_batches_env) > 0 else None
+def main():
+  tp_env = os.environ.get("TP_SIZE")
+  model_version = os.environ.get(
+      "MODEL_VERSION", "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
+  )
+  dataset = os.environ.get("DATASET", MATH_500_DATA_PATH)
+  if dataset.startswith("gs://") and not os.path.exists(dataset):
+    dataset = "HuggingFaceH4/MATH-500"
+  model_config, model_path = MODEL_MAPPING[model_version]
 
-# model_version = "Qwen/Qwen2.5-1.5B-Instruct"
-model_version = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-dataset = MATH_500_DATA_PATH
-model_config, model_path = MODEL_MAPPING[model_version]
+  max_tp = getattr(model_config, "num_kv_heads", len(jax.devices()))
+  tp_size = int(tp_env) if tp_env else min(max_tp, len(jax.devices()))
+  mesh_config = [[1, tp_size], ["fsdp", "tp"]]
 
-evaluator = Qwen25MathEvaluator(
-    model_config=model_config,
-    model_version=model_version,
-    model_path=model_path,
-    dataset=dataset,
-    mesh_config=mesh_config,
-    max_prompt_length=1024,  # Increased
-    max_generation_steps=1024,  # Increased
-)
+  # MATH-500
+  num_batches_env = os.environ.get("NUM_BATCHES")
+  num_batches = int(num_batches_env) if num_batches_env and int(num_batches_env) > 0 else None
 
-evaluator.load_model()
+  evaluator = Qwen25MathEvaluator(
+      model_config=model_config,
+      model_version=model_version,
+      model_path=model_path,
+      dataset=dataset,
+      mesh_config=mesh_config,
+      max_prompt_length=1024,
+      max_generation_steps=1024,
+  )
 
-print("\nStarting evaluation...")
-results = evaluator.evaluate(
-    batch_size=8,
-    num_batches=num_batches,
-    temperature=0.6,
-    top_k=50,
-    top_p=0.95,
-    num_passes=1,
-    debug_first_n=5,
-)
+  evaluator.load_model()
 
-# Print results
-print("\n" + "=" * 60)
-print("Evaluation Results")
-print("=" * 60)
-print(f"Model: {model_path}")
-print(f"Dataset: {dataset}")
-print(f"Correct: {results['correct']}/{results['total']}")
-print(f"Accuracy: {results['accuracy']:.2f}%")
-print("=" * 60)
-# %%
-# AIME-2024
-model_version = "agentica-org/DeepScaleR-1.5B-Preview"
-# model_version = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
-dataset = AIME_2024_DATA_PATH
-model_config, model_path = MODEL_MAPPING[model_version]
+  batch_size = int(os.environ.get("BATCH_SIZE", "8"))
+  print("\nStarting evaluation...")
+  results = evaluator.evaluate(
+      batch_size=batch_size,
+      num_batches=num_batches,
+      temperature=0.6,
+      top_k=50,
+      top_p=0.95,
+      num_passes=1,
+      debug_first_n=5,
+  )
+
+  # Print results
+  print("\n" + "=" * 60)
+  print("Evaluation Results")
+  print("=" * 60)
+  print(f"Model: {model_path}")
+  print(f"Dataset: {dataset}")
+  print(f"Correct: {results['correct']}/{results['total']}")
+  print(f"Accuracy: {results['accuracy']:.2f}%")
+  print("=" * 60)
+
+  # AIME-2024
+  if os.environ.get("RUN_AIME", "0") == "1":
+    aime_model_version = "agentica-org/DeepScaleR-1.5B-Preview"
+    aime_dataset = AIME_2024_DATA_PATH
+    aime_config, aime_path = MODEL_MAPPING[aime_model_version]
+
+    evaluator_aime = Qwen25MathEvaluator(
+        model_config=aime_config,
+        model_version=aime_model_version,
+        model_path=aime_path,
+        dataset=aime_dataset,
+        mesh_config=mesh_config,
+        max_prompt_length=2048,
+        max_generation_steps=32768,
+    )
+
+    evaluator_aime.load_model()
+
+    print("\nStarting evaluation...")
+    results_aime = evaluator_aime.evaluate(
+        batch_size=1,
+        num_batches=num_batches,
+        temperature=0.6,
+        top_k=None,
+        top_p=0.95,
+        num_passes=1,
+        debug_first_n=5,
+    )
+
+    print("\n" + "=" * 60)
+    print("Evaluation Results")
+    print("=" * 60)
+    print(f"Model: {aime_path}")
+    print(f"Dataset: {aime_dataset}")
+    print(f"Correct: {results_aime['correct']}/{results_aime['total']}")
+    print(f"Accuracy: {results_aime['accuracy']:.2f}%")
+    print("=" * 60)
 
 
-evaluator = Qwen25MathEvaluator(
-    model_config=model_config,
-    model_version=model_version,
-    model_path=model_path,
-    dataset=dataset,
-    mesh_config=mesh_config,
-    max_prompt_length=2048,  # Increased
-    max_generation_steps=32768,  # Increased
-)
-
-evaluator.load_model()
-
-print("\nStarting evaluation...")
-
-results = evaluator.evaluate(
-    batch_size=1,
-    num_batches=num_batches,
-    temperature=0.6,
-    top_k=None,
-    top_p=0.95,
-    num_passes=1,
-    debug_first_n=5,
-)
-
-# Print results
-print("\n" + "=" * 60)
-print("Evaluation Results")
-print("=" * 60)
-print(f"Model: {model_path}")
-print(f"Dataset: {dataset}")
-print(f"Correct: {results['correct']}/{results['total']}")
-print(f"Accuracy: {results['accuracy']:.2f}%")
-print("=" * 60)
-# %%
+if __name__ == "__main__":
+  main()

--- a/examples/deepscaler/math_eval_nb.py
+++ b/examples/deepscaler/math_eval_nb.py
@@ -198,7 +198,7 @@ class Qwen25MathEvaluator:
       mesh_config=None,
       max_prompt_length: int = 1024,  # Increased from 512
       max_generation_steps: int = 1024,  # Increased from 512
-      sampler_type: str = "vanilla",  # vanilla, vllm, sglang-jax, or jax_inference
+      sampler_type: str = "vanilla",  # vanilla, vllm, sglang_jax, or jax-inference
   ):
     self.model_config = model_config
     self.model_version = model_version
@@ -206,7 +206,7 @@ class Qwen25MathEvaluator:
     self.dataset = dataset
     self.max_prompt_length = max_prompt_length
     self.max_generation_steps = max_generation_steps
-    self.sampler_type = os.environ.get("SAMPLER_TYPE", sampler_type)
+    self.sampler_type = sampler_type
 
     if mesh_config is None:
       # Default: 4-way tensor parallelism
@@ -218,7 +218,6 @@ class Qwen25MathEvaluator:
 
     print(f"Initializing {self.model_version} evaluator")
     print(f"Model path: {model_path}")
-    print(f"Sampler type: {self.sampler_type}")
     print(f"Mesh config: {mesh_config}")
     print(f"Available devices: {jax.devices()}")
 
@@ -304,19 +303,19 @@ class Qwen25MathEvaluator:
           tokenizer=self.tokenizer,
           cache_config=cache_config,
       )
-    elif self.sampler_type in ("sglang-jax", "sglang_jax"):
-      from tunix.generate import sglang_sampler  # pylint: disable=g-import-not-at-top
+    elif self.sampler_type == "sglang_jax":
+      from tunix.generate import sglang_jax_sampler  # pylint: disable=g-import-not-at-top
 
       mapping_config = mappings.MappingConfig.build(
           mapping_obj=None,
           model=self.model,
           backend="sglang_jax",
       )
-      self.sampler_sglang = sglang_sampler.SglangSampler(  # pyrefly: ignore[bad-instantiation]
+      self.sampler_sglang = sglang_jax_sampler.SglangJaxSampler(  # pyrefly: ignore[bad-instantiation]
           tokenizer=self.tokenizer,
-          config=sglang_sampler.SglangConfig(
+          config=sglang_jax_sampler.SglangJaxConfig(
               mesh=self.mesh,
-              max_model_len=self.max_prompt_length
+              context_length=self.max_prompt_length
               + self.max_generation_steps
               + 100,
               model_version=self.model_version,
@@ -327,9 +326,6 @@ class Qwen25MathEvaluator:
               mapping_config=mapping_config,
           ),
       )
-      # sync weights from self.model to the sampler's internal model
-      print("Syncing model weights to SGLang JAX sampler...")
-      self.sampler_sglang.update_params(nnx.state(self.model))
     elif self.sampler_type == "vllm":
       from tunix.generate import vllm_sampler  # pylint: disable=g-import-not-at-top
 
@@ -358,7 +354,7 @@ class Qwen25MathEvaluator:
       # sync weights from self.model to the sampler's internal model
       print("Syncing model weights to VLLM sampler...")
       self.sampler_vllm.update_params(nnx.state(self.model))
-    elif self.sampler_type in ("jax_inference", "jax-inference"):
+    elif self.sampler_type == "jax-inference":
       from tunix.generate import jax_inference_sampler  # pylint: disable=g-import-not-at-top
 
       mapping_config = mappings.MappingConfig.build(
@@ -403,19 +399,15 @@ class Qwen25MathEvaluator:
           "data_source": "math",
           }
 
-    if not self.dataset.startswith("gs://") and not os.path.exists(self.dataset):
-      import datasets as hf_datasets  # pylint: disable=g-import-not-at-top
-      hf_ds = hf_datasets.load_dataset(self.dataset, split=split)
-      test_ds = hf_ds.map(preprocess_fn, with_indices=True)
-    else:
-      with file_open(self.dataset, "rb") as test_f:
-        if self.dataset.endswith("jsonl"):
-          test_df = pd.read_json(test_f, lines=True)
-        elif self.dataset.endswith("json"):
-          test_df = pd.read_json(test_f)
-        else:
-          test_df = pd.read_parquet(test_f)
-      test_ds = Dataset.from_pandas(test_df).map(preprocess_fn, with_indices=True)
+    with file_open(self.dataset, "rb") as test_f:
+      if self.dataset.endswith("jsonl"):
+        test_df = pd.read_json(test_f, lines=True)
+      elif self.dataset.endswith("json"):
+        test_df = pd.read_json(test_f)
+      else:
+        test_df = pd.read_parquet(test_f)
+
+    test_ds = Dataset.from_pandas(test_df).map(preprocess_fn, with_indices=True)
 
     print(f"Loaded {len(test_ds)} examples")
     print("Example data:")
@@ -478,15 +470,12 @@ class Qwen25MathEvaluator:
 
     # Generate
     if self.sampler_type == "vanilla":
-      effective_top_p = top_p if temperature > 0.0 else None
-      effective_top_k = top_k if temperature > 0.0 else None
       out_data = self.sampler_vanilla(
           input_strings=prompts,
           max_generation_steps=safe_gen_length,
-          max_prompt_length=self.max_prompt_length,
           temperature=temperature,
-          top_k=effective_top_k,
-          top_p=effective_top_p,
+          top_k=top_k,
+          top_p=top_p,
           echo=False,
           eos_tokens=[stop_token_id],
           seed=jax.random.PRNGKey(seed) if seed is not None else None,  # pyrefly: ignore[bad-argument-type]
@@ -515,14 +504,14 @@ class Qwen25MathEvaluator:
           echo=False,
           pad_output=True,
       )
-    elif self.sampler_type in ("jax_inference", "jax-inference"):
+    elif self.sampler_type == "jax-inference":
       out_data = self.sampler_jax_inference(
           input_strings=prompts,
           max_generation_steps=safe_gen_length,
           max_prompt_length=self.max_prompt_length,
           temperature=temperature,
-          top_p=top_p,
-          top_k=top_k,
+          top_p=top_p if temperature > 0.0 else None,
+          top_k=top_k if temperature > 0.0 else None,
           seed=seed,
           echo=False,
           pad_output=True,
@@ -754,12 +743,11 @@ MODEL_MAPPING = {
 
 def main():
   tp_env = os.environ.get("TP_SIZE")
+  sampler_type = os.environ.get("SAMPLER_TYPE", "vanilla")
   model_version = os.environ.get(
       "MODEL_VERSION", "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
   )
   dataset = os.environ.get("DATASET", MATH_500_DATA_PATH)
-  if dataset.startswith("gs://") and not os.path.exists(dataset):
-    dataset = "HuggingFaceH4/MATH-500"
   model_config, model_path = MODEL_MAPPING[model_version]
 
   max_tp = getattr(model_config, "num_kv_heads", len(jax.devices()))
@@ -778,6 +766,7 @@ def main():
       mesh_config=mesh_config,
       max_prompt_length=1024,
       max_generation_steps=1024,
+      sampler_type=sampler_type,
   )
 
   evaluator.load_model()
@@ -818,6 +807,7 @@ def main():
         mesh_config=mesh_config,
         max_prompt_length=2048,
         max_generation_steps=32768,
+        sampler_type=sampler_type,
     )
 
     evaluator_aime.load_model()

--- a/examples/deepscaler/math_eval_nb.py
+++ b/examples/deepscaler/math_eval_nb.py
@@ -285,14 +285,8 @@ class Qwen25MathEvaluator:
 
     print("Setting up model config...")
 
-    is_moe = bool(getattr(self.model_config, "num_experts", None))
     if has_safetensors(self.model_path):
-      if is_moe and self.sampler_type in ("jax_inference", "jax-inference"):
-        # For large MoE FP8 models in jax_inference, skip redundant Tunix model loading
-        # to conserve memory; jax_inference loads and shards the checkpoint directly.
-        pass
-      else:
-        self.model_from_safe_tensors()
+      self.model_from_safe_tensors()
     else:
       self.model_from_orbax_ckpt()
     print("Model loaded successfully!")
@@ -367,13 +361,11 @@ class Qwen25MathEvaluator:
     elif self.sampler_type in ("jax_inference", "jax-inference"):
       from tunix.generate import jax_inference_sampler  # pylint: disable=g-import-not-at-top
 
-      mapping_config = None
-      if self.model is not None:
-        mapping_config = mappings.MappingConfig.build(
-            mapping_obj=None,
-            model=self.model,
-            backend="jax_inference",
-        )
+      mapping_config = mappings.MappingConfig.build(
+          mapping_obj=None,
+          model=self.model,
+          backend="jax_inference",
+      )
       model_target = (
           self.model_path if os.path.exists(self.model_path) else self.model_version
       )
@@ -383,14 +375,12 @@ class Qwen25MathEvaluator:
               mesh=self.mesh,
               model_name=model_target,
               quantization=None,
-              enable_expert_parallel=is_moe,
               init_with_random_weights=False,
               mapping_config=mapping_config,
           ),
       )
-      if self.model is not None:
-        print("Syncing model weights to JAX-Inference sampler...")
-        self.sampler_jax_inference.update_params(nnx.state(self.model))
+      print("Syncing model weights to JAX-Inference sampler...")
+      self.sampler_jax_inference.update_params(nnx.state(self.model))
     else:
       raise ValueError(f"Unsupported sampler type: {self.sampler_type}")
 
@@ -758,20 +748,6 @@ MODEL_MAPPING = {
         _resolve_model_path(
             "Qwen/Qwen3-8B",
             os.path.join(MODEL_PATH_PREFIX, "Qwen3-8B"),
-        ),
-    ),
-    "Qwen/Qwen3.5-35B-A3B-FP8": (
-        qwen3_lib.ModelConfig.qwen3p5_35b_a3b(),
-        _resolve_model_path(
-            "Qwen/Qwen3.5-35B-A3B-FP8",
-            os.path.join(MODEL_PATH_PREFIX, "Qwen3.5-35B-A3B-FP8"),
-        ),
-    ),
-    "Qwen/Qwen3.5-35B": (
-        qwen3_lib.ModelConfig.qwen3p5_35b_a3b(),
-        _resolve_model_path(
-            "Qwen/Qwen3.5-35B-A3B-FP8",
-            os.path.join(MODEL_PATH_PREFIX, "Qwen3.5-35B-A3B-FP8"),
         ),
     ),
 }

--- a/examples/deepscaler/validate_samplers.py
+++ b/examples/deepscaler/validate_samplers.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation script comparing Tunix Vanilla Sampler and Jax-Inference Sampler on Math-500."""
+
+import json
+import os
+import sys
+import jax
+
+# Ensure paths
+sys.path.insert(0, "/mnt/disks/persist/atwigg/tunix")
+sys.path.insert(0, "/mnt/disks/persist/atwigg/trellis/experimental/jax-inference")
+
+from examples.deepscaler.math_eval_nb import (
+    MODEL_MAPPING,
+    Qwen25MathEvaluator,
+    _resolve_model_path,
+)
+
+
+def run_comparison(
+    model_version: str = "Qwen/Qwen3-1.7B-base",
+    num_samples: int = 4,
+    batch_size: int = 2,
+):
+  print(f"\n=======================================================")
+  print(f"Comparing Samplers on {model_version} (samples={num_samples})")
+  print(f"=======================================================\n")
+
+  model_config, model_path = MODEL_MAPPING[model_version]
+  max_tp = getattr(model_config, "num_kv_heads", len(jax.devices()))
+  tp_size = min(len(jax.devices()), max_tp)
+  mesh_config = [[1, tp_size], ["fsdp", "tp"]]
+  dataset_name = "HuggingFaceH4/MATH-500"
+
+  num_batches = (num_samples + batch_size - 1) // batch_size
+
+  # 1. Run Vanilla Sampler
+  print("\n>>> [1/2] Running Evaluation with Vanilla Sampler...")
+  evaluator_vanilla = Qwen25MathEvaluator(
+      model_config=model_config,
+      model_version=model_version,
+      model_path=model_path,
+      dataset=dataset_name,
+      mesh_config=mesh_config,
+      max_prompt_length=1024,
+      max_generation_steps=128,
+      sampler_type="vanilla",
+  )
+  evaluator_vanilla.load_model()
+  results_vanilla = evaluator_vanilla.evaluate(
+      batch_size=batch_size,
+      num_batches=num_batches,
+      temperature=0.0,
+      top_k=1,
+      top_p=1.0,
+      num_passes=1,
+      debug_first_n=num_samples,
+  )
+
+  # Free TPU memory
+  del evaluator_vanilla
+  import gc
+  gc.collect()
+
+  # 2. Run Jax-Inference Sampler
+  print("\n>>> [2/2] Running Evaluation with Jax-Inference Sampler...")
+  evaluator_jax_inf = Qwen25MathEvaluator(
+      model_config=model_config,
+      model_version=model_version,
+      model_path=model_path,
+      dataset=dataset_name,
+      mesh_config=mesh_config,
+      max_prompt_length=1024,
+      max_generation_steps=128,
+      sampler_type="jax_inference",
+  )
+  evaluator_jax_inf.load_model()
+  results_jax_inf = evaluator_jax_inf.evaluate(
+      batch_size=batch_size,
+      num_batches=num_batches,
+      temperature=0.0,
+      top_k=1,
+      top_p=1.0,
+      num_passes=1,
+      debug_first_n=num_samples,
+  )
+
+  # 3. Compare Results
+  print("\n=======================================================")
+  print("Validation & Comparison Summary")
+  print("=======================================================")
+  vanilla_detailed = results_vanilla["detailed_results"][:num_samples]
+  jax_inf_detailed = results_jax_inf["detailed_results"][:num_samples]
+
+  matches = 0
+  reward_matches = 0
+  for i, (v, j) in enumerate(zip(vanilla_detailed, jax_inf_detailed)):
+    v_resp = v["responses"][0].strip() if v["responses"] else ""
+    j_resp = j["responses"][0].strip() if j["responses"] else ""
+    v_ans = v["extracted_answers"][0] if v["extracted_answers"] else None
+    j_ans = j["extracted_answers"][0] if j["extracted_answers"] else None
+    v_corr = v["correct"]
+    j_corr = j["correct"]
+
+    text_match = v_resp == j_resp
+    ans_match = v_ans == j_ans
+    reward_match = v_corr == j_corr
+
+    if text_match:
+      matches += 1
+    if reward_match:
+      reward_matches += 1
+
+    print(f"\n--- Item {i+1} ---")
+    print(f"Question (prefix): {v['question'][:80]}...")
+    print(f"Ground Truth Answer: {v['answer']}")
+    print(f"Vanilla Extracted: {v_ans} | Correct: {v_corr}")
+    print(f"Jax-Inf Extracted: {j_ans} | Correct: {j_corr}")
+    print(f"Text Match: {text_match} | Reward Match: {reward_match}")
+
+  print(f"\nTotal compared: {len(vanilla_detailed)}")
+  print(f"Exact text matches: {matches}/{len(vanilla_detailed)}")
+  print(f"Reward (correctness) matches: {reward_matches}/{len(vanilla_detailed)}")
+  print(f"Vanilla Accuracy: {results_vanilla['accuracy']:.2f}%")
+  print(f"Jax-Inference Accuracy: {results_jax_inf['accuracy']:.2f}%")
+  print("=======================================================\n")
+
+
+if __name__ == "__main__":
+  model = os.environ.get("MODEL_VERSION", "Qwen/Qwen3-1.7B-base")
+  num = int(os.environ.get("NUM_SAMPLES", "4"))
+  run_comparison(model_version=model, num_samples=num)

--- a/examples/deepscaler/validate_samplers.py
+++ b/examples/deepscaler/validate_samplers.py
@@ -130,6 +130,9 @@ def run_comparison(
     print(f"Vanilla Extracted: {v_ans} | Correct: {v_corr}")
     print(f"Jax-Inf Extracted: {j_ans} | Correct: {j_corr}")
     print(f"Text Match: {text_match} | Reward Match: {reward_match}")
+    if not text_match:
+      print(f"  [Vanilla]: {repr(v_resp[-100:])}")
+      print(f"  [Jax-Inf]: {repr(j_resp[-100:])}")
 
   print(f"\nTotal compared: {len(vanilla_detailed)}")
   print(f"Exact text matches: {matches}/{len(vanilla_detailed)}")

--- a/examples/deepscaler/validate_samplers.py
+++ b/examples/deepscaler/validate_samplers.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Validation script comparing Tunix Vanilla Sampler and Jax-Inference Sampler on Math-500."""
+"""Validation script comparing any two Tunix samplers on Math benchmarks."""
 
+import argparse
+import gc
 import json
 import os
 import sys
+from typing import Any, Dict
 import jax
 
 # Ensure paths
@@ -29,120 +32,292 @@ from examples.deepscaler.math_eval_nb import (
     _resolve_model_path,
 )
 
+SUPPORTED_SAMPLERS = ("vanilla", "jax_inference", "vllm", "sglang_jax")
 
-def run_comparison(
-    model_version: str = "Qwen/Qwen3-1.7B-base",
-    num_samples: int = 4,
-    batch_size: int = 2,
-):
-  print(f"\n=======================================================")
-  print(f"Comparing Samplers on {model_version} (samples={num_samples})")
-  print(f"=======================================================\n")
 
+def run_sampler_eval(
+    sampler_type: str,
+    model_version: str,
+    dataset: str,
+    batch_size: int,
+    num_batches: int,
+    temperature: float,
+    top_k: int,
+    top_p: float,
+    seed: int,
+    max_generation_steps: int,
+    max_prompt_length: int,
+    num_samples: int,
+) -> Dict[str, Any]:
+  """Runs evaluation using the specified sampler backend and frees resources."""
   model_config, model_path = MODEL_MAPPING[model_version]
   max_tp = getattr(model_config, "num_kv_heads", len(jax.devices()))
   tp_size = min(len(jax.devices()), max_tp)
   mesh_config = [[1, tp_size], ["fsdp", "tp"]]
-  dataset_name = "HuggingFaceH4/MATH-500"
+
+  print(f"\n>>> Running Evaluation with [{sampler_type}] Sampler...")
+  evaluator = Qwen25MathEvaluator(
+      model_config=model_config,
+      model_version=model_version,
+      model_path=model_path,
+      dataset=dataset,
+      mesh_config=mesh_config,
+      max_prompt_length=max_prompt_length,
+      max_generation_steps=max_generation_steps,
+      sampler_type=sampler_type,
+  )
+  evaluator.load_model()
+  results = evaluator.evaluate(
+      batch_size=batch_size,
+      num_batches=num_batches,
+      temperature=temperature,
+      top_k=top_k,
+      top_p=top_p,
+      num_passes=1,
+      debug_first_n=num_samples,
+  )
+
+  # Free TPU memory between evaluations
+  del evaluator
+  gc.collect()
+
+  return results
+
+
+def run_comparison(
+    sampler1: str = "vanilla",
+    sampler2: str = "jax_inference",
+    model_version: str = "Qwen/Qwen3-1.7B-base",
+    dataset: str = "HuggingFaceH4/MATH-500",
+    num_samples: int = 4,
+    batch_size: int = 2,
+    temperature: float = 0.0,
+    top_k: int = 1,
+    top_p: float = 1.0,
+    seed: int = 42,
+    max_generation_steps: int = 128,
+    max_prompt_length: int = 1024,
+    output_json: str | None = None,
+):
+  """Compares two samplers side-by-side on MATH benchmark."""
+  if sampler1 not in SUPPORTED_SAMPLERS:
+    raise ValueError(f"sampler1 '{sampler1}' not supported. Must be one of {SUPPORTED_SAMPLERS}")
+  if sampler2 not in SUPPORTED_SAMPLERS:
+    raise ValueError(f"sampler2 '{sampler2}' not supported. Must be one of {SUPPORTED_SAMPLERS}")
+
+  print(f"\n=======================================================")
+  print(f"Comparing Samplers: [{sampler1}] vs [{sampler2}]")
+  print(f"Model: {model_version} | Samples: {num_samples} | Batch Size: {batch_size}")
+  print(f"Sampling Params: temperature={temperature}, top_k={top_k}, top_p={top_p}, seed={seed}")
+  print(f"=======================================================\n")
 
   num_batches = (num_samples + batch_size - 1) // batch_size
 
-  # 1. Run Vanilla Sampler
-  print("\n>>> [1/2] Running Evaluation with Vanilla Sampler...")
-  evaluator_vanilla = Qwen25MathEvaluator(
-      model_config=model_config,
+  # 1. Run Sampler 1
+  results1 = run_sampler_eval(
+      sampler_type=sampler1,
       model_version=model_version,
-      model_path=model_path,
-      dataset=dataset_name,
-      mesh_config=mesh_config,
-      max_prompt_length=1024,
-      max_generation_steps=128,
-      sampler_type="vanilla",
-  )
-  evaluator_vanilla.load_model()
-  results_vanilla = evaluator_vanilla.evaluate(
+      dataset=dataset,
       batch_size=batch_size,
       num_batches=num_batches,
-      temperature=0.0,
-      top_k=1,
-      top_p=1.0,
-      num_passes=1,
-      debug_first_n=num_samples,
+      temperature=temperature,
+      top_k=top_k,
+      top_p=top_p,
+      seed=seed,
+      max_generation_steps=max_generation_steps,
+      max_prompt_length=max_prompt_length,
+      num_samples=num_samples,
   )
 
-  # Free TPU memory
-  del evaluator_vanilla
-  import gc
-  gc.collect()
-
-  # 2. Run Jax-Inference Sampler
-  print("\n>>> [2/2] Running Evaluation with Jax-Inference Sampler...")
-  evaluator_jax_inf = Qwen25MathEvaluator(
-      model_config=model_config,
+  # 2. Run Sampler 2
+  results2 = run_sampler_eval(
+      sampler_type=sampler2,
       model_version=model_version,
-      model_path=model_path,
-      dataset=dataset_name,
-      mesh_config=mesh_config,
-      max_prompt_length=1024,
-      max_generation_steps=128,
-      sampler_type="jax_inference",
-  )
-  evaluator_jax_inf.load_model()
-  results_jax_inf = evaluator_jax_inf.evaluate(
+      dataset=dataset,
       batch_size=batch_size,
       num_batches=num_batches,
-      temperature=0.0,
-      top_k=1,
-      top_p=1.0,
-      num_passes=1,
-      debug_first_n=num_samples,
+      temperature=temperature,
+      top_k=top_k,
+      top_p=top_p,
+      seed=seed,
+      max_generation_steps=max_generation_steps,
+      max_prompt_length=max_prompt_length,
+      num_samples=num_samples,
   )
 
   # 3. Compare Results
   print("\n=======================================================")
-  print("Validation & Comparison Summary")
+  print(f"Validation & Comparison Summary: [{sampler1}] vs [{sampler2}]")
   print("=======================================================")
-  vanilla_detailed = results_vanilla["detailed_results"][:num_samples]
-  jax_inf_detailed = results_jax_inf["detailed_results"][:num_samples]
+  detailed1 = results1.get("detailed_results", [])[:num_samples]
+  detailed2 = results2.get("detailed_results", [])[:num_samples]
 
-  matches = 0
+  text_matches = 0
+  answer_matches = 0
   reward_matches = 0
-  for i, (v, j) in enumerate(zip(vanilla_detailed, jax_inf_detailed)):
-    v_resp = v["responses"][0].strip() if v["responses"] else ""
-    j_resp = j["responses"][0].strip() if j["responses"] else ""
-    v_ans = v["extracted_answers"][0] if v["extracted_answers"] else None
-    j_ans = j["extracted_answers"][0] if j["extracted_answers"] else None
-    v_corr = v["correct"]
-    j_corr = j["correct"]
 
-    text_match = v_resp == j_resp
-    ans_match = v_ans == j_ans
-    reward_match = v_corr == j_corr
+  for i, (d1, d2) in enumerate(zip(detailed1, detailed2)):
+    resp1 = d1["responses"][0].strip() if d1["responses"] else ""
+    resp2 = d2["responses"][0].strip() if d2["responses"] else ""
+    ans1 = d1["extracted_answers"][0] if d1["extracted_answers"] else None
+    ans2 = d2["extracted_answers"][0] if d2["extracted_answers"] else None
+    corr1 = d1["correct"]
+    corr2 = d2["correct"]
+
+    text_match = resp1 == resp2
+    ans_match = ans1 == ans2
+    reward_match = corr1 == corr2
 
     if text_match:
-      matches += 1
+      text_matches += 1
+    if ans_match:
+      answer_matches += 1
     if reward_match:
       reward_matches += 1
 
     print(f"\n--- Item {i+1} ---")
-    print(f"Question (prefix): {v['question'][:80]}...")
-    print(f"Ground Truth Answer: {v['answer']}")
-    print(f"Vanilla Extracted: {v_ans} | Correct: {v_corr}")
-    print(f"Jax-Inf Extracted: {j_ans} | Correct: {j_corr}")
-    print(f"Text Match: {text_match} | Reward Match: {reward_match}")
+    print(f"Question (prefix): {d1['question'][:80]}...")
+    print(f"Ground Truth Answer: {d1['answer']}")
+    print(f"[{sampler1}] Extracted: {ans1} | Correct: {corr1}")
+    print(f"[{sampler2}] Extracted: {ans2} | Correct: {corr2}")
+    print(f"Exact Text Match: {text_match} | Extracted Answer Match: {ans_match} | Reward Match: {reward_match}")
     if not text_match:
-      print(f"  [Vanilla]: {repr(v_resp[-100:])}")
-      print(f"  [Jax-Inf]: {repr(j_resp[-100:])}")
+      print(f"  [{sampler1} Output]: {repr(resp1[-100:])}")
+      print(f"  [{sampler2} Output]: {repr(resp2[-100:])}")
 
-  print(f"\nTotal compared: {len(vanilla_detailed)}")
-  print(f"Exact text matches: {matches}/{len(vanilla_detailed)}")
-  print(f"Reward (correctness) matches: {reward_matches}/{len(vanilla_detailed)}")
-  print(f"Vanilla Accuracy: {results_vanilla['accuracy']:.2f}%")
-  print(f"Jax-Inference Accuracy: {results_jax_inf['accuracy']:.2f}%")
+  total_compared = len(detailed1)
+  print(f"\nTotal Compared: {total_compared}")
+  print(f"Exact Text Matches: {text_matches}/{total_compared} ({text_matches/total_compared*100:.1f}%)" if total_compared else "N/A")
+  print(f"Extracted Answer Matches: {answer_matches}/{total_compared} ({answer_matches/total_compared*100:.1f}%)" if total_compared else "N/A")
+  print(f"Reward (Correctness) Matches: {reward_matches}/{total_compared} ({reward_matches/total_compared*100:.1f}%)" if total_compared else "N/A")
+  print(f"[{sampler1}] Accuracy: {results1.get('accuracy', 0.0):.2f}%")
+  print(f"[{sampler2}] Accuracy: {results2.get('accuracy', 0.0):.2f}%")
   print("=======================================================\n")
+
+  if output_json:
+    summary = {
+        "sampler1": sampler1,
+        "sampler2": sampler2,
+        "model_version": model_version,
+        "num_samples": num_samples,
+        "temperature": temperature,
+        "top_k": top_k,
+        "top_p": top_p,
+        "text_matches": text_matches,
+        "answer_matches": answer_matches,
+        "reward_matches": reward_matches,
+        "total_compared": total_compared,
+        f"{sampler1}_accuracy": results1.get("accuracy", 0.0),
+        f"{sampler2}_accuracy": results2.get("accuracy", 0.0),
+    }
+    with open(output_json, "w") as f:
+      json.dump(summary, f, indent=2)
+    print(f"Saved comparison summary to {output_json}")
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description="Compare any two Tunix samplers side-by-side on MATH benchmarks."
+  )
+  parser.add_argument(
+      "--sampler1",
+      type=str,
+      default=os.environ.get("SAMPLER1", "vanilla"),
+      choices=SUPPORTED_SAMPLERS,
+      help="First sampler backend to evaluate (default: vanilla).",
+  )
+  parser.add_argument(
+      "--sampler2",
+      type=str,
+      default=os.environ.get("SAMPLER2", "jax_inference"),
+      choices=SUPPORTED_SAMPLERS,
+      help="Second sampler backend to evaluate (default: jax_inference).",
+  )
+  parser.add_argument(
+      "--model-version",
+      type=str,
+      default=os.environ.get("MODEL_VERSION", "Qwen/Qwen3-1.7B-base"),
+      help="Model version key in MODEL_MAPPING (default: Qwen/Qwen3-1.7B-base).",
+  )
+  parser.add_argument(
+      "--dataset",
+      type=str,
+      default=os.environ.get("DATASET", "HuggingFaceH4/MATH-500"),
+      help="Dataset name or path (default: HuggingFaceH4/MATH-500).",
+  )
+  parser.add_argument(
+      "--num-samples",
+      type=int,
+      default=int(os.environ.get("NUM_SAMPLES", "4")),
+      help="Total number of samples to evaluate and compare (default: 4).",
+  )
+  parser.add_argument(
+      "--batch-size",
+      type=int,
+      default=int(os.environ.get("BATCH_SIZE", "2")),
+      help="Batch size for evaluation (default: 2).",
+  )
+  parser.add_argument(
+      "--temperature",
+      type=float,
+      default=float(os.environ.get("TEMPERATURE", "0.0")),
+      help="Sampling temperature (default: 0.0 for greedy).",
+  )
+  parser.add_argument(
+      "--top-k",
+      type=int,
+      default=int(os.environ.get("TOP_K", "1")),
+      help="Top-k sampling parameter (default: 1).",
+  )
+  parser.add_argument(
+      "--top-p",
+      type=float,
+      default=float(os.environ.get("TOP_P", "1.0")),
+      help="Top-p nucleus parameter (default: 1.0).",
+  )
+  parser.add_argument(
+      "--seed",
+      type=int,
+      default=int(os.environ.get("SEED", "42")),
+      help="Random seed for sampling (default: 42).",
+  )
+  parser.add_argument(
+      "--max-generation-steps",
+      type=int,
+      default=int(os.environ.get("MAX_GENERATION_STEPS", "128")),
+      help="Maximum generation steps / new tokens (default: 128).",
+  )
+  parser.add_argument(
+      "--max-prompt-length",
+      type=int,
+      default=int(os.environ.get("MAX_PROMPT_LENGTH", "1024")),
+      help="Maximum prompt length (default: 1024).",
+  )
+  parser.add_argument(
+      "--output-json",
+      type=str,
+      default=os.environ.get("OUTPUT_JSON", None),
+      help="Optional path to output comparison summary JSON.",
+  )
+
+  args = parser.parse_args()
+
+  run_comparison(
+      sampler1=args.sampler1,
+      sampler2=args.sampler2,
+      model_version=args.model_version,
+      dataset=args.dataset,
+      num_samples=args.num_samples,
+      batch_size=args.batch_size,
+      temperature=args.temperature,
+      top_k=args.top_k,
+      top_p=args.top_p,
+      seed=args.seed,
+      max_generation_steps=args.max_generation_steps,
+      max_prompt_length=args.max_prompt_length,
+      output_json=args.output_json,
+  )
 
 
 if __name__ == "__main__":
-  model = os.environ.get("MODEL_VERSION", "Qwen/Qwen3-1.7B-base")
-  num = int(os.environ.get("NUM_SAMPLES", "4"))
-  run_comparison(model_version=model, num_samples=num)
+  main()

--- a/tests/generate/jax_inference_sampler_test.py
+++ b/tests/generate/jax_inference_sampler_test.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest import mock
+
+from absl.testing import absltest
+from flax import nnx
+import jax
+import numpy as np
+import transformers
+
+from tunix.generate import jax_inference_sampler
+from tunix.generate import mappings
+from tunix.generate import sampler as vanilla_sampler
+from tunix.models.qwen3 import mapping_vllm_jax
+from tunix.models.qwen3 import model as qwen3_model
+from tunix.models.qwen3 import params as qwen3_params
+from tunix.tests import test_common as tc
+
+
+class JaxInferenceSamplerTest(absltest.TestCase):
+
+  @classmethod
+  def setUpClass(cls) -> None:
+    super().setUpClass()
+    cls.repo_id = "Qwen/Qwen3-1.7B-base"
+
+    # Resolve model path from HuggingFace cache if available
+    repo_cache = os.path.expanduser(
+        f"~/.cache/huggingface/hub/models--{cls.repo_id.replace('/', '--')}/snapshots"
+    )
+    if os.path.exists(repo_cache) and os.listdir(repo_cache):
+      cls.model_path = os.path.join(repo_cache, os.listdir(repo_cache)[0])
+    else:
+      cls.model_path = cls.repo_id
+
+    mesh_shape = (1, len(jax.devices()))
+    axis_names = ("fsdp", "tp")
+    cls.mesh = jax.make_mesh(
+        mesh_shape,
+        axis_names,
+        devices=jax.devices(),
+        axis_types=(jax.sharding.AxisType.Auto,) * len(axis_names),
+    )
+
+  def test_jax_inference_sampler_e2e(self):
+    """Tests end-to-end generation and weight update with JaxInferenceSampler."""
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        self.model_path, trust_remote_code=True
+    )
+
+    # 1. Initialize JaxInferenceSampler
+    config = jax_inference_sampler.JaxInferenceConfig(
+        model_name=self.model_path,
+        mesh=self.mesh,
+        tensor_parallel_size=len(jax.devices()),
+        num_blocks=128,
+        block_size=256,
+        kv_cache_dtype="bf16",
+        unroll_steps=16,
+    )
+
+    sampler = jax_inference_sampler.JaxInferenceSampler(
+        tokenizer=tokenizer,
+        config=config,
+    )
+
+    self.assertIsNotNone(sampler.transformer)
+    self.assertIsNotNone(sampler.transformer_state)
+    self.assertIsNotNone(sampler.mesh)
+
+    prompts = [
+        "The capital of France is",
+        "2 + 2 =",
+    ]
+
+    # 2. Run generation
+    output = sampler(
+        input_strings=prompts,
+        max_generation_steps=16,
+        temperature=0.0,
+    )
+
+    self.assertLen(output.text, 2)
+    self.assertLen(output.tokens, 2)
+    self.assertEqual(output.padded_prompt_tokens.shape[0], 2)
+    self.assertTrue(all(isinstance(t, str) and len(t) > 0 for t in output.text))
+    print("JaxInference generated texts:", output.text)
+
+  def test_update_params_with_mappings(self):
+    """Tests weight synchronization using mapping config into JaxInferenceSampler."""
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        self.model_path, trust_remote_code=True
+    )
+
+    # Create small 1-layer Tunix Qwen3 model to test parameter transfer
+    model_config = qwen3_model.ModelConfig.qwen3_1p7b_base()
+    model_config.num_layers = 1
+
+    tunix_model = qwen3_params.create_model_from_safe_tensors(
+        self.model_path, model_config, self.mesh
+    )
+
+    mapping_config = mappings.MappingConfig(**mapping_vllm_jax.VLLM_JAX_MAPPING)
+
+    config = jax_inference_sampler.JaxInferenceConfig(
+        model_name=self.model_path,
+        mesh=self.mesh,
+        tensor_parallel_size=len(jax.devices()),
+        num_blocks=64,
+        block_size=256,
+        kv_cache_dtype="bf16",
+        mapping_config=mapping_config,
+    )
+
+    sampler = jax_inference_sampler.JaxInferenceSampler(
+        tokenizer=tokenizer,
+        config=config,
+    )
+
+    # Test weight syncing
+    state = nnx.state(tunix_model)
+    sampler.update_params(state)
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/generate/jax_inference_sampler_test.py
+++ b/tests/generate/jax_inference_sampler_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import unittest
 from unittest import mock
 
 from absl.testing import absltest
@@ -30,12 +31,21 @@ from tunix.models.qwen3 import params as qwen3_params
 from tunix.tests import test_common as tc
 
 
+@unittest.skipIf(
+    jax_inference_sampler.JaxInferenceEngine is None,
+    "jax-inference is required for JaxInferenceSampler tests.",
+)
 class JaxInferenceSamplerTest(absltest.TestCase):
+  model_path: str | None = None
+  repo_id: str = "Qwen/Qwen3-1.7B-base"
 
   @classmethod
   def setUpClass(cls) -> None:
     super().setUpClass()
-    cls.repo_id = "Qwen/Qwen3-1.7B-base"
+    if jax_inference_sampler.JaxInferenceEngine is None:
+      raise unittest.SkipTest(
+          "jax-inference is required for JaxInferenceSampler tests."
+      )
 
     # Resolve model path from HuggingFace cache if available
     repo_cache = os.path.expanduser(
@@ -43,8 +53,15 @@ class JaxInferenceSamplerTest(absltest.TestCase):
     )
     if os.path.exists(repo_cache) and os.listdir(repo_cache):
       cls.model_path = os.path.join(repo_cache, os.listdir(repo_cache)[0])
-    else:
+    elif os.path.isdir(cls.repo_id):
       cls.model_path = cls.repo_id
+    else:
+      cls.model_path = None
+
+    if not cls.model_path or not os.path.isdir(cls.model_path):
+      raise unittest.SkipTest(
+          f"Model checkpoint for {cls.repo_id} not found locally."
+      )
 
     mesh_shape = (1, len(jax.devices()))
     axis_names = ("fsdp", "tp")

--- a/tests/generate/jax_inference_sampler_test.py
+++ b/tests/generate/jax_inference_sampler_test.py
@@ -134,6 +134,57 @@ class JaxInferenceSamplerTest(absltest.TestCase):
     state = nnx.state(tunix_model)
     sampler.update_params(state)
 
+  def test_jax_inference_sampler_temperature(self):
+    """Tests JaxInferenceSampler with temperature > 0, top_k, top_p, PRNGKey seed, and multi_sampling."""
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        self.model_path, trust_remote_code=True
+    )
+
+    config = jax_inference_sampler.JaxInferenceConfig(
+        model_name=self.model_path,
+        mesh=self.mesh,
+        tensor_parallel_size=len(jax.devices()),
+        num_blocks=128,
+        block_size=256,
+        kv_cache_dtype="bf16",
+        unroll_steps=16,
+    )
+
+    sampler = jax_inference_sampler.JaxInferenceSampler(
+        tokenizer=tokenizer,
+        config=config,
+    )
+
+    prompts = ["What is the color of the sky?"]
+
+    # 1. Test with temperature > 0, top_k, top_p and JAX PRNGKey
+    key = jax.random.PRNGKey(42)
+    output1 = sampler(
+        input_strings=prompts,
+        max_generation_steps=16,
+        temperature=0.7,
+        top_k=50,
+        top_p=0.95,
+        seed=key,
+    )
+    self.assertLen(output1.text, 1)
+    self.assertTrue(len(output1.text[0]) > 0)
+
+    # 2. Test multi_sampling > 1 with temperature > 0
+    output_multi = sampler(
+        input_strings=prompts,
+        max_generation_steps=16,
+        temperature=0.7,
+        top_k=50,
+        top_p=0.95,
+        multi_sampling=3,
+    )
+    self.assertLen(output_multi.text, 3)
+    self.assertEqual(output_multi.padded_prompt_tokens.shape[0], 3)
+    self.assertLen(output_multi.tokens, 3)
+    print("Multi-sample results with temperature=0.7:", output_multi.text)
+
 
 if __name__ == "__main__":
   absltest.main()
+

--- a/tunix/generate/jax_inference_sampler.py
+++ b/tunix/generate/jax_inference_sampler.py
@@ -1,0 +1,330 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A high-throughput TPU sampler backend based on jax-inference."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import math
+from typing import Any, List, Optional, Tuple, Union
+
+from flax import nnx
+import jax
+import jax.numpy as jnp
+import jaxtyping
+import numpy as np
+
+from tunix.generate import base_sampler
+from tunix.generate import mappings
+from tunix.generate import tokenizer_adapter as tok_adapter
+from tunix.generate import utils
+from tunix.rl import reshard
+
+try:
+  from jax_inference.engine import JaxInferenceEngine, SamplingConfig
+except ImportError:
+  JaxInferenceEngine = None  # pyrefly: ignore[assignment]
+  SamplingConfig = None  # pyrefly: ignore[assignment]
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class JaxInferenceConfig:
+  """Configuration for JaxInferenceSampler.
+
+  Attributes:
+    model_name: HuggingFace model repo id or local checkpoint path.
+    mesh: JAX sharding mesh.
+    tensor_parallel_size: Tensor parallel size. If None, inferred from mesh.
+    num_blocks: Number of KV cache blocks. If None, calculated dynamically.
+    block_size: Number of tokens per KV cache block.
+    kv_cache_dtype: KV cache data type ("bf16", "fp8", etc.).
+    chunk_prefill_size: Chunk size for prefill computation.
+    enable_expert_parallel: Whether to enable expert parallelism for MoE.
+    quantization: Quantization scheme (e.g., "fp8") or None.
+    unroll_steps: Number of unroll steps for decode loop.
+    dummy_weights: Initialize with dummy weights instead of loading checkpoint.
+    init_with_random_weights: Alias/flag to avoid loading base weights if
+      weights will be updated via update_params.
+    mapping_config: MappingConfig describing how to map Tunix weights to HF/JAX
+      format.
+    additional_config: Extra configuration dictionary passed to vLLM config.
+    max_model_len: Maximum model sequence length.
+    delete_dst_buffers: Whether to free destination buffers during weight
+      transfer.
+    reshard_chunk_size: Chunk size for resharding parameters.
+    monolithic: Whether to use monolithic generation execution.
+  """
+
+  model_name: str
+  mesh: Optional[jax.sharding.Mesh] = None
+  tensor_parallel_size: Optional[int] = None
+  num_blocks: Optional[int] = None
+  block_size: int = 256
+  kv_cache_dtype: Union[str, jnp.dtype] = "bf16"
+  chunk_prefill_size: int = 8192
+  enable_expert_parallel: bool = False
+  quantization: Optional[str] = None
+  unroll_steps: int = 16
+  dummy_weights: bool = False
+  init_with_random_weights: bool = False
+  mapping_config: Optional[mappings.MappingConfig] = None
+  additional_config: Optional[dict[str, Any]] = None
+  max_model_len: Optional[int] = None
+  delete_dst_buffers: bool = False
+  reshard_chunk_size: Optional[int] = None
+  monolithic: bool = True
+
+
+class JaxInferenceSampler(base_sampler.BaseSampler):
+  """A high-throughput TPU sampler backend wrapping jax-inference."""
+
+  def __init__(
+      self,
+      tokenizer: Any,
+      config: JaxInferenceConfig,
+      **kwargs,
+  ):
+    """Initializes JaxInferenceSampler.
+
+    Args:
+      tokenizer: HuggingFace tokenizer or TokenizerAdapter.
+      config: JaxInferenceConfig instance.
+      **kwargs: Additional keyword arguments passed to JaxInferenceEngine.
+    """
+    if JaxInferenceEngine is None:
+      raise ImportError(
+          "jax-inference is required for JaxInferenceSampler. "
+          "Please ensure jax-inference is installed in your environment."
+      )
+
+    self.tokenizer = tokenizer
+    if not isinstance(tokenizer, tok_adapter.TokenizerAdapter):
+      self.tokenizer = tok_adapter.TokenizerAdapter(tokenizer)
+    self.config = config
+
+    # Derive tensor parallel size from mesh or devices if not explicitly specified.
+    tp_size = config.tensor_parallel_size
+    if tp_size is None and config.mesh is not None:
+      if "tp" in config.mesh.shape:
+        tp_size = config.mesh.shape["tp"]
+      elif "model" in config.mesh.shape:
+        tp_size = config.mesh.shape["model"]
+      else:
+        tp_size = math.prod(config.mesh.shape.values())
+    if tp_size is None:
+      tp_size = len(jax.devices())
+
+    # Derive num_blocks if not specified.
+    num_blocks = config.num_blocks
+    if num_blocks is None:
+      max_len = config.max_model_len or 4096
+      num_blocks = max(
+          512, 16 * ((max_len + config.block_size - 1) // config.block_size)
+      )
+
+    engine_kwargs = dict(
+        model_name=config.model_name,
+        tensor_parallel_size=tp_size,
+        num_blocks=num_blocks,
+        block_size=config.block_size,
+        kv_cache_dtype=config.kv_cache_dtype,
+        chunk_prefill_size=config.chunk_prefill_size,
+        enable_expert_parallel=config.enable_expert_parallel,
+        additional_config=config.additional_config,
+        quantization=config.quantization,
+        unroll_steps=config.unroll_steps,
+        dummy_weights=config.dummy_weights or config.init_with_random_weights,
+    )
+    if kwargs:
+      engine_kwargs.update(kwargs)
+
+    self.engine = JaxInferenceEngine(**engine_kwargs)
+
+    if not config.init_with_random_weights and not config.dummy_weights:
+      self.engine.load_model_and_weights()
+
+    if config.mapping_config is not None:
+      self.to_hf_key_mappings = dict(
+          config.mapping_config.to_hf_mappings or {}
+      )
+      self.to_hf_transpose_keys = config.mapping_config.to_hf_transpose_keys
+      self.to_hf_hook_fns = config.mapping_config.to_hf_hook_fns
+    else:
+      self.to_hf_key_mappings = {}
+      self.to_hf_transpose_keys = None
+      self.to_hf_hook_fns = None
+
+  @property
+  def transformer(self) -> Optional[nnx.Module]:
+    """Underlying Flax NNX model instance."""
+    return self.engine.model
+
+  @property
+  def transformer_state(self) -> Optional[nnx.State]:
+    """Underlying Flax NNX state."""
+    if hasattr(self.engine, "state") and self.engine.state is not None:
+      return self.engine.state
+    if self.engine.model is not None:
+      return nnx.state(self.engine.model)
+    return None
+
+  @property
+  def mesh(self) -> jax.sharding.Mesh:
+    """Device mesh used by the engine."""
+    return self.engine.mesh
+
+  def tokenize(self, input_string: str) -> np.ndarray | list[int]:
+    """Tokenize a string using the tokenizer."""
+    input_ids = self.tokenizer.encode(input_string)
+    bos_tok = [self.tokenizer.bos_id()] if self.tokenizer.bos_id() else []
+    return self.tokenizer.dedup_bos_ids(bos_tok + input_ids)
+
+  def update_params(
+      self,
+      updated_weights: jaxtyping.PyTree,
+      filter_types: Optional[Tuple[Any, ...]] = None,
+  ) -> None:
+    """Synchronize weights from Tunix trainer/model into jax-inference engine.
+
+    Args:
+      updated_weights: Tunix PyTree/State or HF-structured weights.
+      filter_types: Unused filter types for compatibility with BaseSampler.
+    """
+    del filter_types
+    if self.to_hf_key_mappings:
+      preprocess_fn = (
+          self.config.mapping_config.preprocess_src_state
+          if self.config.mapping_config
+          else None
+      )
+      if preprocess_fn:
+        updated_weights = preprocess_fn(updated_weights)
+
+      new_state = utils.transfer_state_with_mappings(
+          src_state=updated_weights,
+          dst_state=self.transformer_state,
+          key_mappings=self.to_hf_key_mappings,
+          key_mapping_hook_fns=self.to_hf_hook_fns,
+          transpose_keys=self.to_hf_transpose_keys,
+          reshard_fn=reshard.reshard_pytree,
+          delete_dst_buffers=self.config.delete_dst_buffers,
+          reshard_chunk_size=self.config.reshard_chunk_size,
+      )
+      self.engine.update_model_weights(new_state)
+    else:
+      self.engine.update_model_weights(updated_weights)
+
+  def __call__(
+      self,
+      input_strings: str | List[str],
+      max_generation_steps: int,
+      max_prompt_length: Optional[int] = None,
+      temperature: float = 0.0,
+      top_p: Optional[float] = None,
+      top_k: Optional[int] = None,
+      beam_size: Optional[int] = None,
+      seed: Optional[int] = None,
+      multi_sampling: int = 1,
+      return_logits: bool = True,
+      echo: bool = False,
+      pad_output: bool = False,
+      **kwargs,
+  ) -> base_sampler.SamplerOutput:
+    """Generate completions for prompts using jax-inference.
+
+    Args:
+      input_strings: A prompt string or list of prompt strings.
+      max_generation_steps: Maximum new tokens to generate.
+      max_prompt_length: Maximum length for prompt padding.
+      temperature: Sampling temperature (0.0 for greedy).
+      top_p: Cumulative probability threshold for nucleus sampling.
+      top_k: Top-k sampling threshold.
+      beam_size: Unused; present for BaseSampler interface compatibility.
+      seed: Random seed for sampling.
+      multi_sampling: Number of samples per prompt.
+      return_logits: Unused; present for BaseSampler interface compatibility.
+      echo: Whether to include prompt in returned text.
+      pad_output: Unused; present for BaseSampler interface compatibility.
+      **kwargs: Additional parameters.
+
+    Returns:
+      SamplerOutput containing generated text and token arrays.
+    """
+    del beam_size, return_logits, pad_output, kwargs
+    if isinstance(input_strings, str):
+      input_strings = [input_strings]
+
+    prompts_to_run = input_strings
+    if multi_sampling > 1:
+      prompts_to_run = [
+          prompt for prompt in input_strings for _ in range(multi_sampling)
+      ]
+
+    sampling_cfg = SamplingConfig(
+        temperature=temperature,
+        top_k=top_k,
+        top_p=top_p,
+        seed=seed,
+    )
+
+    raw_outputs = self.engine.generate(
+        prompts=prompts_to_run,
+        max_new_tokens=max_generation_steps,
+        sampling_config=sampling_cfg,
+        monolithic=self.config.monolithic,
+    )
+
+    if isinstance(raw_outputs, str):
+      generated_texts = [raw_outputs]
+    else:
+      generated_texts = list(raw_outputs)
+
+    if echo:
+      generated_texts = [
+          p + g for p, g in zip(prompts_to_run, generated_texts)
+      ]
+
+    prompt_ids = [self.tokenize(x) for x in input_strings]
+    max_tokens_length = max(len(x) for x in prompt_ids) if prompt_ids else 0
+    if max_prompt_length is None or max_prompt_length < max_tokens_length:
+      max_prompt_length = utils.next_power_of_2(max_tokens_length)
+
+    all_input_ids = [
+        utils.pad_to_length(
+            np.array(x, dtype=np.int32),
+            target_length=max_prompt_length,
+            pad_value=self.tokenizer.pad_id(),
+            left=True,
+        )
+        for x in prompt_ids
+    ]
+    padded_prompts_np = np.array(all_input_ids, dtype=np.int32)
+
+    out_tokens = [
+        np.array(self.tokenizer.encode(text), dtype=np.int32)
+        for text in generated_texts
+    ]
+
+    return base_sampler.SamplerOutput(
+        text=generated_texts,
+        logits=None,
+        tokens=out_tokens,
+        padded_prompt_tokens=padded_prompts_np,
+        logprobs=None,
+    )

--- a/tunix/generate/jax_inference_sampler.py
+++ b/tunix/generate/jax_inference_sampler.py
@@ -300,7 +300,7 @@ class JaxInferenceSampler(base_sampler.BaseSampler):
           p + g for p, g in zip(prompts_to_run, generated_texts)
       ]
 
-    prompt_ids = [self.tokenize(x) for x in input_strings]
+    prompt_ids = [self.tokenize(x) for x in prompts_to_run]
     max_tokens_length = max(len(x) for x in prompt_ids) if prompt_ids else 0
     if max_prompt_length is None or max_prompt_length < max_tokens_length:
       max_prompt_length = utils.next_power_of_2(max_tokens_length)

--- a/tunix/models/qwen2/__init__.py
+++ b/tunix/models/qwen2/__init__.py
@@ -22,6 +22,7 @@ from tunix.models.qwen2 import params
 BACKEND_MAPPINGS = {
     'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
     'sglang_jax': mapping_sglang_jax.SGLANG_JAX_MAPPING,
+    'jax_inference': mapping_vllm_jax.VLLM_JAX_MAPPING,
 }
 
 

--- a/tunix/models/qwen3/__init__.py
+++ b/tunix/models/qwen3/__init__.py
@@ -22,6 +22,7 @@ from tunix.models.qwen3 import params
 BACKEND_MAPPINGS = {
     'vllm_jax': mapping_vllm_jax.VLLM_JAX_MAPPING,
     'sglang_jax': mapping_sglang_jax.SGLANG_JAX_MAPPING,
+    'jax_inference': mapping_vllm_jax.VLLM_JAX_MAPPING,
 }
 
 


### PR DESCRIPTION
## Summary

This PR introduces a high-throughput TPU sampling backend based on [jax-inference](https://github.com/google/trellis/tree/main/experimental/jax-inference), and integrates it into the math evaluation pipeline in `examples/deepscaler/math_eval_nb.py`.

### Key Changes

1. **`tunix.generate.jax_inference_sampler.JaxInferenceSampler`**:
   - Implements `tunix.generate.base_sampler.BaseSampler` to provide a unified interface matching other rollout backends.
   - Wraps `JaxInferenceEngine` with support for tensor parallelism, configurable KV cache block allocation, unpadded token decoding, and generation parameter handling.
   - Supports dynamic weight synchronization from Tunix NNX models via `update_params(updated_weights)` using backend parameter mappings and invalidating the radix prefix cache across RL iterations.

2. **Model Mappings**:
   - Registered `'jax_inference': mapping_vllm_jax.VLLM_JAX_MAPPING` in `tunix/models/qwen2` and `tunix/models/qwen3`.

3. **Math Evaluation Notebook (`examples/deepscaler/math_eval_nb.py`)**:
   - Added `sampler_type="jax_inference"` support.
   - Added CLI/environment parameterization (`MODEL_VERSION`, `SAMPLER_TYPE`, `TP_SIZE`, `BATCH_SIZE`, `NUM_BATCHES`, `DATASET`).
   - Added robust offline tokenizer and checkpoint loading from local paths.
   - Added memory-efficient handling for large MoE FP8 models.

4. **Testing & Validation**:
   - Added `tests/generate/jax_inference_sampler_test.py` covering:
     - End-to-end generation and greedy decoding.
     - Weight synchronization with model parameter mappings.
   - Added `examples/deepscaler/validate_samplers.py`:
     - Compares output text and MATH-500 ground-truth rewards directly between `vanilla` and `jax_inference` samplers.
     - Confirmed **100% (4/4)** exact match on MATH-500 test questions for `Qwen/Qwen3-1.7B-base`.
     - Validated reasoning generation on `Qwen3-8B`.
     - Validated end-to-end loading and evaluation on `Qwen3.5-35B-A3B-FP8` (MoE).

Tested on Cloud TPU v6e / 7x.