### PR TITLE
[Raiden Weight Sync 4/6] Manage cache lifecycle and prefix caching in RaidenWeightSyncDelegate

### DIFF
--- a/tests/experimental/weight_sync/raiden_weight_sync_delegate_test.py
+++ b/tests/experimental/weight_sync/raiden_weight_sync_delegate_test.py
@@ -56,8 +56,9 @@ class _FakeWorker:
 
 class _Request:
 
-  def __init__(self, policy_version):
+  def __init__(self, policy_version, req_id=None):
     self.policy_version = policy_version
+    self.extra_config = {"req_id": req_id} if req_id else {}
 
 
 class RaidenWeightSyncDelegateTest(unittest.IsolatedAsyncioTestCase):
@@ -90,7 +91,7 @@ class RaidenWeightSyncDelegateTest(unittest.IsolatedAsyncioTestCase):
   async def test_repeat_phases_bind_exactly_once(self):
     delegate = self._delegate()
     fake_state = {"w": 1}
-    await delegate.bind_weight_sync(state=fake_state)
+    await delegate.bind_weight_sync(state=fake_state, sampler=mock.MagicMock())
     await delegate.get_weight_sync_metadata()
     await delegate.pre_weight_sync()
     await delegate.weight_sync()
@@ -126,7 +127,49 @@ class RaidenWeightSyncDelegateTest(unittest.IsolatedAsyncioTestCase):
 
   async def test_post_weight_sync_returns_true(self):
     delegate = self._delegate()
+    await delegate.bind_weight_sync(state={"w": 1}, sampler=mock.MagicMock())
     self.assertTrue(await delegate.post_weight_sync())
+
+  async def test_pre_weight_sync_without_sampler_raises(self):
+    delegate = self._delegate()
+    await delegate.bind_weight_sync(state={"w": 1})
+    with self.assertRaisesRegex(RuntimeError, "Sampler is not available"):
+      await delegate.pre_weight_sync()
+
+  async def test_pre_weight_sync_clears_prefix_and_kv_cache(self):
+    sampler = mock.MagicMock()
+    delegate = raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+    await delegate.bind_weight_sync(sampler=sampler, state={"w": 1})
+    req = _Request(policy_version=1, req_id="req-1")
+    await delegate.pre_weight_sync(sync_request=req)
+    sampler.delete_cache.assert_called_once()
+
+  async def test_post_weight_sync_reinitializes_kv_cache(self):
+    sampler = mock.MagicMock()
+    delegate = raiden_weight_sync_delegate.RaidenWeightSyncDelegate()
+    await delegate.bind_weight_sync(sampler=sampler, state={"w": 1})
+    req = _Request(policy_version=1, req_id="req-1")
+    # Only a pre (or an abort) may open a round on the tracker, so the commit
+    # phase has to follow one that carries the same round key.
+    await delegate.pre_weight_sync(sync_request=req)
+    await delegate.post_weight_sync(sync_request=req)
+    sampler.reinitialize_cache.assert_called_once()
+
+  async def test_round_tracker_lifecycle_and_status(self):
+    delegate = self._delegate()
+    await delegate.bind_weight_sync(state={"w": 1}, sampler=mock.MagicMock())
+    req = _Request(policy_version=1, req_id="req-1")
+    await delegate.pre_weight_sync(sync_request=req)
+    await delegate.weight_sync(sync_request=req)
+    await delegate.post_weight_sync(sync_request=req)
+    report = delegate.get_weight_sync_status()
+    self.assertIsNotNone(report)
+
+  async def test_abort_weight_sync_marks_aborted(self):
+    delegate = self._delegate()
+    req = _Request(policy_version=1, req_id="req-1")
+    res = await delegate.abort_weight_sync(sync_request=req)
+    self.assertTrue(res)
 
 
 if __name__ == "__main__":

--- a/tunix/experimental/weight_sync/raiden_weight_sync_delegate.py
+++ b/tunix/experimental/weight_sync/raiden_weight_sync_delegate.py
@@ -17,10 +17,12 @@
 from __future__ import annotations
 
 import os
-from typing import Any, List
+from typing import Any, List, Mapping
 
 from absl import logging
+import jax
 from tunix.experimental.weight_sync import raiden_synchronizer
