### PR TITLE
Override the Pathways array handler for OCDBT base checkpoints

### DIFF
--- a/examples/deepswe/train_maxtext_nb.py
+++ b/examples/deepswe/train_maxtext_nb.py
@@ -890,13 +890,41 @@ trainer_devices = devices[
 # ==========================================
 # 7. Model Initialization via MaxText
 # ==========================================
+from etils import epath
 from orbax.checkpoint._src.serialization import jax_array_handlers
 from orbax.checkpoint._src.serialization import type_handler_registry
 
-# Ensure standard ArrayHandler is used for OCDBT base model restore
-type_handler_registry.register_type_handler(
-    jax.Array, jax_array_handlers.ArrayHandler(), override=True
-)
+# pathwaysutils registers CloudPathwaysArrayHandler on init, which reads
+# checkpoint shards on the Pathways workers. It does not support OCDBT yet
+# (b/365549911), so an OCDBT checkpoint has to fall back to the standard
+# ArrayHandler -- but that one reads on the client and materializes whole arrays
+# in the head container's host RAM.
+#
+# So only pay that cost when the checkpoint really is OCDBT. The client-side
+# restore scales with the largest single array rather than with model size,
+# which is why it goes unnoticed at 35B ([256, 10, 2048, 512] = 5.4 GiB, ~18 GB
+# peak) and is fatal at 397B: the scan axis makes every MoE tensor
+# [512, 15, 4096, 1024] = 64 GiB with ~12 in flight, so the head needs ~690 GB
+# and is OOMKilled. Keeping the reads on the workers peaks at 22 GB instead.
+# Note that checkpoint_storage_concurrent_gb does not bound this path.
+#
+# Outside Pathways this is a no-op either way: ArrayHandler is already the
+# default handler for jax.Array.
+if (epath.Path(MODEL_PATH) / "manifest.ocdbt").exists():
+  print(
+      "Base checkpoint is OCDBT, using the standard ArrayHandler:"
+      f" {MODEL_PATH}",
+      flush=True,
+  )
+  type_handler_registry.register_type_handler(
+      jax.Array, jax_array_handlers.ArrayHandler(), override=True
+  )
+else:
+  print(
+      "Base checkpoint is not OCDBT, keeping the registered handler so reads"
+      f" stay on the Pathways workers: {MODEL_PATH}",
+      flush=True,
+  )
 
 (
     qwen_reference,


### PR DESCRIPTION
## Description

`pathwaysutils` registers `CloudPathwaysArrayHandler`, which reads checkpoint shards on the
Pathways workers. It does not support OCDBT (b/365549911), so `train_maxtext_nb.py`
unconditionally re-registered the standard Orbax `ArrayHandler` before the base model
restore. That handler reads on the client and materializes whole arrays in the head
container's host RAM.

The cost scales with the largest single array, not with model size, so it is invisible at
35B and fatal at 397B:

| model | checkpoint | largest array | per array | peak host RAM | result |
|---|---|---|---|---|---|
| 35B | scanned | `[256, 10, 2048, 512]` | 5.4 GiB | ~18 GB | fine |
| 397B | scanned | `[512, 15, 4096, 1024]` | 64 GiB | ~690 GB | OOMKilled |

The scan axis (60 layers / `inhomogeneous_layer_cycle_interval` 4 = 15) inflates every MoE
tensor 15x, and ~12 are in flight at once (4 layer-slots x {`wi_0`, `wi_1`, `wo`}). The head
container is OOMKilled on a 733 GiB node about 12 seconds into the restore, before training
starts.

`checkpoint_storage_concurrent_gb` does not bound this path: dropping it from 96 to 8
produced an identical allocation curve.

Make the override conditional on the checkpoint actually being OCDBT, detected via
`manifest.ocdbt`. OCDBT checkpoints keep the previous behaviour; non-OCDBT ones keep
`CloudPathwaysArrayHandler`, so the reads stay on the workers.

Measured on v5p-512 with Qwen3.5-397B-A17B, everything else identical:

| | peak host RAM | restore throughput | outcome |
|---|---|---|---|
| before | ~690 GB | ~1 GB/s | OOMKilled |
| after | 22 GB | 475 GB/s | completes |

The 35B path is unaffected -- its checkpoint contains `manifest.ocdbt`, so it still takes
the override.

Outside Pathways this is a no-op either way: `ArrayHandler` is already the default handler
for `jax.Array`.

Resolves #\<issue_number_goes_here\>

**Reference**

- b/365549911 -- `CloudPathwaysArrayHandler` does not support OCDBT (the reason the override
  exists at all).

**Colab Notebook**

N/A -- no new API; this changes handler selection inside the existing DeepSWE training
entrypoint.

**Checklist**

- [ ] I have added all the necessary unit tests for my change.
- [x] I have verified that my change does not break existing code and all unit tests pass.
- [x] I have added all appropriate doc-strings/documentation.
- [x] My PR is based on the latest changes of the main branch (if unsure, rebase the code).
- [x] I have signed the [Contributor License Agreement](https://cla.developers.google.com/about).
- [x] I have followed [Contribution Guidelines](https://github.com/google/tunix/blob/main/docs/contributing.md).
