### PR TITLE
[Raiden Weight Sync 3/6] Extract RaidenDestinationWeightSyncMixin for rollout samplers

### DIFF
--- a/tests/experimental/rollout/inprocess_vllm_sampler_adapter_test.py
+++ b/tests/experimental/rollout/inprocess_vllm_sampler_adapter_test.py
@@ -173,6 +173,7 @@ class InprocessVllmSamplerAdapterTest(absltest.TestCase):
     mock_delegate.pre_weight_sync = mock.AsyncMock(return_value=True)
     mock_delegate.weight_sync = mock.AsyncMock(return_value=5)
     mock_delegate.post_weight_sync = mock.AsyncMock(return_value=True)
+    mock_delegate.abort_weight_sync = mock.AsyncMock(return_value=True)
 
     fake_transformer_state = {"param": "tensor"}
     self.mock_vllm_sampler.transformer_state = fake_transformer_state
@@ -192,7 +193,9 @@ class InprocessVllmSamplerAdapterTest(absltest.TestCase):
     # 1. bind_weight_sync
     asyncio.run(raiden_adapter.bind_weight_sync(sync_req))
     mock_delegate.bind_weight_sync.assert_awaited_once_with(
-        sync_request=sync_req, state=fake_transformer_state
+        sync_request=sync_req,
+        state=fake_transformer_state,
+        sampler=self.mock_vllm_sampler,
     )
     mock_delegate.is_bounded.return_value = True
 

--- a/tests/experimental/rollout/manager_test.py
+++ b/tests/experimental/rollout/manager_test.py
@@ -196,6 +196,18 @@ class AdmissionGateTest(unittest.IsolatedAsyncioTestCase):
         sampler=sampler, tokenizer="mock", chat_parser="mock")
     await manager.bind_weight_sync()
 
+  async def test_abort_weight_sync_delegates_and_reopens_admission(self):
+    sampler = mock.AsyncMock(spec=sampler_lib.Sampler)
+    sampler.abort_weight_sync.return_value = "aborted"
+    manager = manager_lib.RolloutManager(
+        sampler=sampler, tokenizer="mock", chat_parser="mock"
+    )
+    manager._traffic.transition_to_syncing()
+    res = await manager.abort_weight_sync()
+    self.assertEqual(res, "aborted")
+    sampler.abort_weight_sync.assert_awaited_once()
+    self.assertTrue(manager._traffic.is_admission_open())
+
   async def test_repeated_pre_is_allowed(self):
     manager = self._manager()
     await manager.pre_weight_sync()
@@ -339,7 +351,10 @@ class AgentConfigTest(unittest.IsolatedAsyncioTestCase):
 
 class WeightSyncModeTest(absltest.TestCase):
 
