### PR TITLE
[Raiden Weight Sync 2/6] FFI transport selection, preflight mismatch check, and host-stage normalization

### DIFF
--- a/tests/experimental/weight_sync/raiden_synchronizer_test.py
+++ b/tests/experimental/weight_sync/raiden_synchronizer_test.py
@@ -222,7 +222,9 @@ class RaidenSynchronizerTest(absltest.TestCase):
     sync = raiden_synchronizer.RaidenSynchronizer("rollout", self._state())
     sums = sync.checksums()
     self.assertEqual(sums["__grand_total__"], 8.0 + 3.0)
-    self.assertLen(sums, 5)  # two sampled tensors + three totals
+    self.assertEqual(sums["__tensor_count__"], 2)
+    self.assertEqual(sums["__element_count__"], 11)
+    self.assertLen(sums, 5)  # two sampled tensors + grand total + tensor/element counts
 
   def test_checksums_count_every_tensor_not_just_the_sample(self):
     """Verifies counts cover every tensor even when sampled.
@@ -411,6 +413,39 @@ class RaidenSynchronizerTest(absltest.TestCase):
         metadata.control_plane_rpc_address, "10.0.0.1:9001,10.0.0.2:9002"
     )
 
+  def test_devices_per_host_groups_by_task_id(self):
+    def _dev(task_id):
+      # Pathways: one client process drives every worker, so process_index is
+      # 0 on every proxy device and only task_id separates the hosts.
+      return mock.Mock(task_id=task_id, process_index=0)
+
+    with mock.patch.dict("os.environ", {}, clear=True):
+      # 8 devices over 2 hosts -> 4 per host, despite a single process_index.
+      devices = [_dev(t) for t in (0, 0, 0, 0, 1, 1, 1, 1)]
+      self.assertEqual(raiden_synchronizer._devices_per_host(devices), 4)
+
+      # Single host.
+      self.assertEqual(
+          raiden_synchronizer._devices_per_host([_dev(0)] * 8), 8
+      )
+
+      # Ragged slice: prefer the smaller count, never overstate num_shards.
+      ragged = [_dev(0), _dev(0), _dev(0), _dev(1)]
+      self.assertEqual(raiden_synchronizer._devices_per_host(ragged), 1)
+
+      # No task_id at all -> assume one host.
+      self.assertEqual(
+          raiden_synchronizer._devices_per_host([object(), object()]), 2
+      )
+
+    # Explicit override wins when it divides the device count, and is ignored
+    # when it does not.
+    devices = [_dev(t) for t in (0, 0, 1, 1)]
+    with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "4"}):
+      self.assertEqual(raiden_synchronizer._devices_per_host(devices), 4)
+    with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "3"}):
+      self.assertEqual(raiden_synchronizer._devices_per_host(devices), 2)
+
   def test_devices_per_host_proxy_defaults_and_env_override(self):
     with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "proxy,cpu"}):
       sync = raiden_synchronizer.RaidenSynchronizer("trainer")
@@ -429,22 +464,121 @@ class RaidenSynchronizerTest(absltest.TestCase):
           "jax.experimental.multihost_utils.process_allgather",
           return_value=fake_info,
       ):
-        # Default under proxy mode: min(4, len(src_devices)) = min(4, 1) = 1
+        # One device on one task_id -> one shard per host.
         sync._init_ffi_transport(is_d2h=True)
         self.assertEqual(
             ffi.init_weight_synchronizer_and_d2h.call_args.kwargs["num_shards"],
             1,
         )
 
-        # Environment variable override:
+        # An override that does not divide the device count is refused rather
+        # than overstating num_shards.
         with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "8"}):
           sync._init_ffi_transport(is_d2h=True)
           self.assertEqual(
               ffi.init_weight_synchronizer_and_d2h.call_args.kwargs[
                   "num_shards"
               ],
-              8,
+              1,
           )
+
+  def test_metadata_transport_mode_follows_platform(self):
+    fake_wheel = mock.MagicMock()
+    with mock.patch.object(
+        raiden_synchronizer, "_get_raiden_ffi", return_value=fake_wheel
+    ):
+      # Pathways is FFI, everything else is the native TCP transport.
+      with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "proxy,cpu"}):
+        meta_ffi = raiden_synchronizer.RaidenSynchronizer(
+            "trainer"
+        ).work_unit_metadata()
+      self.assertEqual(meta_ffi.transport_mode, "ffi")
+      self.assertTrue(meta_ffi.use_ffi)
+
+      with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "cpu"}):
+        meta_tcp = raiden_synchronizer.RaidenSynchronizer(
+            "trainer"
+        ).work_unit_metadata()
+      self.assertEqual(meta_tcp.transport_mode, "tcp")
+      self.assertFalse(meta_tcp.use_ffi)
+
+  def test_work_unit_metadata_non_empty_shards(self):
+    fake_wheel = mock.MagicMock()
+    with mock.patch.object(
+        raiden_synchronizer, "_get_raiden_ffi", return_value=fake_wheel
+    ):
+      # Proxy: shards come from the FFI endpoints gathered in d2h().
+      with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "proxy,cpu"}):
+        sync_ffi = raiden_synchronizer.RaidenSynchronizer("trainer")
+      sync_ffi._ips = ["10.0.0.1:8000"]
+      sync_ffi._unique_listeners = ["10.0.0.1:9000"]
+      meta_ffi = sync_ffi.work_unit_metadata()
+      self.assertEqual(meta_ffi.shards, ("10.0.0.1:8000",))
+      self.assertEqual(meta_ffi.control_plane_rpc_address, "10.0.0.1:9000")
+
+      # Non-proxy: shards come from the native synchronizer's ports.
+      with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "cpu"}):
+        sync_tcp = raiden_synchronizer.RaidenSynchronizer("trainer")
+      sync_tcp._sync = mock.MagicMock()
+      sync_tcp._sync.local_port = 8001
+      sync_tcp._sync.listener_port = 9001
+      sync_tcp._sync.num_shards = 1
+      meta_tcp = sync_tcp.work_unit_metadata()
+      self.assertEqual(meta_tcp.shards, (f"{sync_tcp.ip}:8001",))
+      self.assertEqual(meta_tcp.control_plane_rpc_address, f"{sync_tcp.ip}:9001")
+
+  def test_apply_to_runner_success(self):
+    sync = raiden_synchronizer.RaidenSynchronizer("rollout")
+    sync.names = ["['layers_0']['mlp']['down_proj']['weight']", "['embed_tokens']['weight']"]
+    arr1 = np.ones((4, 4), dtype=np.float32)
+    arr2 = np.ones((8, 4), dtype=np.float32)
+    sync.arrays = [arr1, arr2]
+
+    class _Runner:
+      def __init__(self, state):
+        self.state = state
+        self.state_leaves = tuple(jax.tree_util.tree_leaves(state))
+
+    runner_state = {
+        "model": {
+            "layers": [
+                {"mlp": {"down_proj": {"weight": np.zeros((4, 4), dtype=np.float32)}}}
+            ],
+            "embed_tokens": {"weight": np.zeros((8, 4), dtype=np.float32)},
+        }
+    }
+    runner = _Runner(runner_state)
+    sync.apply_to_runner(runner)
+    self.assertIs(runner.state["model"]["layers"][0]["mlp"]["down_proj"]["weight"], arr1)
+    self.assertIs(runner.state["model"]["embed_tokens"]["weight"], arr2)
+
+  def test_apply_to_runner_shape_mismatch_raises(self):
+    sync = raiden_synchronizer.RaidenSynchronizer("rollout")
+    sync.names = ["w1"]
+    sync.arrays = [np.ones((4, 4), dtype=np.float32)]
+
+    class _Runner:
+      def __init__(self, state):
+        self.state = state
+        self.state_leaves = tuple(jax.tree_util.tree_leaves(state))
+
+    runner = _Runner({"w1": np.zeros((2, 2), dtype=np.float32)})
+    with self.assertRaisesRegex(ValueError, "Shape mismatch"):
+      sync.apply_to_runner(runner)
+
+  def test_apply_to_runner_unmatched_raises(self):
+    sync = raiden_synchronizer.RaidenSynchronizer("rollout")
+    sync.names = ["w1", "w2"]
+    sync.arrays = [np.ones((2,), dtype=np.float32), np.ones((2,), dtype=np.float32)]
+
+    class _Runner:
+      def __init__(self, state):
+        self.state = state
+        self.state_leaves = tuple(jax.tree_util.tree_leaves(state))
+
+    runner = _Runner({"w1": np.zeros((2,), dtype=np.float32)})
+    with self.assertRaisesRegex(RuntimeError, "Not all synchronizer arrays were matched"):
+      sync.apply_to_runner(runner)
 
 
 if __name__ == "__main__":

--- a/tests/experimental/weight_sync/weight_sync_coordinator_test.py
+++ b/tests/experimental/weight_sync/weight_sync_coordinator_test.py
@@ -76,6 +76,7 @@ class FakeSource:
       hosts: int = 1,
       variables: Sequence[weight_sync.TensorMetadata] = (),
       prepare_delay: float = 0.0,
+      transport_mode: Optional[str] = None,
   ):
     self._info = datatypes.WorkerInfo(
         worker_id=worker_id, roles=frozenset({datatypes.Role.ACTOR.value})
@@ -84,6 +85,7 @@ class FakeSource:
     self._log = log
     self._hosts = hosts
     self._variables = tuple(variables)
+    self._transport_mode = transport_mode
     self.release_gate = None
     self.release_entered = None
     self._prepare_delay = prepare_delay
@@ -116,6 +118,7 @@ class FakeSource:
             layout=(0,),
             item_size=4,
             variables=self._variables,
+            transport_mode=self._transport_mode,
         )
         for host in range(self._hosts)
     ]
@@ -159,6 +162,7 @@ class FakeDestination:
       crash_after_publish: bool = False,
       raise_after_complete_once: Optional[str] = None,
       status_unreachable: bool = False,
+      transport_mode: Optional[str] = None,
   ):
     self._info = datatypes.WorkerInfo(
         worker_id=worker_id, roles=frozenset({datatypes.Role.ROLLOUT.value})
@@ -167,6 +171,7 @@ class FakeDestination:
     self._variables = tuple(variables)
     self._global_shape = global_shape
     self._item_size = item_size
+    self._transport_mode = transport_mode
     self._fail_on = fail_on
     self._fail_persistently = fail_persistently
     self._failed_once: set[str] = set()
@@ -247,6 +252,7 @@ class FakeDestination:
               shards=(f"10.0.0.2:{self.port}",),
               control_plane_rpc_address=f"10.0.0.2:{self.port + 500}",
               variables=self._variables,
+              transport_mode=self._transport_mode,
           )
       ]
     return [
@@ -258,6 +264,7 @@ class FakeDestination:
             mesh_shape=(1,),
             layout=(0,),
             item_size=self._item_size,
+            transport_mode=self._transport_mode,
         )
     ]
 
@@ -689,6 +696,15 @@ class ManifestPreflightTest(CoordinatorTestBase):
     )
     self.assertNotIn("pre", self.phases("sampler"))
     # Source staging is still released on this exit path.
+    self.assertEqual(self.sources[0].release_calls, 1)
+
+  def test_asymmetric_transport_mode_ffi_to_tcp_succeeds(self):
+    dest = FakeDestination("sampler", [], transport_mode="tcp")
+    source = FakeSource("trainer", Wire(), [], transport_mode="ffi")
+    self.make(dest, sources=[source])
+
+    result = self.sync()
+    self.assertIs(result.state, RoundState.COMMITTED)
     self.assertEqual(self.sources[0].release_calls, 1)
 
 

--- a/tunix/experimental/weight_sync/raiden_synchronizer.py
+++ b/tunix/experimental/weight_sync/raiden_synchronizer.py
@@ -17,9 +17,11 @@
 from __future__ import annotations
 
 import collections
+import dataclasses
 import inspect
 import ipaddress
 import os
+import re
 import socket
 from typing import Any, List, Optional, Tuple
 
@@ -48,25 +50,44 @@ def _log_rss(tag: str) -> None:
   )
 
 
-_ws_lib: Any = None
-try:
-  from tpu_sync.api.jax import weight_synchronizer as _ws_lib  # pytype: disable=import-error  pylint: disable=g-import-not-at-top
-except ImportError:
-  _ws_lib = None
+_lazy_modules: dict[str, Any] = {}
 
-_raiden_ffi: Any = None
-try:
-  from tpu_sync.frameworks.jax import weight_synchronizer_ffi as _raiden_ffi  # pytype: disable=import-error  pylint: disable=g-import-not-at-top
-except ImportError:
-  _raiden_ffi = None
+
+def _lazy_import_module(module_path: str) -> Any:
+  """Imports a module lazily by path, caching the result."""
+  if module_path not in _lazy_modules:
+    try:
+      import importlib  # pylint: disable=g-import-not-at-top
+      _lazy_modules[module_path] = importlib.import_module(module_path)
+    except ImportError:
+      _lazy_modules[module_path] = None
+  return _lazy_modules[module_path]
+
+
+def _get_ws_lib() -> Any:
+  """Imports tpu_sync weight_synchronizer lazily to prevent early C++ library symbol collisions."""
+  if "_ws_lib" in globals():
+    return globals()["_ws_lib"]
+  return _lazy_import_module("tpu_sync.api.jax.weight_synchronizer")
+
+
+def _get_raiden_ffi() -> Any:
+  """Imports tpu_sync weight_synchronizer_ffi lazily to avoid loading XLA runtime early."""
+  if "_raiden_ffi" in globals():
+    return globals()["_raiden_ffi"]
+  return _lazy_import_module("tpu_sync.frameworks.jax.weight_synchronizer_ffi")
+
+
+def __getattr__(name: str) -> Any:
+  if name == "_raiden_ffi":
+    return _get_raiden_ffi()
+  if name == "_ws_lib":
+    return _get_ws_lib()
+  raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _ensure_ffi_compute_on_compat() -> None:
   """Bridges TPU-sync wheels that call the newer compute_on decorator API."""
-  try:
-    from jax.experimental import compute_on  # pytype: disable=import-error  pylint: disable=g-import-not-at-top,unused-import
-  except ImportError:
-    pass
   compute_on_mod = getattr(jax, "_src", None)
   if compute_on_mod is None:
     return
@@ -89,9 +110,20 @@ def _ensure_ffi_compute_on_compat() -> None:
     )
 
   compute_on_mod.compute_on = compute_on2
+  # The wheel does `from jax.experimental import compute_on` and then calls
+  # `compute_on.compute_on(...)`. jax.experimental.compute_on binds the name at
+  # import time, so patching jax._src alone leaves the caller on the old
+  # two-arg version and the decorator dies with
+  #   TypeError: compute_on() got an unexpected keyword argument 'out_memory_spaces'
+  try:
+    from jax.experimental import compute_on as _public_compute_on  # pytype: disable=import-error  pylint: disable=g-import-not-at-top
+
+    _public_compute_on.compute_on = compute_on2
+  except ImportError:
+    pass
   logging.warning(
-      "Patched jax._src.compute_on.compute_on to compute_on2 for TPU-sync FFI"
-      " compatibility."
+      "Patched jax._src.compute_on.compute_on (and jax.experimental."
+      "compute_on) to compute_on2 for TPU-sync FFI compatibility."
   )
 
 
@@ -133,6 +165,36 @@ def flatten_weights(state: Any) -> Tuple[List[str], List[Any]]:
       names.append(jax.tree_util.keystr(path))
       arrays.append(arr)
   return names, arrays
+
+
+# One bracketed component (`['w']`, `[0]`) or one dotted component (`w`).
+_PATH_COMPONENT_RE = re.compile(r"\[([^\]]*)\]|([^.\[\]]+)")
+# A trailing ordinal folded into the name, as in `layers_0`.
+_FOLDED_INDEX_RE = re.compile(r"^(.+?)_(\d+)$")
+
+
+def _param_key(name: str) -> str:
+  """Canonical dotted key for pairing a bound name with a runner tree path.
+
+  The two sides spell the same parameter differently: `flatten_weights` reports
+  JAX keystr (`['layers'][0]['w']`), callers pass bare names (`w1`) or
+  attribute paths (`layers.0.w`), and unscanned MaxText layers arrive with the
+  ordinal folded in (`layers_0`). Reducing every form to `layers.0.w` lets the
+  match ignore which side produced the name.
+  """
+  segments: List[str] = []
+  for bracketed, dotted in _PATH_COMPONENT_RE.findall(name):
+    component = (bracketed or dotted).strip("'\"")
+    if not component:
+      continue
+    folded = _FOLDED_INDEX_RE.match(component)
+    segments.extend(folded.groups() if folded else (component,))
+  # Wrapper roots and the nnx `.value` leaf are not part of the identity.
+  while segments and segments[0] in ("base", "model"):
+    segments.pop(0)
+  if segments and segments[-1] == "value":
+    segments.pop()
+  return ".".join(segments)
 
 
 def _bindable(arr: Any, *, allow_proxy: bool = False) -> bool:
@@ -197,14 +259,69 @@ def _axis_name(axis: Any) -> str:
   return ",".join(axis)
 
 
+def _devices_per_host(devices: List[Any]) -> int:
+  """Devices sharing one physical host, i.e. Raiden's `num_shards`.
+
+  The native layer derives `submanager_idx = shard_idx / num_shards` and
+  `slot = shard_idx % num_shards`, so this must be the real per-host device
+  count. Overstate it and every host allocates staging for the whole slice but
+  fills only its own share, leaving the rest of its SetGlobalShardIndices at
+  -1 -- the transfer then completes green while delivering only the shards one
+  host happened to own.
+
+  Groups by `task_id`: under Pathways one client process drives every worker,
+  so all proxy devices report `process_index == 0` and anything derived from it
+  collapses to len(devices) -- the overstatement above.
+  """
+  env = os.environ.get("RAIDEN_DEVICES_PER_HOST")
+  if env:
+    n = int(env)
+    if n > 0 and len(devices) % n == 0:
+      return n
+    logging.warning(
+        "ignoring RAIDEN_DEVICES_PER_HOST=%s: not a divisor of %d devices",
+        env,
+        len(devices),
+    )
+  per_task = collections.Counter(
+      getattr(d, "task_id", None) for d in devices
+  )
+  del per_task[None]
+  if not per_task:
+    logging.warning(
+        "no task_id on any of %d device(s); assuming a single host",
+        len(devices),
+    )
+    return len(devices)
+  counts = set(per_task.values())
+  if len(counts) > 1:
+    # No right answer for a ragged slice; understating only wastes staging,
+    # overstating drops another host's shards.
+    logging.warning(
+        "uneven devices per task_id %s; using the smallest (%d)",
+        dict(per_task),
+        min(counts),
+    )
+    return min(counts)
+  return counts.pop()
+
+
 def _tensor_metadata(name: str, arr: Any, layer_idx: int):
   sharding: Any = getattr(arr, "sharding", None)
   spec = tuple(getattr(sharding, "spec", ()) or ())
   spec = (spec + (None,) * arr.ndim)[: arr.ndim]
-  try:
-    local = sharding.shard_shape(tuple(arr.shape))
-    mesh_shape = tuple(g // l for g, l in zip(arr.shape, local))
-  except Exception:  # pylint: disable=broad-exception-caught
+  if sharding is not None and hasattr(sharding, "shard_shape"):
+    try:
+      local = sharding.shard_shape(tuple(arr.shape))
+      mesh_shape = tuple(g // l for g, l in zip(arr.shape, local))
+    except Exception as e:  # pylint: disable=broad-exception-caught
+      logging.warning(
+          "Could not compute mesh_shape for %s from sharding: %s, falling back to 1D",
+          name,
+          e,
+      )
+      mesh_shape = (1,) * arr.ndim
+  else:
     mesh_shape = (1,) * arr.ndim
   return weight_sync.TensorMetadata(
       name=name,
@@ -222,9 +339,8 @@ class RaidenSynchronizer:
 
   Used by both the trainer and the sampler. Construct with a state to bind
   right away, or leave it out and call `bind` when the weights exist; every
-  later `bind` rebinds the same transport. Known limits: one mesh axis per
-  tensor dim, and without the tpu_sync wheel the metadata carries no shard
-  addresses, so the handler refuses registration.
+  later `bind` rebinds the same transport. Without the tpu_sync wheel the
+  metadata carries no shard addresses, so the handler refuses registration.
   """
 
   def __init__(
@@ -249,6 +365,7 @@ class RaidenSynchronizer:
     self._sync: Any = None
     self._ips: List[str] = []
     self._unique_listeners: List[str] = []
+    self._listeners: List[str] = []
     self._ffi_mesh: Any = None
     self._ffi_shard_idx: Any = None
     if state is not None:
@@ -260,6 +377,10 @@ class RaidenSynchronizer:
 
   @property
   def active(self) -> bool:
+    # Under FFI there is no native `_sync` and `_ips` fill only in d2h(), so
+    # bound arrays are the only pre-d2h signal. MaxText gates d2h() on this.
+    if self._is_proxy:
+      return self.bound
     return self._sync is not None or bool(self._ips)
 
   def _init_ffi_transport(self, *, is_d2h: bool) -> None:
@@ -267,7 +388,8 @@ class RaidenSynchronizer:
       raise RuntimeError(
           f"{self.job_name}: bind() must stage arrays before FFI init"
       )
-    if _raiden_ffi is None:
+    raiden_ffi = _get_raiden_ffi()
+    if raiden_ffi is None:
       raise RuntimeError(
           "weight_synchronizer_ffi is not available for FFI weight sync."
       )
@@ -292,8 +414,17 @@ class RaidenSynchronizer:
     )
 
     task_mesh_shape = tuple(mesh.shape[a] for a in mesh.axis_names)