+from tunix.experimental.weight_sync import weight_sync_coordinator
 
 
 class RaidenWeightSyncDelegate:
@@ -36,14 +38,24 @@ class RaidenWeightSyncDelegate:
   abort after a partial weight_sync cannot restore the previous weights.
   """
 
-  def __init__(self, *args, worker_index: int = 0, **kwargs):
-    super().__init__(*args, **kwargs)
+  def __init__(
+      self,
+      *args,
+      worker_index: int = 0,
+      **kwargs,
+  ):
+    del args, kwargs
+    # TODO(tunix-dev): add a lock when enabling multiple samplers in one worker.
+    self._sampler = None
     self._synchronizers: List[Any] = [
         raiden_synchronizer.RaidenSynchronizer(
-            "rollout", worker_index=worker_index, auto_h2d=True
+            "rollout",
+            worker_index=worker_index,
+            auto_h2d=True,
         )
     ]
     self._version = 0
+    self._tracker = weight_sync_coordinator.WorkerRoundTracker()
 
   def is_bounded(
       self,
@@ -52,10 +64,12 @@ class RaidenWeightSyncDelegate:
     return all(s.bound for s in self._synchronizers)
 
   async def bind_weight_sync(
-      self, sync_request: Any = None, state: Any = None, **kwargs
+      self, sync_request: Any = None, state: Any = None, sampler: Any = None, **kwargs
   ) -> Any:
     """Binds destination-side transport resources for weight sync."""
     del sync_request, kwargs
+    if sampler is not None:
+      self._sampler = sampler
 
     for sync in self._synchronizers:
       # The state arrays never change, so one bind covers every round.
@@ -69,14 +83,33 @@ class RaidenWeightSyncDelegate:
     del kwargs
     return [s.work_unit_metadata() for s in self._synchronizers]
 
+  def _has_round(self, sync_request: Any) -> bool:
+    extra = getattr(sync_request, "extra_config", None) or {}
+    return extra.get("req_id") is not None
+
   async def pre_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Pre-sync phase hook executed before weight transfer begins."""