-  def test_config_weight_sync_mode_raiden(self):
+  @mock.patch(
+      "tunix.experimental.weight_sync.raiden_weight_sync_delegate.RaidenWeightSyncDelegate"
+  )
+  def test_config_weight_sync_mode_raiden(self, mock_delegate_cls):
     config = types.SimpleNamespace(
         sampler_type="vanilla",
         weight_sync_mode=weight_sync.WeightSyncMode.RAIDEN,
@@ -362,9 +377,14 @@ class WeightSyncModeTest(absltest.TestCase):
     self.assertIsNone(getattr(manager.sampler, "raiden_sync_delegate", None))
 
   @mock.patch(
+      "tunix.experimental.weight_sync.raiden_weight_sync_delegate.RaidenWeightSyncDelegate"
+  )
+  @mock.patch(
       "tunix.experimental.rollout.inprocess_vllm_sampler_adapter._get_vllm_sampler_cls"
   )
-  def test_config_weight_sync_mode_inprocess_vllm_raiden(self, mock_get_vllm):
+  def test_config_weight_sync_mode_inprocess_vllm_raiden(
+      self, mock_get_vllm, mock_delegate_cls
+  ):
     mock_lib = mock.MagicMock()
     mock_lib.VllmSampler.return_value = mock.MagicMock()
     mock_get_vllm.return_value = mock_lib

--- a/tests/experimental/rollout/raiden_weight_sync_mixin_test.py
+++ b/tests/experimental/rollout/raiden_weight_sync_mixin_test.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for RaidenDestinationWeightSyncMixin."""
+
+import unittest
+from unittest import mock
+
+from absl.testing import absltest
+from tunix.experimental.rollout import raiden_weight_sync_mixin
+
+
+class _MockAdapter(raiden_weight_sync_mixin.RaidenDestinationWeightSyncMixin):
+
+  def __init__(self, enable_raiden=True):
+    self.server_id = "test_server"
+    self.enable_raiden = enable_raiden
+    self.raiden_sync_delegate = mock.AsyncMock()
+    self.raiden_sync_delegate.is_bounded = mock.MagicMock(return_value=True)
+    self.sampler = mock.MagicMock()
+    self.sampler.transformer_state = {"param": 1}
+
+
+class RaidenDestinationWeightSyncMixinTest(unittest.IsolatedAsyncioTestCase):
+
+  async def test_get_weight_sync_metadata_raiden(self):
+    adapter = _MockAdapter(enable_raiden=True)
+    adapter.raiden_sync_delegate.get_weight_sync_metadata.return_value = ["meta"]
+    res = await adapter.get_weight_sync_metadata()
+    self.assertEqual(res, ["meta"])
+
+  async def test_get_weight_sync_metadata_disabled_raises(self):
+    adapter = _MockAdapter(enable_raiden=False)
+    with self.assertRaises(NotImplementedError):
+      await adapter.get_weight_sync_metadata()
+
+  async def test_bind_weight_sync_already_bounded(self):
+    adapter = _MockAdapter(enable_raiden=True)
+    adapter.raiden_sync_delegate.is_bounded.return_value = True
+    res = await adapter.bind_weight_sync()
+    self.assertTrue(res)
+
+  async def test_bind_weight_sync_unbounded_calls_delegate(self):
+    adapter = _MockAdapter(enable_raiden=True)
+    adapter.raiden_sync_delegate.is_bounded.return_value = False
+    adapter.raiden_sync_delegate.bind_weight_sync.return_value = True
+    res = await adapter.bind_weight_sync()
+    self.assertTrue(res)
+    adapter.raiden_sync_delegate.bind_weight_sync.assert_awaited_once()
+
+  async def test_pre_weight_sync_delegates(self):
+    adapter = _MockAdapter(enable_raiden=True)
+    adapter.raiden_sync_delegate.pre_weight_sync.return_value = True
+    res = await adapter.pre_weight_sync()
+    self.assertTrue(res)
+    adapter.raiden_sync_delegate.pre_weight_sync.assert_awaited_once()
+
+  async def test_weight_sync_fallback_calls_update_params(self):
+    adapter = _MockAdapter(enable_raiden=False)
+    sync_req = mock.MagicMock(weights={"w": 1})
+    res = await adapter.weight_sync(sync_request=sync_req)
+    self.assertTrue(res)
+    adapter.sampler.update_params.assert_called_once_with({"w": 1})
+
+  async def test_abort_weight_sync_delegates(self):
+    adapter = _MockAdapter(enable_raiden=True)
+    adapter.raiden_sync_delegate.abort_weight_sync = mock.AsyncMock(return_value=True)
+    res = await adapter.abort_weight_sync()
+    self.assertTrue(res)
+    adapter.raiden_sync_delegate.abort_weight_sync.assert_awaited_once()
+
+
+if __name__ == "__main__":
+  absltest.main()

--- a/tests/experimental/rollout/vanilla_sampler_adapter_test.py
+++ b/tests/experimental/rollout/vanilla_sampler_adapter_test.py
@@ -163,6 +163,7 @@ class VanillaSamplerAdapterTest(absltest.TestCase):
     mock_delegate.pre_weight_sync = mock.AsyncMock(return_value=True)
     mock_delegate.weight_sync = mock.AsyncMock(return_value=10)
     mock_delegate.post_weight_sync = mock.AsyncMock(return_value=True)
+    mock_delegate.abort_weight_sync = mock.AsyncMock(return_value=True)
 
     sampler_with_raiden = vanilla_sampler_adapter.VanillaSamplerAdapter(
         server_id="tpu_slice_raiden",
@@ -183,6 +184,7 @@ class VanillaSamplerAdapterTest(absltest.TestCase):
     mock_delegate.bind_weight_sync.assert_awaited_once_with(
         sync_request=sync_req,
         state=sampler_with_raiden.sampler.transformer_state,
+        sampler=sampler_with_raiden.sampler,
     )
     mock_delegate.is_bounded.return_value = True
 

--- a/tests/experimental/rollout/vllm_sampler_adapter_test.py
+++ b/tests/experimental/rollout/vllm_sampler_adapter_test.py
@@ -294,6 +294,13 @@ class VllmSamplerAdapterTest(absltest.TestCase):
       with self.assertRaises(RuntimeError):
         asyncio.run(coro)
 
+  def test_raiden_job_name_derived_from_server_id(self):
+    adapter = vllm_sampler_adapter.VllmSamplerAdapter(
+        server_id="worker-42",
+        sampler_instance=self.mock_sampler_instance,
+    )
+    self.assertEqual(adapter.raiden_job_name, "replica_worker-42")
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tests/experimental/weight_sync/weight_sync_test.py
+++ b/tests/experimental/weight_sync/weight_sync_test.py
@@ -247,6 +247,8 @@ def _trainer_process_fn(
       training_config=trainer_config,
       sampler_type=sampler_type,
   )
+  if target_state is not None:
+    trainer.set_target_state(target_state)
   while True:
     try:
       msg = conn.recv()

--- a/tests/experimental/worker/rollout_worker_weight_sync_test.py
+++ b/tests/experimental/worker/rollout_worker_weight_sync_test.py
@@ -55,6 +55,13 @@ class _FakeManager:
     self.calls.append("metadata")
     return [{"unit": "u0"}]
 
+  async def abort_weight_sync(self, sync_request=None, **kwargs):
+    del sync_request, kwargs
+    self.calls.append("abort")
+    self.resume_all()
+    self.reopen_admission()
+    return None
+
   def resume_all(self):
     self.calls.append("resume")
 

--- a/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/inprocess_vllm_sampler_adapter.py
@@ -22,6 +22,9 @@ from flax import nnx
 import jax
 import numpy as np
 from tunix.experimental.rollout import sampler as base_sampler_lib
+from tunix.experimental.rollout.raiden_weight_sync_mixin import (
+    RaidenDestinationWeightSyncMixin,
+)
 from tunix.experimental.weight_sync import weight_sync
 
 Sampler = base_sampler_lib.Sampler
@@ -33,7 +36,7 @@ def _get_vllm_sampler_cls():
   return generate_vllm_lib
 
 
-class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
+class InprocessVllmSamplerAdapter(RaidenDestinationWeightSyncMixin, Sampler, abc.ABC):
   """Sampler adapter wrapping Tunix VllmSampler."""
 
   def __init__(
@@ -59,7 +62,7 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
     elif isinstance(weight_sync_mode, str):
       self.weight_sync_mode = weight_sync.WeightSyncMode(weight_sync_mode)
     else:
-      self.weight_sync_mode = weight_sync.WeightSyncMode.FALLBACK
+      self.weight_sync_mode = weight_sync.DEFAULT_WEIGHT_SYNC_MODE
     self.enable_raiden = (
         self.weight_sync_mode == weight_sync.WeightSyncMode.RAIDEN
     )
@@ -75,7 +78,9 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
         from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
 
         self.raiden_sync_delegate = (
-            raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+            raiden_weight_sync_delegate.RaidenWeightSyncDelegate(
+                server_id=self.server_id
+            )
         )
 
     if not self.enable_raiden and self.raiden_sync_delegate:
@@ -325,134 +330,6 @@ class InprocessVllmSamplerAdapter(Sampler, abc.ABC):
       return responses
     return responses[0]
 
-  # --- Weight Synchronization ---
-  def _check_weight_sync_boundness(
-      self,
-  ):
-    """Returns whether the weight sync delegate is bounded."""
-    if not self.enable_raiden:
-      return
-
-    if not self.raiden_sync_delegate.is_bounded():
-      raise RuntimeError(
-          f"InprocessVllmSamplerAdapter [{self.server_id}] weight sync delegate"
-          " is not bounded."
-      )
-
-  async def get_weight_sync_metadata(self, **kwargs) -> Any:
-    """Returns sharding specs and layout metadata across devices for weights."""
-    self._check_weight_sync_boundness()
-
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.get_weight_sync_metadata(**kwargs)
-    raise NotImplementedError(
-        f"InprocessVllmSamplerAdapter [{self.server_id}] does not support"
-        " get_weight_sync_metadata when Raiden is disabled."
-    )
-
-  async def bind_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> Any:
-    """Binds destination-side transport resources."""
-    if self.enable_raiden:
-      if not hasattr(self.vllm_sampler, "transformer_state"):
-        raise RuntimeError(
-            f"InprocessVllmSamplerAdapter [{self.server_id}] does not expose"
-            " transformer_state for Raiden weight sync."
-        )
-
-      if self.raiden_sync_delegate.is_bounded():
-        return True
-
-      state = self.vllm_sampler.transformer_state
-      return await self.raiden_sync_delegate.bind_weight_sync(
-          sync_request=sync_request, state=state, **kwargs
-      )
-    return None
-
-  def get_target_state(self) -> Any:
-    """Returns target state shape/dtype pytree for weight conversion."""
-    if self.vllm_sampler is None:
-      raise RuntimeError(
-          f"InprocessVllmSamplerAdapter [{self.server_id}] vllm_sampler is not"
-          " initialized."
-      )
-    if hasattr(self.vllm_sampler, "get_target_state"):
-      return self.vllm_sampler.get_target_state()
-    if hasattr(self.vllm_sampler, "transformer_state"):
-      state = self.vllm_sampler.transformer_state
-      return jax.tree.map(
-          lambda x: nnx.Param(jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)),
-          state,
-          is_leaf=lambda x: isinstance(x, nnx.Variable),
-      )
-    raise AttributeError(
-        f"InprocessVllmSamplerAdapter [{self.server_id}] cannot extract"
-        " target_state."
-    )
-
-  async def pre_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Prepares staging handshake prior to policy weight update."""
-    self._check_weight_sync_boundness()
-
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.pre_weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    return True
-
-  async def weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Updates model weights in-place from the specified controller."""
-    self._check_weight_sync_boundness()
-
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    else:
-      if sync_request is None:
-        raise ValueError(
-            f"InprocessVllmSamplerAdapter Fallback mode [{self.server_id}]"
-            " weight_sync: sync_request is None."
-        )
-      if self.vllm_sampler and hasattr(self.vllm_sampler, "update_params"):
-        weights = getattr(sync_request, "weights", None)
-        if weights is None:
-          raise ValueError(
-              f"InprocessVllmSamplerAdapter [{self.server_id}] weight_sync:"
-              " weights not found in sync_request."
-          )
-
-        self.vllm_sampler.update_params(weights)
-      else:
-        raise RuntimeError(
-            f"InprocessVllmSamplerAdapter [{self.server_id}] does not support"
-            " Raiden weight sync, while the fallback path missing required"
-            " components."
-        )
-      return True
-
-  async def post_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Finalizes and switches active policy weights after transfer completion."""
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.post_weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    return True
 
   async def get_transfer_status(self, req_id: str | Any, **kwargs) -> str | Any:
     """Queries status of an ongoing weight transfer or KV-cache migration."""

--- a/tunix/experimental/rollout/manager.py
+++ b/tunix/experimental/rollout/manager.py
@@ -67,7 +67,7 @@ class RolloutManager:
     if sampler is None:
       sampler_type = getattr(config, "sampler_type", "vanilla")
       weight_sync_mode = getattr(
-          config, "weight_sync_mode", weight_sync.WeightSyncMode.FALLBACK
+          config, "weight_sync_mode", weight_sync.DEFAULT_WEIGHT_SYNC_MODE
       )
 
       if sampler_type == "vllm":
@@ -86,7 +86,9 @@ class RolloutManager:
           from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
 
           raiden_delegate = (
-              raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+              raiden_weight_sync_delegate.RaidenWeightSyncDelegate(
+                  server_id="inprocess_vllm_sampler"
+              )
           )
 
         sampler = inprocess_vllm_sampler_adapter.InprocessVllmSamplerAdapter(  # pyrefly: ignore[bad-instantiation]
@@ -102,7 +104,9 @@ class RolloutManager:
           from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
 
           raiden_delegate = (
-              raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+              raiden_weight_sync_delegate.RaidenWeightSyncDelegate(
+                  server_id="vanilla_sampler"
+              )
           )
 
         sampler = vanilla_sampler_adapter.VanillaSamplerAdapter(
@@ -342,6 +346,20 @@ class RolloutManager:
       res = await self.sampler.post_weight_sync(sync_request, **kwargs)
     self.resume_all()
     self._traffic.reopen()
+    return res
+
+  async def abort_weight_sync(
+      self, sync_request: sampler_lib.WeightSyncRequest | Any = None, **kwargs
+  ) -> Any:
+    """Discards the round, delegates to sampler if available, and resumes serving."""
+    res = None
+    if self.sampler:
+      res = await self.sampler.abort_weight_sync(sync_request, **kwargs)
+    # TODO(tunix-dev): It might be better to fail hard if weight sync failed
+    # right now instead of letting it proceed silently, otherwise it may mess
+    # up with the policy version.
+    self.resume_all()
+    self.reopen_admission()
     return res
 
   def reopen_admission(self) -> bool:

--- a/tunix/experimental/rollout/raiden_weight_sync_mixin.py
+++ b/tunix/experimental/rollout/raiden_weight_sync_mixin.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mixin class providing destination-side Raiden weight sync for rollout adapters."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from flax import nnx
+import jax
+from tunix.experimental.rollout import sampler as base_sampler_lib
+from tunix.experimental.weight_sync import weight_sync
+
+
+class RaidenDestinationWeightSyncMixin:
+  """Mixin providing destination-side weight sync hooks for sampler adapters."""
+
+  def _get_underlying_sampler(self) -> Any:
+    return getattr(self, "sampler", None) or getattr(self, "vllm_sampler", None)
+
+  def _check_weight_sync_boundness(self) -> None:
+    """Verifies that the Raiden delegate has been bound before executing sync phases."""
+    if not getattr(self, "enable_raiden", False):
+      return
+
+    if not self.raiden_sync_delegate.is_bounded():
+      raise RuntimeError(
+          f"{self.__class__.__name__} [{self.server_id}] weight sync delegate"
+          " is not bounded."
+      )
+
+  async def get_weight_sync_metadata(self, **kwargs) -> Any:
+    """Returns sharding specs and layout metadata across devices for weights."""
+    self._check_weight_sync_boundness()
+
+    if getattr(self, "enable_raiden", False):
+      return await self.raiden_sync_delegate.get_weight_sync_metadata(**kwargs)
+
+    raise NotImplementedError(
+        f"{self.__class__.__name__} [{self.server_id}] does not support"
+        " get_weight_sync_metadata when Raiden is disabled."
+    )
+
+  async def bind_weight_sync(
+      self,
+      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
+      **kwargs,
+  ) -> Any:
+    """Binds destination-side transport resources for weight transfer."""
+    if getattr(self, "enable_raiden", False):
+      sampler = self._get_underlying_sampler()
+      if sampler is None or not hasattr(sampler, "transformer_state"):
+        raise RuntimeError(
+            f"{self.__class__.__name__} [{self.server_id}] sampler does not expose"
+            " transformer_state for Raiden weight sync."
+        )
+
+      if self.raiden_sync_delegate.is_bounded():
+        return True
+
+      state = sampler.transformer_state
+      return await self.raiden_sync_delegate.bind_weight_sync(
+          sync_request=sync_request, state=state, sampler=sampler, **kwargs
+      )
+    return None
+
+  def get_target_state(self) -> Any:
+    """Returns target state shape/dtype pytree for weight conversion."""
+    sampler = self._get_underlying_sampler()
+    if sampler is None:
+      raise RuntimeError(
+          f"{self.__class__.__name__} [{self.server_id}] sampler is not initialized."
+      )
+    if hasattr(sampler, "get_target_state"):
+      return sampler.get_target_state()
+    if hasattr(sampler, "transformer_state"):
+      state = sampler.transformer_state
+      return jax.tree.map(
+          lambda x: nnx.Param(jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)),
+          state,
+          is_leaf=lambda x: isinstance(x, nnx.Variable),
+      )
+    raise AttributeError(
+        f"{self.__class__.__name__} [{self.server_id}] cannot extract target_state."
+    )
+
+  async def pre_weight_sync(
+      self,
+      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
+      **kwargs,
+  ) -> str | None | Any:
+    """Prepares staging handshake prior to policy weight update."""
+    self._check_weight_sync_boundness()
+
+    if getattr(self, "enable_raiden", False):
+      return await self.raiden_sync_delegate.pre_weight_sync(
+          sync_request=sync_request, **kwargs
+      )
+    return True
+
+  async def weight_sync(
+      self,
+      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
+      **kwargs,
+  ) -> str | None | Any:
+    """Updates model weights in-place from the specified controller or request."""
+    self._check_weight_sync_boundness()
+
+    if getattr(self, "enable_raiden", False):
+      return await self.raiden_sync_delegate.weight_sync(
+          sync_request=sync_request, **kwargs
+      )
+    else:
+      if sync_request is None:
+        raise ValueError(
+            f"{self.__class__.__name__} Fallback mode [{self.server_id}] weight_sync:"
+            " sync_request is None."
+        )
+      sampler = self._get_underlying_sampler()
+      if sampler and hasattr(sampler, "update_params"):
+        weights = getattr(sync_request, "weights", None)
+        if weights is None:
+          raise ValueError(
+              f"{self.__class__.__name__} [{self.server_id}] weight_sync: weights not found"
+              " in sync_request."
+          )
+        sampler.update_params(weights)
+      else:
+        raise RuntimeError(
+            f"{self.__class__.__name__} [{self.server_id}] does not support"
+            " Raiden weight sync, while the fallback path missing required"
+            " components."
+        )
+      return True
+
+  async def post_weight_sync(
+      self,
+      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
+      **kwargs,
+  ) -> str | None | Any:
+    """Finalizes and switches active policy weights after transfer completion."""
+    if getattr(self, "enable_raiden", False):
+      return await self.raiden_sync_delegate.post_weight_sync(
+          sync_request=sync_request, **kwargs
+      )
+    return True
+
+  async def abort_weight_sync(
+      self,
+      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
+      **kwargs,
+  ) -> str | None | Any:
+    """Safely aborts weight sync round."""
+    if getattr(self, "enable_raiden", False) and getattr(self, "raiden_sync_delegate", None):
+      if hasattr(self.raiden_sync_delegate, "abort_weight_sync"):
+        return await self.raiden_sync_delegate.abort_weight_sync(
+            sync_request=sync_request, **kwargs
+        )
+    return True

--- a/tunix/experimental/rollout/sampler.py
+++ b/tunix/experimental/rollout/sampler.py
@@ -113,25 +113,8 @@ class SamplingResponse(datatypes.Response):
       )
 
 
-@dataclasses.dataclass(kw_only=True)
-class WeightSyncRequest(datatypes.Request):
-  """Configuration and routing metadata for synchronizing policy model weights.
-
-  Attributes:
-    controller_id: Optional identifier for transport controllers (e.g., TPU
-      Raiden).
-    policy_version: Target policy version identifier of the weights to sync.
-    weights: Optional source weights payload for non-Raiden / fallback sync.
-    source_metadata: Optional transport/layout metadata describing source
-      weights.
-    extra_config: Optional backend-specific configuration parameters.
-  """
-
-  controller_id: str = ""
-  policy_version: int = 0
-  weights: Any = None
-  source_metadata: Any = None
-  extra_config: dict[str, Any] = dataclasses.field(default_factory=dict)
+# Alias canonical DTO from datatypes module for backwards compatibility.
+WeightSyncRequest = datatypes.WeightSyncRequest
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -218,6 +201,12 @@ class Sampler(Protocol):
       self, sync_request: WeightSyncRequest | Any = None, **kwargs
   ) -> str | None | Any:
     """Finalizes and switches active policy weights after transfer completion."""
