### PR TITLE
Gate jax[tpu] dependency behind a Linux platform marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
   "importlib_resources",
   # Jax 0.7.2 has performance regression on OSS
   # Jax 0.11.1 removed jax.experimental.hijax.MutableHiType, which flax (through 0.12.8, the newest release) still subclasses
-  "jax[tpu]>=0.6.0,!=0.7.2,<0.11.1",
+  # tpu wheels are only available on linux, so we use platform marker to gate the extra
+  "jax[tpu]>=0.6.0,!=0.7.2,<0.11.1; platform_system == 'Linux'",
+  "jax>=0.6.0,!=0.7.2,<0.11.1; platform_system != 'Linux'",
   "jaxtyping",
   "jinja2",  # Huggingface chat template
   "kagglehub",


### PR DESCRIPTION
Fixes #2047.

Implements option 2 as requested in https://github.com/google/tunix/issues/2047#issuecomment-5533695381: keep `jax[tpu]` as a hard dependency on Linux (so downstream libraries like qwix, metrax, and orbax that reinstall JAX keep working in the nightly regression), and depend on plain `jax` on other platforms where libtpu ships no wheels.

Version constraints are unchanged on both branches (`>=0.6.0,!=0.7.2,<0.11.1`). On Linux (including TPU hosts and CI) the resolved dependency set is identical to before, so this is fully backward-compatible; on macOS the package becomes installable, and other non-Linux platforms no longer pull in the TPU runtime.