-    del sync_request, kwargs
+    del kwargs
+    if self._has_round(sync_request):
+      if not self._tracker.admit(sync_request, "prepared"):
+        return True
+      self._tracker.complete(sync_request, "prepared")
+
+    if self._sampler is None:
+      raise RuntimeError("Sampler is not available for weight sync")
+
+    self._sampler.delete_cache()
+    jax.effects_barrier()
+
     return True
 
   async def weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Executes weight installation on device from host staging buffer."""
     del kwargs
+    if self._has_round(sync_request):
+      if not self._tracker.admit(sync_request, "h2d_done"):
+        return self._version
+
     for sync in self._synchronizers:
       if not sync.bound:
         raise RuntimeError("bind_weight_sync must run before weight_sync")
@@ -87,12 +120,42 @@ class RaidenWeightSyncDelegate:
         logging.info("destination checksums: %s", sync.checksums())
     version = getattr(sync_request, "policy_version", 0)
     self._version = version if version else self._version + 1
+
+    if self._has_round(sync_request):
+      self._tracker.complete(sync_request, "h2d_done")
+
     return self._version
 
   async def post_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
     """Post-sync phase hook executed after weight installation completes."""
-    del sync_request, kwargs
+    del kwargs
+    if self._has_round(sync_request):
+      if not self._tracker.admit(sync_request, "committed"):
+        return True
+
     if os.environ.get("VERIFY_WEIGHTS", "").lower() == "true":
       for sync in self._synchronizers:
         logging.info("raiden metrics: %s", sync.metrics())
+
+    if self._sampler is None:
+      raise RuntimeError("Sampler is not available for weight sync")
+
+    self._sampler.reinitialize_cache()
+
+    if self._has_round(sync_request):
+      self._tracker.complete(sync_request, "committed")
+
     return True
+
+  async def abort_weight_sync(self, sync_request: Any = None, **kwargs) -> Any:
+    """Safely handles abort of weight sync round."""
+    del kwargs
+    if self._has_round(sync_request):
+      if not self._tracker.admit(sync_request, "aborted"):
+        return False
+      self._tracker.complete(sync_request, "aborted")
+    return True
+
+  def get_weight_sync_status(self) -> Mapping[str, Any]:
+    """Reports worker-side round status for coordinator recovery checks."""
+    return self._tracker.report()

--- a/tunix/generate/base_sampler.py
+++ b/tunix/generate/base_sampler.py
@@ -98,3 +98,11 @@ class BaseSampler(ABC):
     raise NotImplementedError(
         f"{type(self).__name__} does not implement update_params."
     )
+
+  def delete_cache(self) -> None:
+    """Deletes KV cache to free up memory before weight sync."""
+    pass
+
+  def reinitialize_cache(self) -> None:
+    """Reinitializes KV cache after weight sync."""
+    pass

--- a/tunix/generate/vllm_sampler.py
+++ b/tunix/generate/vllm_sampler.py
@@ -22,7 +22,6 @@ import os
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from absl import logging
-from flax import nnx
 import jax
 import jaxtyping
 import numpy as np
@@ -184,6 +183,24 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           " jax.sharding.Mesh."
       )
 
+  def delete_cache(self) -> None:
+    if self.llm is not None:
+      self.llm.reset_prefix_cache()
+      self.llm.collective_rpc("delete_kv_cache") # will free hbm
+    elif self._driver is not None:
+      self._driver.llm_engine.reset_prefix_cache()
+      self._driver.llm_engine.collective_rpc("delete_kv_cache")
+
+  def reinitialize_cache(self) -> None:
+    self._model_runner.state_leaves = tuple(
+        jax.tree_util.tree_leaves(self._model_runner.state)
+    )
+
+    if self.llm is not None:
+      self.llm.collective_rpc("reinitialize_kv_cache")
+    elif self._driver is not None:
+      self._driver.llm_engine.collective_rpc("reinitialize_kv_cache")
+
   # TODO(b/434969743): Optimize weight sharing between trainer and vllm sampler.
   def update_params(
       self,
@@ -192,12 +209,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
   ):
     del filter_types
 
-    if self.llm is not None:
-      self.llm.reset_prefix_cache()
-      self.llm.collective_rpc("delete_kv_cache") # will free hbm
-    elif self._driver is not None:
-      self._driver.llm_engine.reset_prefix_cache()
-      self._driver.llm_engine.collective_rpc("delete_kv_cache")
+    self.delete_cache()
 
     # Synchronization point before weight sync
     jax.effects_barrier()
@@ -235,18 +247,7 @@ class VllmSampler(base_sampler.BaseSampler):  # pylint: disable=invalid-name
           reshard_chunk_size=self.config.reshard_chunk_size,
       )
 
-    if hasattr(self._model_runner, "state_leaves"):
-      if isinstance(self._model_runner.state, nnx.State):
-        self._model_runner.state_leaves = tuple(
-            jax.tree_util.tree_leaves(self._model_runner.state)
-        )
-      else:
-        self._model_runner.state_leaves = self._model_runner.state
-
-    if self.llm is not None:
-      self.llm.collective_rpc("reinitialize_kv_cache")
-    elif self._driver is not None:
-      self._driver.llm_engine.collective_rpc("reinitialize_kv_cache")
+    self.reinitialize_cache()
 
   def _is_torchax_backend(self) -> bool:
     """True when tpu-inference runs the vLLM (torchax) model implementation.


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #2083.

**Stack:**
- [T1] https://github.com/google/tunix/pull/2146: Multi-host discovery & multi-axis sharding in RaidenHandler
- [T2a] https://github.com/google/tunix/pull/2147: Transport selection, FFI preflight mismatch check, and host-stage normalization
- [T3] https://github.com/google/tunix/pull/2148: Extract RaidenDestinationWeightSyncMixin
- **[T4] google/tunix (this PR)**: Cache lifecycle and prefix caching
- [T5] google/tunix: MoE 128-lane interleaving for TPU GMM layout (pairs with MaxText M2)
- [T6] google/tunix: MaxText trainer configuration plumbing

## Details
- Resets prefix cache and clears stale KV entries upon weight transfer.
- Adds `--enable_prefix_caching` flag (default `false`) to avoid recurrent state desync in hybrid models (such as Qwen3.5 GDN layers).