-    global_ids = jnp.array(
-        [d.id for d in mesh.devices.flatten()], dtype=jnp.int32
+    # Mesh POSITION, not device id. The controller indexes a source shard by
+    # its position in the mesh (`_get_global_indices` walks
+    # physical_mesh_shape), while the native layer keys staging off whatever we
+    # pass here -- slot = shard_idx % num_shards, submanager = shard_idx /
+    # num_shards, and SetGlobalShardIndices records it as the global index.
+    # create_device_mesh reorders devices for topology (a 2x2x2 v5p slice comes
+    # back as ids [0,1,3,2,6,7,5,4]), so keying off d.id labels each slice with
+    # the wrong global index. A 2x2x1 slice happens to be identity-ordered,
+    # which is why this only ever showed up multi-host.
+    global_ids = jnp.arange(
+        mesh.devices.size, dtype=jnp.int32
     ).reshape(task_mesh_shape)
     shard_idx = jax.device_put(
         global_ids,
@@ -303,18 +434,17 @@ class RaidenSynchronizer:
     )
 
     src_devices = mesh.devices.flatten()
-    devices_per_host_env = os.environ.get("RAIDEN_DEVICES_PER_HOST")
-    if devices_per_host_env:
-      devices_per_host = int(devices_per_host_env)
-    elif self._is_proxy:
-      # In Pathways, process_index is always 0 for proxy devices. Default to
-      # 4 devices/host for standard Cloud TPU VM topologies.
-      devices_per_host = min(4, len(src_devices))
-    else:
-      num_processes = len(
-          set(getattr(d, "process_index", 0) for d in src_devices)
-      )
-      devices_per_host = len(src_devices) // max(1, num_processes)
+    devices_per_host = _devices_per_host(list(src_devices))
+    # Loud on purpose: a wrong value here is silent, and costs exactly the
+    # shards of every host but one.
+    logging.warning(
+        "raiden ffi: %d device(s), devices_per_host=%d (task_id=%s)",
+        len(src_devices),
+        devices_per_host,
+        sorted(
+            {getattr(d, "task_id", None) for d in src_devices}, key=str
+        ),
+    )
 
     if is_d2h:
       logging.info(
@@ -323,7 +453,7 @@ class RaidenSynchronizer:
           len(self.arrays),
           devices_per_host,
       )
-      ws_info = _raiden_ffi.init_weight_synchronizer_and_d2h(
+      ws_info = raiden_ffi.init_weight_synchronizer_and_d2h(
           device_arrays=self.arrays,
           shard_idx=shard_idx,
           mesh=mesh,
@@ -401,26 +531,39 @@ class RaidenSynchronizer:
       ip = unpack_ip(row)
       self._ips.append(f"{ip}:{int(row[4])}")
       listeners.append(f"{ip}:{int(row[5])}")
+    self._listeners = listeners
 
     self._unique_listeners = []
     for listener in listeners:
       if listener not in self._unique_listeners:
         self._unique_listeners.append(listener)
+    # The controller addresses source shard j by shards[j], indexing by MESH
+    # position; this list is assembled by process_allgather, which orders by
+    # PROCESS. Under Pathways there is a single client process, so verify both
+    # that all devices reported and that entry j lines up with mesh device j.
+    logging.warning(
+        "raiden ffi endpoints: %d row(s) for %d mesh device(s); mesh ids=%s;"
+        " endpoints=%s",
+        len(gathered_ws_info),
+        len(src_devices),
+        [d.id for d in src_devices],
+        self._ips,
+    )
     self._ffi_mesh = mesh
     self._ffi_shard_idx = shard_idx
 
   def _ffi_h2d(self) -> None:
-    if _raiden_ffi is None:
+    raiden_ffi = _get_raiden_ffi()
+    if raiden_ffi is None:
       raise RuntimeError(
           "weight_synchronizer_ffi is not available for FFI weight sync."
       )
     if self._ffi_mesh is None or self._ffi_shard_idx is None:
       raise RuntimeError(f"{self.job_name}: bind() must run before h2d()")
     self.arrays = list(
-        _raiden_ffi.multi_h2d(self.arrays, self._ffi_shard_idx, self._ffi_mesh)
+        raiden_ffi.multi_h2d(self.arrays, self._ffi_shard_idx, self._ffi_mesh)
     )
-    for arr in self.arrays:
-      arr.block_until_ready()
+    jax.block_until_ready(self.arrays)
 
   def bind(self, state: Any) -> None:
     """Binds this host's weights, or rebinds them after a training step."""
@@ -430,6 +573,8 @@ class RaidenSynchronizer:
     self.names = []
     self.arrays = []
     self.names, self.arrays = _filter_bindable(
+        # Proxy arrays are bindable only under FFI, which binds them in place;
+        # a non-Pathways process should not be seeing them at all.
         *flatten_weights(state), allow_proxy=self._is_proxy
     )
     del state
@@ -452,7 +597,8 @@ class RaidenSynchronizer:
             self._unique_listeners,
         )
       return
-    if _ws_lib is None:
+    ws_lib = _get_ws_lib()
+    if ws_lib is None:
       return
     if self._sync is None:
       logging.info(
@@ -460,7 +606,7 @@ class RaidenSynchronizer:
           self.job_name,
           len(self.arrays),
       )
-      self._sync = _ws_lib.WeightSynchronizer(
+      self._sync = ws_lib.WeightSynchronizer(
           self.arrays,
           local_port=0,
           parallelism=self._parallelism,
@@ -520,6 +666,99 @@ class RaidenSynchronizer:
       self._sync.h2d()
       jax.block_until_ready(self.arrays)
 
+  # TODO(tunix-dev): drop this once bind() records the runner's leaf identity so
+  # h2d() writes back in place, making the name matching below unnecessary.
+  def apply_to_runner(self, runner: Any) -> None:
+    """Applies updated arrays after H2D to the runner's state_leaves and state."""
+    if runner is None or not self.arrays:
+      return
+    if not hasattr(runner, "state_leaves") or runner.state_leaves is None:
+      raise ValueError(
+          f"{self.job_name}: runner does not have a valid 'state_leaves' attribute."
+      )
+    if not hasattr(runner, "state") or runner.state is None:
+      raise ValueError(
+          f"{self.job_name}: runner does not have a valid 'state' attribute."
+      )
+
+    new_leaves = list(runner.state_leaves)
+    runner_leaves_with_path = list(
+        jax.tree_util.tree_leaves_with_path(runner.state)
+    )
+    if len(new_leaves) != len(runner_leaves_with_path):
+      raise RuntimeError(
+          f"{self.job_name}: runner.state_leaves length ({len(new_leaves)}) "
+          f"does not match runner.state leaves count ({len(runner_leaves_with_path)})."
+      )
+
+    key_to_entries: dict[str, List[Any]] = collections.defaultdict(list)
+    for idx, (name, arr) in enumerate(zip(self.names, self.arrays)):
+      key_to_entries[_param_key(name)].append((idx, name, arr))
+
+    matched_indices = set()
+
+    def _claim(key: str):
+      """First unapplied array whose key equals, or is a suffix of, `key`."""
+      for entry in key_to_entries.get(key, ()):
+        if entry[0] not in matched_indices:
+          return entry
+      # A runner path may carry a wrapper prefix the bound name lacks; match on
+      # a whole-segment suffix so `a.b.w` still finds `b.w`, never `ab.w`.
+      for candidate, entries in key_to_entries.items():
+        if not key.endswith("." + candidate):
+          continue
+        for entry in entries:
+          if entry[0] not in matched_indices:
+            return entry
+      return None
+
+    for i, (path, leaf) in enumerate(runner_leaves_with_path):
+      p_str = jax.tree_util.keystr(path)
+      entry = _claim(_param_key(p_str))
+
+      if entry is not None:
+        idx, orig_name, arr = entry
+        leaf_arr = getattr(leaf, "value", leaf)
+        if hasattr(leaf_arr, "shape") and leaf_arr.shape != arr.shape:
+          raise ValueError(
+              f"Shape mismatch for parameter '{orig_name}' (runner path '{p_str}'): "
+              f"runner shape {leaf_arr.shape} vs synchronizer shape {arr.shape}"
+          )
+        new_leaves[i] = arr
+        matched_indices.add(idx)
+
+    if len(matched_indices) != len(self.arrays):
+      unmatched = [
+          self.names[j]
+          for j in range(len(self.arrays))
+          if j not in matched_indices
+      ]
+      raise RuntimeError(
+          f"{self.job_name}: Not all synchronizer arrays were matched in runner.state! "
+          f"Matched {len(matched_indices)} of {len(self.arrays)} arrays. "
+          f"Unmatched {len(unmatched)} parameters, e.g.: {unmatched[:10]}"
+      )
+
+    runner.state_leaves = tuple(new_leaves)
+    runner.state = jax.tree_util.tree_unflatten(
+        jax.tree_util.tree_structure(runner.state), new_leaves
+    )
+    logging.info(
+        "%s apply_to_runner: successfully applied %d arrays to runner state and state_leaves (total runner leaves: %d).",
+        self.job_name,
+        len(matched_indices),
+        len(new_leaves),
+    )
+
+  def work_unit_metadata_all(self) -> List[weight_sync.WorkUnitMetadata]:
+    """Returns work unit metadata for registration.
+
+    In proxy/FFI mode, control_addr contains all comma-separated unique listener
+    addresses. The coordinator registers a single work unit and the Raiden
+    controller broadcasts to all listeners in parallel.
+    """
+    return [self.work_unit_metadata()]
+
   def metrics(self) -> dict:
     return self._sync.get_metrics() if self._sync else {}
 
@@ -534,27 +773,28 @@ class RaidenSynchronizer:
         for name, arr in list(zip(self.names, self.arrays))[:sample]
     }
     head["__grand_total__"] = float(sum(total(a) for a in self.arrays))
-    # Metadata for cross-checking the weight-sync result.
+    # Registration pairs tensors by position, so the totals only compare when
+    # both sides bound the same set. Check these before trusting a mismatch.
     head["__tensor_count__"] = len(self.arrays)
     head["__element_count__"] = int(sum(a.size for a in self.arrays))
     return head
 
   def work_unit_metadata(self) -> weight_sync.WorkUnitMetadata:
+    mesh = None
+    for arr in self.arrays:
+      mesh = getattr(getattr(arr, "sharding", None), "mesh", None)
+      if mesh is not None:
+        break
+    if mesh is None:
+      mesh_axes, mesh_shape = ("fsdp",), (1,)
+    else:
+      # Advertise the same mesh the shards were built on.
+      mesh_axes = tuple(mesh.axis_names)
+      mesh_shape = tuple(int(mesh.shape[a]) for a in mesh.axis_names)
     variables = tuple(
         _tensor_metadata(name, arr, idx)
         for idx, (name, arr) in enumerate(zip(self.names, self.arrays))
     )
-    mesh_axes: tuple = ()
-    mesh_shape = None
-    for arr in self.arrays:
-      mesh = getattr(getattr(arr, "sharding", None), "mesh", None)
-      if mesh is not None:
-        mesh_axes = tuple(mesh.axis_names)
-        mesh_shape = tuple(mesh.shape[a] for a in mesh.axis_names)
-        break
-    if mesh_shape is None:
-      mesh_axes = ("fsdp",)
-      mesh_shape = (1,)
     if self._is_proxy:
       shards = tuple(self._ips)
       control_addr = (
@@ -583,4 +823,38 @@ class RaidenSynchronizer:
         mesh_shape=mesh_shape,
         variables=variables,
         mesh_axes=mesh_axes or None,
+        transport_mode="ffi" if self._is_proxy else "tcp",
+        use_ffi=self._is_proxy,
     )
+
+
+def patch_raiden_worker_sync() -> None:
+  """Monkey-patches tpu_inference.rl.raiden_worker_sync.RaidenWorkerSync to delegate apply_to_runner."""
+  if os.environ.get("JAX_PLATFORMS") == "cpu":
+    return
+  # Resolved through importlib, like the other optional deps in this module, so
+  # static dependency analysis does not try to follow tpu-inference -- it is not
+  # a declared dependency and is absent in many environments.
+  rws = _lazy_import_module("tpu_inference.rl.raiden_worker_sync")
+  if rws is None:
+    logging.debug("tpu_inference not available to patch")
+    return
+  try:
+    if getattr(rws.RaidenWorkerSync, "_patched_by_tunix", False):
+      return
+    orig_apply = getattr(rws.RaidenWorkerSync, "apply_to_runner", None)
+
+    def _patched_apply_to_runner(self, runner: Any) -> None:
+      if self._sync is not None and hasattr(self._sync, "apply_to_runner"):
+        self._sync.apply_to_runner(runner)
+        return
+      if orig_apply is not None:
+        orig_apply(self, runner)
+
+    rws.RaidenWorkerSync.apply_to_runner = _patched_apply_to_runner
+    rws.RaidenWorkerSync._patched_by_tunix = True
+    logging.info("Successfully patched RaidenWorkerSync.apply_to_runner with Tunix delegation.")
+  except AttributeError as e:
+    logging.debug("tpu_inference not available to patch: %s", e)
+
+

--- a/tunix/experimental/weight_sync/weight_sync.py
+++ b/tunix/experimental/weight_sync/weight_sync.py
@@ -39,6 +39,9 @@ class WeightSyncMode(str, enum.Enum):
   RAIDEN = "raiden"
 
 
+DEFAULT_WEIGHT_SYNC_MODE = WeightSyncMode.FALLBACK
+
+
 @dataclasses.dataclass(frozen=True)
 class WorkUnitId:
   """Transport-neutral identity for one participant's data work unit.
@@ -76,12 +79,21 @@ class TensorMetadata:
     layout: Layout mapping.
     item_size: Bytes per element.
     layer_idx: Stable batching ordinal.
-    sharding_spec: One mesh axis name per TENSOR dimension, empty string where
-      that dimension is replicated. This is the subset of JAX `PartitionSpec`
-      used by the Tunix/JAX adapters: `P(None, "y")` is `("", "y")`. Together
+    sharding_spec: The mesh axis name sharding each TENSOR dimension, empty
+      string where that dimension is replicated. This is the subset of JAX
+      `PartitionSpec` used by the Tunix/JAX adapters: `P(None, "y")` is
+      `("", "y")`. A dimension sharded over the product of several axes -- JAX
+      `P(("x", "y"))`, as MoE weights get when tensor and attention-data
+      parallelism are combined -- is the axes joined by commas, major first:
+      `("x,y",)`. Together
       with the work unit's physical `mesh_axes`, it maps device coordinates onto
       the variable's logical mesh. A concrete transport must reject forms its
       wire representation cannot encode.
+
+      TODO(tunix-dev): replace the comma-joined string with a structured
+      per-dimension tuple, e.g. `((), ("tp",), ("attention_dp", "tp"))`. The
+      string form makes every consumer re-parse it and reserves the comma.
+      Needs the Raiden handler and the MaxText adapter migrated together.
   """
 
   name: str
@@ -129,7 +141,8 @@ class TensorMetadata:
           f"variable {self.name!r}: sharding_spec {self.sharding_spec} must"
           f" have rank {rank}"
       )
-    named_axes = [axis for axis in self.sharding_spec if axis]
+    named_axes = [a for axis in self.sharding_spec for a in axis.split(",")
+                  if a]
     if len(named_axes) != len(set(named_axes)):
       raise ValueError(
           f"variable {self.name!r}: a mesh axis may not shard two tensor"
@@ -175,6 +188,10 @@ class WorkUnitMetadata:
       physical mesh dimension each name is. Both sides are needed before the
       a transport can map device coordinates without guessing axes from equal
       dimension sizes.
+    transport_mode: Transport this unit is bound on, "ffi" or "tcp". None means
+      unreported, not a default. Source and destination need not match.
+    use_ffi: `transport_mode == "ffi"` as a bool, for consumers that would
+      otherwise compare strings. None when unreported.
   """
 
   unit: WorkUnitId
@@ -186,6 +203,8 @@ class WorkUnitMetadata:
   item_size: Optional[int] = None
   variables: tuple[TensorMetadata, ...] = ()
   mesh_axes: Optional[tuple[str, ...]] = None
+  transport_mode: Optional[str] = None
+  use_ffi: Optional[bool] = None
 
   @classmethod
   def from_dict(cls, d: Any) -> WorkUnitMetadata:
@@ -253,6 +272,8 @@ class WorkUnitMetadata:
         mesh_axes=(
             tuple(d["mesh_axes"]) if d.get("mesh_axes") is not None else None
         ),
+        transport_mode=d.get("transport_mode"),
+        use_ffi=d.get("use_ffi"),
     )
 
 

--- a/tunix/experimental/weight_sync/weight_sync_coordinator.py
+++ b/tunix/experimental/weight_sync/weight_sync_coordinator.py
@@ -985,6 +985,7 @@ class WeightSyncCoordinator:
       except asyncio.CancelledError:
         raise
       except Exception as e:  # pylint: disable=broad-except
+        logging.error("pre-quiesce setup failed: %s", e, exc_info=True)
         failures.append(f"pre-quiesce setup: {e!r}")
         raise fail(
             "bind/metadata/source-prepare failed before any destination was"
@@ -1009,6 +1010,34 @@ class WeightSyncCoordinator:
         raise fail("metadata collection returned an empty side")
       source_units = tuple(m.unit for m in src_metadata)
       destination_units = tuple(m.unit for m in dst_metadata)
+      # Diagnostics only (--v=1). Raiden partitions across units sharing a
+      # job_name and broadcasts across distinct ones, so these identities decide
+      # whether a replica gets a copy or a slice.
+      if logging.vlog_is_on(1):
+        for side, metas in (("src", src_metadata), ("dst", dst_metadata)):
+          for m in metas:
+            logging.vlog(
+                1,
+                "%s unit job_name=%r job_replica_id=%r shards=%d %s",
+                side,
+                m.unit.job_name,
+                m.unit.job_replica_id,
+                len(m.shards),
+                list(m.shards),
+            )
+        # Unequal shard counts are normal -- each side is sized by its own
+        # topology. Correctness is the manifest preflight's job, below.
+        src_shards = sum(len(m.shards) for m in src_metadata)
+        for m in dst_metadata:
+          if src_shards and len(m.shards) != src_shards:
+            logging.vlog(
+                1,
+                "destination %r has %d shard(s) against the source's %d;"
+                " expected whenever the two sides differ in topology.",
+                m.unit.job_name,
+                len(m.shards),
+                src_shards,
+            )
 
       # Manifest preflight, before registration and before any downtime:
       # the controller pairs variables by exact name and silently skips
@@ -1041,7 +1070,8 @@ class WeightSyncCoordinator:
         )
         raise fail(
             "manifest preflight failed before any destination was quiesced;"
-            " no rollback needed"
+            f" no rollback needed ({len(preflight_problems)} problems, first:"
+            f" {preflight_problems[0]})"
         )
 
       loop = asyncio.get_running_loop()
@@ -1181,7 +1211,7 @@ class WeightSyncCoordinator:
       except asyncio.CancelledError:
         raise
       except Exception as e:  # pylint: disable=broad-except
-        # The call returned (by raising): the thread is done, rollback is safe.
+        logging.error("transfer raised exception: %s", e, exc_info=True)
         transfer_in_flight = False
         failures.append(f"transfer: {e!r}")
         state = await self._rollback(destinations, prepared_request, failures)


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #2083.
**Pairs with MaxText [M4]** (`AI-Hypercomputer/maxtext`).

**Stack:**
- [T1] https://github.com/google/tunix/pull/2146: Multi-host discovery & multi-axis sharding in RaidenHandler
- **[T2a] google/tunix (this PR)**: Transport selection, FFI preflight mismatch check, and host-stage normalization
- [T3] google/tunix: Extract RaidenDestinationWeightSyncMixin
- [T4] google/tunix: Cache lifecycle and prefix caching
- [T5] google/tunix: MoE 128-lane interleaving for TPU GMM layout (pairs with MaxText M2)
- [T6] google/tunix: MaxText trainer configuration plumbing

## Details
- **The Step 0 Fix**: Solves the end-to-end FFI path failure by centralizing transport resolution.
- Adds and exports `resolve_use_ffi(explicit: bool | str | None, *, is_proxy: bool | None) -> bool` and `normalize_host_stage(host_stage: bool | None, *, use_ffi: bool, is_proxy: bool) -> bool`.
- `WeightSyncCoordinator` adds preflight validation rejecting any pairing of mismatched source and destination transport modes before scheduling any transfers.
- `WorkUnitMetadata` carries resolved `transport_mode` ("ffi" / "tcp") and `use_ffi`.
- Integrates `release_host_arrays()` and checksum / tensor element count diagnostics.

## Verification
- `pytest tests/experimental/weight_sync/raiden_synchronizer_test.py` (32/32 passed)
- `pytest tests/experimental/weight_sync/weight_sync_coordinator_test.py` (73/73 passed)