### PR TITLE
Fix pre-commit mdformat hook dependency conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: mdformat
         args: ["--wrap", "80"]
         additional_dependencies:
-          - mdformat-gfm==0.3.5
+          - mdformat-gfm==1.0.0
           - "markdown-it-py[linkify]"
           # (optional) other plugins:
           # - mdformat-frontmatter


### PR DESCRIPTION
The `mdformat` pre-commit hook is currently broken: the hook repo is pinned to `rev: 1.0.0`, but the additional dependency `mdformat-gfm==0.3.5` requires `mdformat<0.8.0,>=0.7.5`, so pip fails with `ResolutionImpossible` while building the hook environment and every `git commit` in a fresh clone aborts:

```
The conflict is caused by:
    The user requested mdformat 1.0.0 (from .../pre-commit/...)
    mdformat-gfm 0.3.5 depends on mdformat<0.8.0 and >=0.7.5
ERROR: ResolutionImpossible
```

This bumps `mdformat-gfm` to 1.0.0, which supports mdformat 1.0.0 (its requirement is `mdformat>=0.7.5` with no upper bound). Verified locally that the hook environment now installs and the hook runs.

Note: since the hook has been uninstallable for a while, the repo's markdown files have drifted from mdformat's style — with the fixed hook, `pre-commit run mdformat --all-files` currently reformats ~28 files. I left that out of this PR to keep it reviewable; happy to send the mechanical reformat as a follow-up if you'd like.