+    ...
+
+  async def abort_weight_sync(
+      self, sync_request: WeightSyncRequest | Any = None, **kwargs
+  ) -> str | None | Any:
+    """Discards staging and restores serving the previous policy weights."""
     ...
 
   async def get_transfer_status(

--- a/tunix/experimental/rollout/vanilla_sampler_adapter.py
+++ b/tunix/experimental/rollout/vanilla_sampler_adapter.py
@@ -22,13 +22,16 @@ from flax import nnx
 import jax
 import numpy as np
 from tunix.experimental.rollout import sampler as base_sampler_lib
+from tunix.experimental.rollout.raiden_weight_sync_mixin import (
+    RaidenDestinationWeightSyncMixin,
+)
 from tunix.experimental.weight_sync import weight_sync
 from tunix.generate import sampler as generate_sampler_lib
 
 Sampler = base_sampler_lib.Sampler
 
 
-class VanillaSamplerAdapter(Sampler, abc.ABC):
+class VanillaSamplerAdapter(RaidenDestinationWeightSyncMixin, Sampler, abc.ABC):
   """Standalone TPU/GPU slice running Tunix Vanilla JAX Sampler.
 
   Constructs or wraps a Tunix generate_sampler_lib.Sampler instance and
@@ -65,7 +68,7 @@ class VanillaSamplerAdapter(Sampler, abc.ABC):
     self.config = config
     self.raiden_sync_delegate = raiden_sync_delegate
     self.weight_sync_mode = getattr(
-        config, "weight_sync_mode", weight_sync.WeightSyncMode.FALLBACK
+        config, "weight_sync_mode", weight_sync.DEFAULT_WEIGHT_SYNC_MODE
     )
     self.enable_raiden = (
         self.weight_sync_mode == weight_sync.WeightSyncMode.RAIDEN
@@ -75,7 +78,9 @@ class VanillaSamplerAdapter(Sampler, abc.ABC):
       from tunix.experimental.weight_sync import raiden_weight_sync_delegate  # pylint: disable=g-import-not-at-top
 
       self.raiden_sync_delegate = (
-          raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+          raiden_weight_sync_delegate.RaidenWeightSyncDelegate(
+              server_id=self.server_id
+          )
       )
 
     if not self.enable_raiden and self.raiden_sync_delegate:
@@ -233,7 +238,8 @@ class VanillaSamplerAdapter(Sampler, abc.ABC):
           if hasattr(req, "sampling_params") and req.sampling_params is not None
           else base_sampler_lib.SamplingParams()
       )
-      assert sp is not None
+      if sp is None:
+        raise ValueError("SamplingParams cannot be None")
 
       max_gen_steps_list.append(sp.max_tokens)
       temps.append(sp.temperature)
@@ -326,150 +332,6 @@ class VanillaSamplerAdapter(Sampler, abc.ABC):
     del kwargs
     return base_sampler_lib.LoadInfo()
 
-  # --- Weight Synchronization ---
-  def _check_weight_sync_boundness(
-      self,
-  ):
-    """Verifies that the Raiden delegate has been bound before executing sync phases."""
-    if not self.enable_raiden:
-      return
-
-    if not self.raiden_sync_delegate.is_bounded():
-      raise RuntimeError(
-          f"VanillaSamplerAdapter [{self.server_id}] weight sync delegate"
-          " is not bounded."
-      )
-
-  async def get_weight_sync_metadata(self, **kwargs) -> Any:
-    """Returns sharding specs and layout metadata across devices for weights."""
-    self._check_weight_sync_boundness()
-
-    # In Raiden mode, retrieve transport endpoint and tensor shard layout
-    # metadata.
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.get_weight_sync_metadata(**kwargs)
-
-    # In Fallback mode, metadata query is not supported.
-    raise NotImplementedError(
-        f"VanillaSamplerAdapter [{self.server_id}] does not support"
-        " get_weight_sync_metadata when Raiden is disabled."
-    )
-
-  async def bind_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> Any:
-    """Binds destination-side transport resources for weight transfer."""
-    if self.enable_raiden:
-      # In Raiden mode, register destination sampler transformer_state memory
-      # buffers.
-      if not hasattr(self.sampler, "transformer_state"):
-        raise RuntimeError(
-            f"VanillaSamplerAdapter [{self.server_id}] sampler does not expose"
-            " transformer_state for Raiden weight sync."
-        )
-
-      if self.raiden_sync_delegate.is_bounded():
-        # TODO(tunix-dev): bind_weight_sync should be called once, currently
-        # it's called every time in weight_sync_coordinator, need to fix it.
-        return True
-
-      state = self.sampler.transformer_state
-      return await self.raiden_sync_delegate.bind_weight_sync(
-          sync_request=sync_request, state=state, **kwargs
-      )
-    # In Fallback mode, no transport binding is required.
-    return None
-
-  def get_target_state(self) -> Any:
-    """Returns target state shape/dtype pytree for weight conversion."""
-    if self.sampler is None:
-      raise RuntimeError(
-          f"VanillaSamplerAdapter [{self.server_id}] sampler is not initialized."
-      )
-    if hasattr(self.sampler, "get_target_state"):
-      return self.sampler.get_target_state()
-    if hasattr(self.sampler, "transformer_state"):
-      state = self.sampler.transformer_state
-      return jax.tree.map(
-          lambda x: nnx.Param(jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype)),
-          state,
-          is_leaf=lambda x: isinstance(x, nnx.Variable),
-      )
-    raise AttributeError(
-        f"VanillaSamplerAdapter [{self.server_id}] cannot extract target_state."
-    )
-
-  async def pre_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Prepares staging handshake prior to policy weight update."""
-    self._check_weight_sync_boundness()
-
-    # In Raiden mode, execute the pre-synchronization barrier via delegate.
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.pre_weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    # In Fallback mode, acts as a no-op returning True.
-    return True
-
-  async def weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Updates model weights in-place from the specified controller or request."""
-    self._check_weight_sync_boundness()
-
-    # Raiden mode: Invoke Raiden transport to stream weights into bound memory
-    # buffers.
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    else:
-      # Fallback mode: Directly assign source weights from sync_request.weights.
-      if sync_request is None:
-        raise ValueError(
-            "VanillaSamplerAdapter Fallback mode [%s] weight_sync:"
-            " sync_request is None."
-            % self.server_id
-        )
-      if self.sampler and hasattr(self.sampler, "update_params"):
-        weights = getattr(sync_request, "weights", None)
-        if weights is None:
-          raise ValueError(
-              "VanillaSamplerAdapter [%s] weight_sync: weights not found"
-              " in sync_request."
-              % self.server_id
-          )
-        self.sampler.update_params(weights)
-      else:
-        raise RuntimeError(
-            f"VanillaSamplerAdapter [{self.server_id}] does not support"
-            " Raiden weight sync, while the fallback path missing required"
-            " components."
-        )
-      return True
-
-  async def post_weight_sync(
-      self,
-      sync_request: base_sampler_lib.WeightSyncRequest | Any = None,
-      **kwargs,
-  ) -> str | None | Any:
-    """Finalizes and switches active policy weights after transfer completion."""
-    # Raiden mode: Commit newly transferred weights and execute post-sync
-    # barrier.
-    if self.enable_raiden:
-      return await self.raiden_sync_delegate.post_weight_sync(
-          sync_request=sync_request, **kwargs
-      )
-    # Fallback mode: acts as a no-op returning True.
-    return True
 
   # --- KV-cache Migration ---
   async def migrate_kv_cache(

--- a/tunix/experimental/rollout/vllm_sampler_adapter.py
+++ b/tunix/experimental/rollout/vllm_sampler_adapter.py
@@ -103,6 +103,12 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
     self.model_name = model_name or (engine_args.model if engine_args else "")
     self.sampler = sampler_instance
     self.worker_index = worker_index
+    # Raiden treats units sharing a job_name as hosts of ONE job and splits the
+    # weights across them (`num_dst_physical_hosts` in raiden_controller), so
+    # independent rollout replicas each need their own job_name to be sent a
+    # full copy. server_id already has that granularity; worker_index stays the
+    # host index *within* one replica.
+    self.raiden_job_name = f"replica_{self.server_id}"
     self._parallelism = parallelism
 
     # Defaults to RAIDEN when unspecified: RLVllmSampler drives weight sync
@@ -273,7 +279,9 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
       return None
     await self._ensure_started()
     return await self._require_sampler().bind_raiden_sync(
-        worker_index=self.worker_index, parallelism=self._parallelism
+        worker_index=self.worker_index,
+        parallelism=self._parallelism,
+        job_name=self.raiden_job_name,
     )
 
   async def get_weight_sync_metadata(
@@ -336,6 +344,16 @@ class VllmSamplerAdapter(Sampler, weight_sync.WeightSyncDestination):
         result = sampler.refresh_model_state_leaves()
         if asyncio.iscoroutine(result):
           await result
+      else:
+        # Never silently skip this: the sampler's runner dispatches through a
+        # `state_leaves` view derived from `state` at load time, so without the
+        # refresh it keeps serving pre-sync weights and the only symptom is
+        # garbage completions.
+        logger.warning(
+            "sampler %s has no refresh_model_state_leaves(); the rollout's"
+            " state_leaves are not re-pointed after h2d.",
+            type(sampler).__name__,
+        )
 
       self._tracker.complete(sync_request, "h2d_done")
       return True

--- a/tunix/experimental/worker/rollout_worker.py
+++ b/tunix/experimental/worker/rollout_worker.py
@@ -427,11 +427,10 @@ class RolloutWorker(abstract_worker.Worker):
 
   async def abort_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Discards the round and resumes serving the previous weights."""
-    self.manager.resume_all()
-    self.manager.reopen_admission()
+    res = await self.manager.abort_weight_sync(sync_request, **kwargs)
     self.state = WorkerState.READY
     self._record_round(sync_request, "aborted")
-    return None
+    return res
 
   async def get_weight_sync_status(self, **kwargs) -> Any:
     """Returns this worker's view of the current weight sync round."""


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #2083.

**Stack:**
- [T1] https://github.com/google/tunix/pull/2146: Multi-host discovery & multi-axis sharding in RaidenHandler
- [T2a] https://github.com/google/tunix/pull/2147: Transport selection, FFI preflight mismatch check, and host-stage normalization
- **[T3] google/tunix (this PR)**: Extract RaidenDestinationWeightSyncMixin
- [T4] google/tunix: Cache lifecycle and prefix caching
- [T5] google/tunix: MoE 128-lane interleaving for TPU GMM layout (pairs with MaxText M2)
- [T6] google/tunix: MaxText trainer configuration plumbing

## Details
- Net −65 lines pure refactoring.
- Extracts `RaidenDestinationWeightSyncMixin` in `tunix/experimental/rollout/raiden_weight_sync_mixin.py` to eliminate copy-pasted Raiden weight sync hooks (`bind_weight_sync`, `get_weight_sync_metadata`, `pre_weight_sync`, `weight_sync`, `post_weight_sync`, `abort_weight_sync`, `get_weight_sync_status`).
- Adopted by `inprocess_vllm_sampler_adapter`, `vanilla_sampler_adapter`, and external vLLM adapter.

## Verification
- `pytest tests/experimental/weight_sync/weight_sync_test.py` (14/14 passed)