### PR TITLE
[Raiden Weight Sync 5/6] MoE 128-lane weight interleaving for TPU GMM layout

### DIFF
--- a/tests/generate/utils_test.py
+++ b/tests/generate/utils_test.py
@@ -310,9 +310,7 @@ class UtilsTest(parameterized.TestCase):
     new_tgt_state = utils.transfer_state_with_mappings(
         src, dst, mappings, reshard_fn=mock_reshard_fn
     )
-    self.assertTrue(
-        jnp.allclose(new_tgt_state["decoder.layer_0"], 3.0)
-    )
+    self.assertTrue(jnp.allclose(new_tgt_state["decoder.layer_0"], 3.0))
 
   def test_transfer_state_with_padding(self):
     # Create source module with smaller head dim
@@ -548,11 +546,11 @@ class UtilsTest(parameterized.TestCase):
     dst_state = MockState(dst_params)
 
     # Apply preprocessing if it exists in mapping
-    if 'preprocess_src_state' in VLLM_JAX_MAPPING:
-      src_state = VLLM_JAX_MAPPING['preprocess_src_state'](src_state)
+    if "preprocess_src_state" in VLLM_JAX_MAPPING:
+      src_state = VLLM_JAX_MAPPING["preprocess_src_state"](src_state)
 
-    key_mappings = VLLM_JAX_MAPPING['to_hf_mappings']
-    transpose_keys = VLLM_JAX_MAPPING['to_hf_transpose_keys']
+    key_mappings = VLLM_JAX_MAPPING["to_hf_mappings"]
+    transpose_keys = VLLM_JAX_MAPPING["to_hf_transpose_keys"]
 
     new_tgt_state = utils.transfer_state_with_mappings(
         src_state,
@@ -579,27 +577,35 @@ class UtilsTest(parameterized.TestCase):
 
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["language_model.layers.0.self_attn.qkv_proj.weight"],
+            new_tgt_state.params[
+                "language_model.layers.0.self_attn.qkv_proj.weight"
+            ],
             expected_qkv,
         )
     )
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["language_model.layers.0.mlp.gate_up_proj.weight"],
+            new_tgt_state.params[
+                "language_model.layers.0.mlp.gate_up_proj.weight"
+            ],
             expected_gate_up,
         )
     )
 
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["language_model.layers.0.experts.kernel_gating_upproj_EDF"],
+            new_tgt_state.params[
+                "language_model.layers.0.experts.kernel_gating_upproj_EDF"
+            ],
             src_params["layers.0.moe.gating_einsum"].value,
         )
     )
 
     self.assertTrue(
         jnp.array_equal(
-            new_tgt_state.params["language_model.layers.0.experts.kernel_down_proj_EFD"],
+            new_tgt_state.params[
+                "language_model.layers.0.experts.kernel_down_proj_EFD"
+            ],
             src_params["layers.0.moe.linear"].value,
         )
     )
@@ -741,11 +747,13 @@ class UtilsTest(parameterized.TestCase):
     # Target: (num_heads, head_dim=128)
     src_q_proj = jnp.ones((8, 64), dtype=jnp.float32) * 2.0
     src = MockState({"transformer.layers.0.attn.q_proj": MockParam(src_q_proj)})
-    dst = MockState({
-        "transformer.layers.0.attn.q_proj": MockParam(
-            jnp.zeros((8, 128), dtype=jnp.float32)
-        )
-    })
+    dst = MockState(
+        {
+            "transformer.layers.0.attn.q_proj": MockParam(
+                jnp.zeros((8, 128), dtype=jnp.float32)
+            )
+        }
+    )
 
     mappings = {
         "transformer.layers.0.attn.q_proj": (
@@ -880,17 +888,21 @@ class UtilsTest(parameterized.TestCase):
   def test_transfer_state_directly_simple_transfer(self):
     """Tests direct state transfer with matching structures."""
     src_state = nnx.Dict(
-        decoder=nnx.Dict(layer0=nnx.Dict(weight=nnx.Param(jnp.array([1.0, 2.0]))))
+        decoder=nnx.Dict(
+            layer0=nnx.Dict(weight=nnx.Param(jnp.array([1.0, 2.0])))
+        )
     )
     dst_state = nnx.Dict(
-        decoder=nnx.Dict(layer0=nnx.Dict(weight=nnx.Param(jnp.array([0.0, 0.0]))))
+        decoder=nnx.Dict(
+            layer0=nnx.Dict(weight=nnx.Param(jnp.array([0.0, 0.0])))
+        )
     )
 
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer0']['weight'][...],
+        dst_state["decoder"]["layer0"]["weight"][...],
         jnp.array([1.0, 2.0]),
     )
 
@@ -913,7 +925,7 @@ class UtilsTest(parameterized.TestCase):
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
     np.testing.assert_array_equal(
-        dst_state['model']['decoder']['layer0']['weight'][...],
+        dst_state["model"]["decoder"]["layer0"]["weight"][...],
         jnp.array(1.0),
     )
 
@@ -941,14 +953,14 @@ class UtilsTest(parameterized.TestCase):
     )
 
     np.testing.assert_array_equal(
-        dst_state_fewer_keys['decoder']['layer0']['weight'][...],
+        dst_state_fewer_keys["decoder"]["layer0"]["weight"][...],
         jnp.array(1.0),
     )
     np.testing.assert_array_equal(
-        dst_state_fewer_keys['decoder']['layer1']['weight'][...],
+        dst_state_fewer_keys["decoder"]["layer1"]["weight"][...],
         jnp.array(2.0),
     )
-    self.assertFalse(hasattr(dst_state_fewer_keys['decoder'], 'layer2'))
+    self.assertFalse(hasattr(dst_state_fewer_keys["decoder"], "layer2"))
 
     # Scenario 2: Destination has more keys than source, with no unique keys in source
     src_state_fewer_keys = nnx.Dict(
@@ -969,16 +981,16 @@ class UtilsTest(parameterized.TestCase):
     )
 
     np.testing.assert_array_equal(
-        dst_state_more_keys['decoder']['layer0']['weight'][...],
+        dst_state_more_keys["decoder"]["layer0"]["weight"][...],
         jnp.array(10.0),
     )
     # Extra keys in dst should be preserved
     np.testing.assert_array_equal(
-        dst_state_more_keys['decoder']['layer1']['weight'][...],
+        dst_state_more_keys["decoder"]["layer1"]["weight"][...],
         jnp.array(20.0),
     )
     np.testing.assert_array_equal(
-        dst_state_more_keys['decoder']['layer2']['weight'][...],
+        dst_state_more_keys["decoder"]["layer2"]["weight"][...],
         jnp.array(30.0),
     )
 
@@ -1001,73 +1013,63 @@ class UtilsTest(parameterized.TestCase):
 
     # Common key should be updated
     np.testing.assert_array_equal(
-        dst_state_mixed['decoder']['layer0']['weight'][...], jnp.array(1.0)
+        dst_state_mixed["decoder"]["layer0"]["weight"][...], jnp.array(1.0)
     )
     # Extra key in dst should be preserved
-    self.assertIn('kv_cache', dst_state_mixed)
+    self.assertIn("kv_cache", dst_state_mixed)
     # Extra key in src ('layer1') should NOT be added to dst.
-    self.assertFalse(hasattr(dst_state_mixed['decoder'], 'layer1'))
+    self.assertFalse(hasattr(dst_state_mixed["decoder"], "layer1"))
 
   def test_transfer_state_directly_with_plain_dicts(self):
     """Tests transfer with plain dicts and various variables."""
     src_state = {
-        'decoder': {
-            'layer0': {
-                    'weight': nnx.Param(jnp.array(1.0)),
-                    'some_variable': nnx.Variable(jnp.array([1, 2])),
-                },
-            'extra_layer': {
-                'sub': {
-                    'value': nnx.Param(jnp.array(3.0))
-                }
+        "decoder": {
+            "layer0": {
+                "weight": nnx.Param(jnp.array(1.0)),
+                "some_variable": nnx.Variable(jnp.array([1, 2])),
             },
+            "extra_layer": {"sub": {"value": nnx.Param(jnp.array(3.0))}},
         },
-        'some_other_variable': nnx.Variable(jnp.array(42)),
+        "some_other_variable": nnx.Variable(jnp.array(42)),
     }
     dst_state = {
-        'decoder': {
-            'layer0': {
-                    'weight': nnx.Param(jnp.array(0.0)),
-                    'some_variable': nnx.Variable(jnp.array([0, 0])),
-                },
-            'layer1': {
-                'weight': nnx.Param(jnp.array(0.0))
-            },  # untouched
-            'extra_layer': {
-                'sub': {
-                    'value': nnx.Param(jnp.array(0.0))
-                }
+        "decoder": {
+            "layer0": {
+                "weight": nnx.Param(jnp.array(0.0)),
+                "some_variable": nnx.Variable(jnp.array([0, 0])),
             },
+            "layer1": {"weight": nnx.Param(jnp.array(0.0))},  # untouched
+            "extra_layer": {"sub": {"value": nnx.Param(jnp.array(0.0))}},
         },
-        'some_other_variable': nnx.Variable(jnp.array(0)),
-        'untouched_variable': nnx.Variable(jnp.array(-1)),  # untouched
+        "some_other_variable": nnx.Variable(jnp.array(0)),
+        "untouched_variable": nnx.Variable(jnp.array(-1)),  # untouched
     }
 
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer0']['weight'][...], jnp.array(1.0)
+        dst_state["decoder"]["layer0"]["weight"][...], jnp.array(1.0)
     )
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer0']['some_variable'][...], jnp.array([1, 2])
+        dst_state["decoder"]["layer0"]["some_variable"][...], jnp.array([1, 2])
     )
 
     np.testing.assert_array_equal(
-        dst_state['decoder']['extra_layer']['sub']['value'][...],
+        dst_state["decoder"]["extra_layer"]["sub"]["value"][...],
         jnp.array(3.0),
     )
     np.testing.assert_array_equal(
-        dst_state['some_other_variable'][...], jnp.array(42)
+        dst_state["some_other_variable"][...], jnp.array(42)
     )
 
     # Check that layer1 was not touched
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer1']['weight'][...], jnp.array(0.0)
+        dst_state["decoder"]["layer1"]["weight"][...], jnp.array(0.0)
     )
     # Check that untouched_variable was not touched
     np.testing.assert_array_equal(
-        dst_state['untouched_variable'][...], jnp.array(-1)
+        dst_state["untouched_variable"][...], jnp.array(-1)
     )
 
   def test_attention_weight_num_heads_repetition_and_rank_alignment(self):
@@ -1290,7 +1292,7 @@ class UtilsTest(parameterized.TestCase):
             decoder=nnx.Dict(
                 layers=nnx.Dict(
                     mlp=nnx.Dict(
-                         # Stacked weight for 2 layers: 0->10.0, 1->20.0
+                        # Stacked weight for 2 layers: 0->10.0, 1->20.0
                         weight=nnx.Param(jnp.array([10.0, 20.0]))
                     )
                 )
@@ -1301,21 +1303,31 @@ class UtilsTest(parameterized.TestCase):
     dst_state = nnx.Dict(
         model=nnx.Dict(
             decoder=nnx.Dict(
-                layers_0=nnx.Dict(mlp=nnx.Dict(weight=nnx.Param(jnp.array(0.0)))),
-                layers_1=nnx.Dict(mlp=nnx.Dict(weight=nnx.Param(jnp.array(0.0)))),
+                layers_0=nnx.Dict(
+                    mlp=nnx.Dict(weight=nnx.Param(jnp.array(0.0)))
+                ),
+                layers_1=nnx.Dict(
+                    mlp=nnx.Dict(weight=nnx.Param(jnp.array(0.0)))
+                ),
             )
         )
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     np.testing.assert_array_equal(
-        dst_state['model']['decoder']['layers_0']['mlp']['weight'][...], # Use [...]
+        dst_state["model"]["decoder"]["layers_0"]["mlp"]["weight"][
+            ...
+        ],  # Use [...]
         jnp.array(10.0),
     )
     np.testing.assert_array_equal(
-        dst_state['model']['decoder']['layers_1']['mlp']['weight'][...], # Use [...]
+        dst_state["model"]["decoder"]["layers_1"]["mlp"]["weight"][
+            ...
+        ],  # Use [...]
         jnp.array(20.0),
     )
 
@@ -1336,14 +1348,16 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     np.testing.assert_array_equal(
-        dst_state['layers']['layers_0']['mlp']['weight'][...],
+        dst_state["layers"]["layers_0"]["mlp"]["weight"][...],
         jnp.array(100.0),
     )
     np.testing.assert_array_equal(
-        dst_state['layers']['layers_1']['mlp']['weight'][...],
+        dst_state["layers"]["layers_1"]["mlp"]["weight"][...],
         jnp.array(200.0),
     )
 
@@ -1358,9 +1372,13 @@ class UtilsTest(parameterized.TestCase):
             # Scanned layers in float32
             layers=nnx.Dict(
                 mlp=nnx.Dict(
-                    weight=nnx.Param(jnp.array([[10.0, 11.0], [20.0, 21.0]], dtype=jnp.float32))
+                    weight=nnx.Param(
+                        jnp.array(
+                            [[10.0, 11.0], [20.0, 21.0]], dtype=jnp.float32
+                        )
+                    )
                 )
-            )
+            ),
         )
     )
 
@@ -1372,37 +1390,49 @@ class UtilsTest(parameterized.TestCase):
             ),
             # Unrolled layers in bfloat16
             layers_0=nnx.Dict(
-                mlp=nnx.Dict(weight=nnx.Param(jnp.zeros((2,), dtype=jnp.bfloat16)))
+                mlp=nnx.Dict(
+                    weight=nnx.Param(jnp.zeros((2,), dtype=jnp.bfloat16))
+                )
             ),
             layers_1=nnx.Dict(
-                mlp=nnx.Dict(weight=nnx.Param(jnp.zeros((2,), dtype=jnp.bfloat16)))
-            )
+                mlp=nnx.Dict(
+                    weight=nnx.Param(jnp.zeros((2,), dtype=jnp.bfloat16))
+                )
+            ),
         )
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     # Verify direct mapping cast
-    self.assertEqual(dst_state['decoder']['layer0']['weight'].dtype, jnp.bfloat16)
+    self.assertEqual(
+        dst_state["decoder"]["layer0"]["weight"].dtype, jnp.bfloat16
+    )
     np.testing.assert_allclose(
-        dst_state['decoder']['layer0']['weight'][...],
+        dst_state["decoder"]["layer0"]["weight"][...],
         jnp.array([1.0, 2.0, 3.0], dtype=jnp.bfloat16),
-        atol=1e-2
+        atol=1e-2,
     )
 
     # Verify scanned layer mapping cast
-    self.assertEqual(dst_state['decoder']['layers_0']['mlp']['weight'].dtype, jnp.bfloat16)
-    np.testing.assert_allclose(
-        dst_state['decoder']['layers_0']['mlp']['weight'][...],
-        jnp.array([10.0, 11.0], dtype=jnp.bfloat16),
-        atol=1e-2
+    self.assertEqual(
+        dst_state["decoder"]["layers_0"]["mlp"]["weight"].dtype, jnp.bfloat16
     )
-    self.assertEqual(dst_state['decoder']['layers_1']['mlp']['weight'].dtype, jnp.bfloat16)
     np.testing.assert_allclose(
-        dst_state['decoder']['layers_1']['mlp']['weight'][...],
+        dst_state["decoder"]["layers_0"]["mlp"]["weight"][...],
+        jnp.array([10.0, 11.0], dtype=jnp.bfloat16),
+        atol=1e-2,
+    )
+    self.assertEqual(
+        dst_state["decoder"]["layers_1"]["mlp"]["weight"].dtype, jnp.bfloat16
+    )
+    np.testing.assert_allclose(
+        dst_state["decoder"]["layers_1"]["mlp"]["weight"][...],
         jnp.array([20.0, 21.0], dtype=jnp.bfloat16),
-        atol=1e-2
+        atol=1e-2,
     )
 
   def test_transfer_state_directly_scanned_layers_casting(self):
@@ -1419,41 +1449,54 @@ class UtilsTest(parameterized.TestCase):
     # Destination has unrolled layers_X in bfloat16
     dst_state = nnx.Dict(
         layers=nnx.Dict(
-            layers_0=nnx.Dict(mlp=nnx.Dict(weight=nnx.Param(jnp.zeros((), dtype=jnp.bfloat16)))),
-            layers_1=nnx.Dict(mlp=nnx.Dict(weight=nnx.Param(jnp.zeros((), dtype=jnp.bfloat16)))),
+            layers_0=nnx.Dict(
+                mlp=nnx.Dict(
+                    weight=nnx.Param(jnp.zeros((), dtype=jnp.bfloat16))
+                )
+            ),
+            layers_1=nnx.Dict(
+                mlp=nnx.Dict(
+                    weight=nnx.Param(jnp.zeros((), dtype=jnp.bfloat16))
+                )
+            ),
         )
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     # Verify casting and slicing for implicit layers
-    self.assertEqual(dst_state['layers']['layers_0']['mlp']['weight'].dtype, jnp.bfloat16)
-    np.testing.assert_allclose(
-        dst_state['layers']['layers_0']['mlp']['weight'][...],
-        jnp.array(100.0, dtype=jnp.bfloat16),
-        atol=1e-2
+    self.assertEqual(
+        dst_state["layers"]["layers_0"]["mlp"]["weight"].dtype, jnp.bfloat16
     )
-    self.assertEqual(dst_state['layers']['layers_1']['mlp']['weight'].dtype, jnp.bfloat16)
     np.testing.assert_allclose(
-        dst_state['layers']['layers_1']['mlp']['weight'][...],
+        dst_state["layers"]["layers_0"]["mlp"]["weight"][...],
+        jnp.array(100.0, dtype=jnp.bfloat16),
+        atol=1e-2,
+    )
+    self.assertEqual(
+        dst_state["layers"]["layers_1"]["mlp"]["weight"].dtype, jnp.bfloat16
+    )
+    np.testing.assert_allclose(
+        dst_state["layers"]["layers_1"]["mlp"]["weight"][...],
         jnp.array(200.0, dtype=jnp.bfloat16),
-        atol=1e-2
+        atol=1e-2,
     )
 
   def test_transfer_state_directly_repeats_kv_heads(self):
     """Tests that direct-match weights are repeated when dst has more heads."""
-    src = jnp.array([[1., 2., 3., 4., 5., 6., 7., 8.],
-                     [3., 4., 5., 6., 7., 8., 9., 10.]], dtype=jnp.float32)
-    src_state = nnx.Dict(
-        attn=nnx.Dict(
-            kv_weight=nnx.Param(src)
-        )
+    src = jnp.array(
+        [
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
+            [3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        ],
+        dtype=jnp.float32,
     )
+    src_state = nnx.Dict(attn=nnx.Dict(kv_weight=nnx.Param(src)))
     dst_state = nnx.Dict(
-        attn=nnx.Dict(
-            kv_weight=nnx.Param(jnp.zeros((4, 8), dtype=jnp.float32))
-        )
+        attn=nnx.Dict(kv_weight=nnx.Param(jnp.zeros((4, 8), dtype=jnp.float32)))
     )
 
     mock_reshard = lambda source, target: source
@@ -1461,7 +1504,7 @@ class UtilsTest(parameterized.TestCase):
 
     expected = jnp.repeat(src, 2, axis=0)
     np.testing.assert_array_equal(
-        dst_state['attn']['kv_weight'][...],
+        dst_state["attn"]["kv_weight"][...],
         expected,
     )
 
@@ -1490,15 +1533,17 @@ class UtilsTest(parameterized.TestCase):
     )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     expected = jnp.repeat(jnp.ones((2, 8), dtype=jnp.float32), 2, axis=0)
     np.testing.assert_array_equal(
-        dst_state['layers_0']['attn']['kv_weight'][...],
+        dst_state["layers_0"]["attn"]["kv_weight"][...],
         expected,
     )
     np.testing.assert_array_equal(
-        dst_state['layers_1']['attn']['kv_weight'][...],
+        dst_state["layers_1"]["attn"]["kv_weight"][...],
         expected,
     )
 
@@ -1508,7 +1553,7 @@ class UtilsTest(parameterized.TestCase):
     # tgt: (embed=4, kv_heads=4, head_dim=8) — 2x repeat on kv_heads axis
     src = jnp.arange(4 * 3 * 2 * 8, dtype=jnp.float32).reshape(4, 3, 2, 8)
     tgt = jnp.zeros((4, 4, 8), dtype=jnp.float32)
-    result = utils._unstack_scanned_param(src, tgt, key_path='test')[1]
+    result = utils._unstack_scanned_param(src, tgt, key_path="test")[1]
     # Should return layer 1 slice: shape (4, 2, 8)
     np.testing.assert_equal(result.shape, (4, 2, 8))
     np.testing.assert_array_equal(result, src[:, 1, :, :])
@@ -1518,16 +1563,16 @@ class UtilsTest(parameterized.TestCase):
     # src: scanned, shape (2, 2, 4) = (embed, layers, kv_heads*head_dim combined)
     # Use small shapes: embed=4, layers=2, kv_heads=2, head_dim=4
     # scanned param shape: (4, 2, 2, 4)
-    layer0 = jnp.array([[1., 2., 3., 4.], [5., 6., 7., 8.]], dtype=jnp.float32)  # (2, 4)
-    layer1 = jnp.array([[9., 10., 11., 12.], [13., 14., 15., 16.]], dtype=jnp.float32)
+    layer0 = jnp.array(
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype=jnp.float32
+    )  # (2, 4)
+    layer1 = jnp.array(
+        [[9.0, 10.0, 11.0, 12.0], [13.0, 14.0, 15.0, 16.0]], dtype=jnp.float32
+    )
     # Stack into scanned shape (2, 2, 4): [layer0, layer1] on axis 0
     scanned = jnp.stack([layer0, layer1], axis=0)  # (2, 2, 4)
     src_state = nnx.Dict(
-        layers=nnx.Dict(
-            attn=nnx.Dict(
-                kv_weight=nnx.Param(scanned)
-            )
-        )
+        layers=nnx.Dict(attn=nnx.Dict(kv_weight=nnx.Param(scanned)))
     )
     # dst: unrolled, each layer has (4, 4) — 2x repeat on kv_heads axis
     dst_state = nnx.Dict(
@@ -1543,21 +1588,25 @@ class UtilsTest(parameterized.TestCase):
         ),
     )
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0)
+    utils.transfer_state_directly(
+        src_state, dst_state, reshard_fn=mock_reshard, scan_axis=0
+    )
 
     expected_0 = jnp.repeat(layer0, 2, axis=0)  # (4, 4)
     expected_1 = jnp.repeat(layer1, 2, axis=0)
-    np.testing.assert_array_equal(dst_state['layers_0']['attn']['kv_weight'][...], expected_0)
-    np.testing.assert_array_equal(dst_state['layers_1']['attn']['kv_weight'][...], expected_1)
+    np.testing.assert_array_equal(
+        dst_state["layers_0"]["attn"]["kv_weight"][...], expected_0
+    )
+    np.testing.assert_array_equal(
+        dst_state["layers_1"]["attn"]["kv_weight"][...], expected_1
+    )
 
   def test_sglang_jax_1d_kv_bias_alignment(self):
     """Test 1-D KV bias alignment for sglang_jax rollout engine."""
     src_key = "layers.0.attn.k_bias"
     src_k_bias = jnp.arange(128, dtype=jnp.float32)
     src = MockState({src_key: MockParam(src_k_bias)})
-    dst = MockState(
-        {src_key: MockParam(jnp.zeros((1024,), dtype=jnp.float32))}
-    )
+    dst = MockState({src_key: MockParam(jnp.zeros((1024,), dtype=jnp.float32))})
     mappings = {src_key: (src_key, None)}
 
     result = utils.transfer_state_with_mappings(
@@ -1586,9 +1635,7 @@ class UtilsTest(parameterized.TestCase):
     )
 
     dst_state = nnx.Dict(
-        layers=nnx.Dict(
-            wi=nnx.Param(jnp.zeros((2, 4), dtype=jnp.float32))
-        )
+        layers=nnx.Dict(wi=nnx.Param(jnp.zeros((2, 4), dtype=jnp.float32)))
     )
 
     mock_reshard = lambda source, target: source
@@ -1596,7 +1643,7 @@ class UtilsTest(parameterized.TestCase):
 
     expected_wi = jnp.concatenate([wi_0_val, wi_1_val], axis=-1)
     np.testing.assert_array_equal(
-        dst_state['layers']['wi'][...],
+        dst_state["layers"]["wi"][...],
         expected_wi,
     )
 
@@ -1610,15 +1657,19 @@ class UtilsTest(parameterized.TestCase):
     """
     # Layout: [experts=3, num_layers=2, features=2] (scan_axis=1).
     wi_0_val = jnp.array(
-        [[[1., 2.], [10., 20.]],
-         [[3., 4.], [30., 40.]],
-         [[5., 6.], [50., 60.]]],
+        [
+            [[1.0, 2.0], [10.0, 20.0]],
+            [[3.0, 4.0], [30.0, 40.0]],
+            [[5.0, 6.0], [50.0, 60.0]],
+        ],
         dtype=jnp.float32,
     )
     wi_1_val = jnp.array(
-        [[[100., 200.], [1000., 2000.]],
-         [[300., 400.], [3000., 4000.]],
-         [[500., 600.], [5000., 6000.]]],
+        [
+            [[100.0, 200.0], [1000.0, 2000.0]],
+            [[300.0, 400.0], [3000.0, 4000.0]],
+            [[500.0, 600.0], [5000.0, 6000.0]],
+        ],
         dtype=jnp.float32,
     )
 
@@ -1628,20 +1679,26 @@ class UtilsTest(parameterized.TestCase):
             wi_1=nnx.Param(wi_1_val),
         )
     )
-    dst_state = nnx.Dict(**{
-        'layers_0': nnx.Dict(wi=nnx.Param(jnp.zeros((3, 4), dtype=jnp.float32))),
-        'layers_1': nnx.Dict(wi=nnx.Param(jnp.zeros((3, 4), dtype=jnp.float32))),
-    })
+    dst_state = nnx.Dict(
+        **{
+            "layers_0": nnx.Dict(
+                wi=nnx.Param(jnp.zeros((3, 4), dtype=jnp.float32))
+            ),
+            "layers_1": nnx.Dict(
+                wi=nnx.Param(jnp.zeros((3, 4), dtype=jnp.float32))
+            ),
+        }
+    )
 
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
     np.testing.assert_array_equal(
-        dst_state['layers_0']['wi'][...],
+        dst_state["layers_0"]["wi"][...],
         jnp.concatenate([wi_0_val[:, 0, :], wi_1_val[:, 0, :]], axis=-1),
     )
     np.testing.assert_array_equal(
-        dst_state['layers_1']['wi'][...],
+        dst_state["layers_1"]["wi"][...],
         jnp.concatenate([wi_0_val[:, 1, :], wi_1_val[:, 1, :]], axis=-1),
     )
 
@@ -1674,22 +1731,28 @@ class UtilsTest(parameterized.TestCase):
           leaf, (NamedSharding, sharding.SingleDeviceSharding)
       )
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer0']['weight'][...], src_val
+        dst_state["decoder"]["layer0"]["weight"][...], src_val
     )
 
   def test_transfer_state_directly_delete_dst_buffers_chunked(self):
     """delete_dst_buffers=True works through the chunked path too."""
     src_state = nnx.Dict(
-        decoder=nnx.Dict(**{
-            f'layer{i}': nnx.Dict(weight=nnx.Param(jnp.array([float(i + 1)])))
-            for i in range(4)
-        })
+        decoder=nnx.Dict(
+            **{
+                f"layer{i}": nnx.Dict(
+                    weight=nnx.Param(jnp.array([float(i + 1)]))
+                )
+                for i in range(4)
+            }
+        )
     )
     dst_state = nnx.Dict(
-        decoder=nnx.Dict(**{
-            f'layer{i}': nnx.Dict(weight=nnx.Param(jnp.array([0.0])))
-            for i in range(4)
-        })
+        decoder=nnx.Dict(
+            **{
+                f"layer{i}": nnx.Dict(weight=nnx.Param(jnp.array([0.0])))
+                for i in range(4)
+            }
+        )
     )
 
     inspected_targets = []
@@ -1713,7 +1776,7 @@ class UtilsTest(parameterized.TestCase):
       )
     for i in range(4):
       np.testing.assert_array_equal(
-          dst_state['decoder'][f'layer{i}']['weight'][...],
+          dst_state["decoder"][f"layer{i}"]["weight"][...],
           jnp.array([float(i + 1)]),
       )
 
@@ -1742,21 +1805,23 @@ class UtilsTest(parameterized.TestCase):
     # If deletion misfired the next access raises "Array has been deleted".
     np.testing.assert_array_equal(np.asarray(shared), [1.0, 2.0, 3.0])
     np.testing.assert_array_equal(
-        dst_state['decoder']['layer0']['weight'][...], [1.0, 2.0, 3.0]
+        dst_state["decoder"]["layer0"]["weight"][...], [1.0, 2.0, 3.0]
     )
 
   def test_transfer_state_directly_delete_dst_buffers_scanned_layers(self):
     """Unstacked-slice targets remain valid after delete_dst_buffers=True."""
     scanned = jnp.arange(8, dtype=jnp.float32).reshape(2, 4)
     src_state = nnx.Dict(layers=nnx.Dict(weight=nnx.Param(scanned)))
-    dst_state = nnx.Dict(**{
-        'layers_0': nnx.Dict(
-            weight=nnx.Param(jnp.zeros(4, dtype=jnp.float32))
-        ),
-        'layers_1': nnx.Dict(
-            weight=nnx.Param(jnp.zeros(4, dtype=jnp.float32))
-        ),
-    })
+    dst_state = nnx.Dict(
+        **{
+            "layers_0": nnx.Dict(
+                weight=nnx.Param(jnp.zeros(4, dtype=jnp.float32))
+            ),
+            "layers_1": nnx.Dict(
+                weight=nnx.Param(jnp.zeros(4, dtype=jnp.float32))
+            ),
+        }
+    )
 
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(
@@ -1768,10 +1833,10 @@ class UtilsTest(parameterized.TestCase):
     )
 
     np.testing.assert_array_equal(
-        dst_state['layers_0']['weight'][...], scanned[0]
+        dst_state["layers_0"]["weight"][...], scanned[0]
     )
     np.testing.assert_array_equal(
-        dst_state['layers_1']['weight'][...], scanned[1]
+        dst_state["layers_1"]["weight"][...], scanned[1]
     )
 
   def test_transfer_state_directly_fuses_moe_weights_with_padding(self):
@@ -1832,15 +1897,19 @@ class UtilsTest(parameterized.TestCase):
     """
     # Source: scanned [experts=3, num_layers=2, features=2] with scan_axis=1.
     wi_0_val = jnp.array(
-        [[[1., 2.], [10., 20.]],
-         [[3., 4.], [30., 40.]],
-         [[5., 6.], [50., 60.]]],
+        [
+            [[1.0, 2.0], [10.0, 20.0]],
+            [[3.0, 4.0], [30.0, 40.0]],
+            [[5.0, 6.0], [50.0, 60.0]],
+        ],
         dtype=jnp.float32,
     )
     wi_1_val = jnp.array(
-        [[[100., 200.], [1000., 2000.]],
-         [[300., 400.], [3000., 4000.]],
-         [[500., 600.], [5000., 6000.]]],
+        [
+            [[100.0, 200.0], [1000.0, 2000.0]],
+            [[300.0, 400.0], [3000.0, 4000.0]],
+            [[500.0, 600.0], [5000.0, 6000.0]],
+        ],
         dtype=jnp.float32,
     )
 
@@ -1859,18 +1928,24 @@ class UtilsTest(parameterized.TestCase):
     sharding = NamedSharding(mesh, PartitionSpec(None, "model"))
 
     # Per-layer fused target: (3 experts, 8 features). Two layers, unrolled dst.
-    dst_state = nnx.Dict(**{
-        'layers_0': nnx.Dict(
-            wi=nnx.Param(
-                jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharding)
-            )
-        ),
-        'layers_1': nnx.Dict(
-            wi=nnx.Param(
-                jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharding)
-            )
-        ),
-    })
+    dst_state = nnx.Dict(
+        **{
+            "layers_0": nnx.Dict(
+                wi=nnx.Param(
+                    jax.device_put(
+                        jnp.zeros((3, 8), dtype=jnp.float32), sharding
+                    )
+                )
+            ),
+            "layers_1": nnx.Dict(
+                wi=nnx.Param(
+                    jax.device_put(
+                        jnp.zeros((3, 8), dtype=jnp.float32), sharding
+                    )
+                )
+            ),
+        }
+    )
 
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
@@ -1881,17 +1956,17 @@ class UtilsTest(parameterized.TestCase):
     # gives [a, 0, c, 0, b, 0, d, 0].
     expected_layers_0 = jnp.array(
         [
-            [1., 0., 100., 0., 2., 0., 200., 0.],
-            [3., 0., 300., 0., 4., 0., 400., 0.],
-            [5., 0., 500., 0., 6., 0., 600., 0.],
+            [1.0, 0.0, 100.0, 0.0, 2.0, 0.0, 200.0, 0.0],
+            [3.0, 0.0, 300.0, 0.0, 4.0, 0.0, 400.0, 0.0],
+            [5.0, 0.0, 500.0, 0.0, 6.0, 0.0, 600.0, 0.0],
         ],
         dtype=jnp.float32,
     )
     expected_layers_1 = jnp.array(
         [
-            [10., 0., 1000., 0., 20., 0., 2000., 0.],
-            [30., 0., 3000., 0., 40., 0., 4000., 0.],
-            [50., 0., 5000., 0., 60., 0., 6000., 0.],
+            [10.0, 0.0, 1000.0, 0.0, 20.0, 0.0, 2000.0, 0.0],
+            [30.0, 0.0, 3000.0, 0.0, 40.0, 0.0, 4000.0, 0.0],
+            [50.0, 0.0, 5000.0, 0.0, 60.0, 0.0, 6000.0, 0.0],
         ],
         dtype=jnp.float32,
     )
@@ -1921,24 +1996,22 @@ class UtilsTest(parameterized.TestCase):
     sharded = NamedSharding(mesh, PartitionSpec(None, "model"))
 
     wi_0_val = jnp.array(
-        [[1., 2., 3., 4.],
-         [5., 6., 7., 8.],
-         [9., 10., 11., 12.]],
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
         dtype=jnp.float32,
     )
     src_wi_0 = jax.device_put(wi_0_val, replicated)
 
     src_state = nnx.Dict(layers=nnx.Dict(wi_0=nnx.Param(src_wi_0)))
-    dst_state = nnx.Dict(layers=nnx.Dict(
-        wi_0=nnx.Param(
-            jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharded)
+    dst_state = nnx.Dict(
+        layers=nnx.Dict(
+            wi_0=nnx.Param(
+                jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharded)
+            )
         )
-    ))
+    )
 
     mock_reshard = lambda source, target: source
-    utils.transfer_state_directly(
-        src_state, dst_state, reshard_fn=mock_reshard
-    )
+    utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
     result = dst_state["layers"]["wi_0"][...]
 
     self.assertEqual(result.shape, (3, 8))
@@ -1948,9 +2021,11 @@ class UtilsTest(parameterized.TestCase):
     # -> [1, 2, 0, 0, 3, 4, 0, 0]. Device 0 sees [1, 2, 0, 0]; device 1
     # sees [3, 4, 0, 0] — no data shifts across the shard boundary.
     expected = jnp.array(
-        [[1., 2., 0., 0., 3., 4., 0., 0.],
-         [5., 6., 0., 0., 7., 8., 0., 0.],
-         [9., 10., 0., 0., 11., 12., 0., 0.]],
+        [
+            [1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0],
+            [5.0, 6.0, 0.0, 0.0, 7.0, 8.0, 0.0, 0.0],
+            [9.0, 10.0, 0.0, 0.0, 11.0, 12.0, 0.0, 0.0],
+        ],
         dtype=jnp.float32,
     )
     np.testing.assert_array_equal(result, expected)
@@ -1974,19 +2049,21 @@ class UtilsTest(parameterized.TestCase):
     sharded = NamedSharding(mesh, PartitionSpec(None, "model"))
 
     wi_0_val = jnp.array(
-        [[1., 2., 3., 4.],
-         [5., 6., 7., 8.],
-         [9., 10., 11., 12.]],
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
         dtype=jnp.float32,
     )
-    src_state = nnx.Dict(layers=nnx.Dict(
-        wi_0=nnx.Param(jax.device_put(wi_0_val, replicated)),
-    ))
-    dst_state = nnx.Dict(layers=nnx.Dict(
-        wi_0=nnx.Param(
-            jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharded)
-        ),
-    ))
+    src_state = nnx.Dict(
+        layers=nnx.Dict(
+            wi_0=nnx.Param(jax.device_put(wi_0_val, replicated)),
+        )
+    )
+    dst_state = nnx.Dict(
+        layers=nnx.Dict(
+            wi_0=nnx.Param(
+                jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharded)
+            ),
+        )
+    )
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
@@ -1994,9 +2071,11 @@ class UtilsTest(parameterized.TestCase):
     # gets 2 trailing zeros, then chunks flatten — so device 0 owns
     # `[a, b, 0, 0]` and device 1 owns `[c, d, 0, 0]` for each row.
     expected = jnp.array(
-        [[1., 2., 0., 0., 3., 4., 0., 0.],
-         [5., 6., 0., 0., 7., 8., 0., 0.],
-         [9., 10., 0., 0., 11., 12., 0., 0.]],
+        [
+            [1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0],
+            [5.0, 6.0, 0.0, 0.0, 7.0, 8.0, 0.0, 0.0],
+            [9.0, 10.0, 0.0, 0.0, 11.0, 12.0, 0.0, 0.0],
+        ],
         dtype=jnp.float32,
     )
     self.assertEqual(dst_state["layers"]["wi_0"][...].shape, (3, 8))
@@ -2020,22 +2099,28 @@ class UtilsTest(parameterized.TestCase):
 
     # Scanned replicated source: (experts=3, num_layers=2, features=4) at scan_axis=1.
     wi_0_unsharded = jnp.array(
-        [[[1., 2., 3., 4.], [10., 20., 30., 40.]],
-         [[5., 6., 7., 8.], [50., 60., 70., 80.]],
-         [[9., 10., 11., 12.], [90., 100., 110., 120.]]],
+        [
+            [[1.0, 2.0, 3.0, 4.0], [10.0, 20.0, 30.0, 40.0]],
+            [[5.0, 6.0, 7.0, 8.0], [50.0, 60.0, 70.0, 80.0]],
+            [[9.0, 10.0, 11.0, 12.0], [90.0, 100.0, 110.0, 120.0]],
+        ],
         dtype=jnp.float32,
     )
-    src_state = nnx.Dict(layers=nnx.Dict(
-        wi_0=nnx.Param(jax.device_put(wi_0_unsharded, replicated)),
-    ))
+    src_state = nnx.Dict(
+        layers=nnx.Dict(
+            wi_0=nnx.Param(jax.device_put(wi_0_unsharded, replicated)),
+        )
+    )
 
     def _zeros():
       return jax.device_put(jnp.zeros((3, 8), dtype=jnp.float32), sharded)
 
-    dst_state = nnx.Dict(**{
-        "layers_0": nnx.Dict(wi_0=nnx.Param(_zeros())),
-        "layers_1": nnx.Dict(wi_0=nnx.Param(_zeros())),
-    })
+    dst_state = nnx.Dict(
+        **{
+            "layers_0": nnx.Dict(wi_0=nnx.Param(_zeros())),
+            "layers_1": nnx.Dict(wi_0=nnx.Param(_zeros())),
+        }
+    )
     mock_reshard = lambda source, target: source
     utils.transfer_state_directly(src_state, dst_state, reshard_fn=mock_reshard)
 
@@ -2045,15 +2130,19 @@ class UtilsTest(parameterized.TestCase):
     # so the per-row layout becomes [a, b, 0, 0, c, d, 0, 0] — aligned with
     # the target's 2-shard split on the last axis.
     expected_layer_0 = jnp.array(
-        [[1., 2., 0., 0., 3., 4., 0., 0.],
-         [5., 6., 0., 0., 7., 8., 0., 0.],
-         [9., 10., 0., 0., 11., 12., 0., 0.]],
+        [
+            [1.0, 2.0, 0.0, 0.0, 3.0, 4.0, 0.0, 0.0],
+            [5.0, 6.0, 0.0, 0.0, 7.0, 8.0, 0.0, 0.0],
+            [9.0, 10.0, 0.0, 0.0, 11.0, 12.0, 0.0, 0.0],
+        ],
         dtype=jnp.float32,
     )
     expected_layer_1 = jnp.array(
-        [[10., 20., 0., 0., 30., 40., 0., 0.],
-         [50., 60., 0., 0., 70., 80., 0., 0.],
-         [90., 100., 0., 0., 110., 120., 0., 0.]],
+        [
+            [10.0, 20.0, 0.0, 0.0, 30.0, 40.0, 0.0, 0.0],
+            [50.0, 60.0, 0.0, 0.0, 70.0, 80.0, 0.0, 0.0],
+            [90.0, 100.0, 0.0, 0.0, 110.0, 120.0, 0.0, 0.0],
+        ],
         dtype=jnp.float32,
     )
     self.assertEqual(dst_state["layers_0"]["wi_0"][...].shape, (3, 8))
@@ -2073,7 +2162,7 @@ class UtilsTest(parameterized.TestCase):
     attention keys take the repeat-only path. This pins that contract.
     """
     src = jnp.array(
-        [[1., 2., 3., 4.], [5., 6., 7., 8.]], dtype=jnp.float32
+        [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype=jnp.float32
     )  # shape (2, 4) — kv_heads=2, head_dim=4
     tgt_shape = (8, 4)  # 4x KV-head expansion only.
     result = utils._align_per_axis(
@@ -2104,7 +2193,7 @@ class UtilsTest(parameterized.TestCase):
     mismatched axis. This test exercises a synthetic case to pin that down.
     """
     src = jnp.array(
-        [[[1., 2.], [3., 4.]]],  # (1, 2, 2)
+        [[[1.0, 2.0], [3.0, 4.0]]],  # (1, 2, 2)
         dtype=jnp.float32,
     )
     result = utils._align_per_axis(
@@ -2114,67 +2203,83 @@ class UtilsTest(parameterized.TestCase):
     expected = jnp.pad(src, ((0, 1), (0, 0), (0, 2)))
     np.testing.assert_array_equal(np.asarray(result), expected)
 
-
-
   def test_unroll_scanned_layers_dict_state(self):
-    src_state = {'layer_0.weight': jnp.ones((2, 4))}
+    src_state = {"layer_0.weight": jnp.ones((2, 4))}
     src_to_tgt_map = {
-        'layer_0.weight': (MockParam(jnp.zeros((2, 4))), 'decoder.layer_0.weight', None)
+        "layer_0.weight": (
+            MockParam(jnp.zeros((2, 4))),
+            "decoder.layer_0.weight",
+            None,
+        )
     }
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
-    self.assertIn(('layer_0.weight', 'decoder.layer_0.weight'), result)
-    self.assertTrue(jnp.array_equal(result[('layer_0.weight', 'decoder.layer_0.weight')][0], jnp.ones((2, 4))))
+    self.assertIn(("layer_0.weight", "decoder.layer_0.weight"), result)
+    self.assertTrue(
+        jnp.array_equal(
+            result[("layer_0.weight", "decoder.layer_0.weight")][0],
+            jnp.ones((2, 4)),
+        )
+    )
 
   def test_unroll_scanned_layers_flat_state(self):
-    src_state = MockState({'layer_0.weight': MockParam(jnp.ones((2, 4)))})
+    src_state = MockState({"layer_0.weight": MockParam(jnp.ones((2, 4)))})
     src_to_tgt_map = {
-        'layer_0.weight': (MockParam(jnp.zeros((2, 4))), 'decoder.layer_0.weight', None)
+        "layer_0.weight": (
+            MockParam(jnp.zeros((2, 4))),
+            "decoder.layer_0.weight",
+            None,
+        )
     }
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
-    self.assertIn(('layer_0.weight', 'decoder.layer_0.weight'), result)
+    self.assertIn(("layer_0.weight", "decoder.layer_0.weight"), result)
 
   def test_unroll_scanned_layers_skips_rng(self):
-    src_state = {'rng_seed': jnp.zeros(1), 'layer_0.weight': jnp.zeros((2, 4))}
+    src_state = {"rng_seed": jnp.zeros(1), "layer_0.weight": jnp.zeros((2, 4))}
     src_to_tgt_map = {
-        'layer_0.weight': (MockParam(jnp.zeros((2, 4))), 'decoder.layer_0.weight', None),
-        'rng_seed': (MockParam(jnp.zeros(1)), 'decoder.rng_seed', None)
+        "layer_0.weight": (
+            MockParam(jnp.zeros((2, 4))),
+            "decoder.layer_0.weight",
+            None,
+        ),
+        "rng_seed": (MockParam(jnp.zeros(1)), "decoder.rng_seed", None),
     }
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
-    self.assertNotIn(('rng_seed', 'decoder.rng_seed'), result)
-    self.assertIn(('layer_0.weight', 'decoder.layer_0.weight'), result)
+    self.assertNotIn(("rng_seed", "decoder.rng_seed"), result)
+    self.assertIn(("layer_0.weight", "decoder.layer_0.weight"), result)
 
   def test_unroll_scanned_layers_skips_missing_mapping(self):
-    src_state = {'missing.weight': jnp.zeros((2, 4))}
+    src_state = {"missing.weight": jnp.zeros((2, 4))}
     src_to_tgt_map = {}
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
     self.assertEmpty(result)
 
   def test_unroll_scanned_layers_unrolls_with_layer_axis(self):
-    sharding_spec = ('layer', 'model')
-    src_state = {'scanned.weight': jnp.ones((2, 4))}
+    sharding_spec = ("layer", "model")
+    src_state = {"scanned.weight": jnp.ones((2, 4))}
     tgt_param = [MockParam(jnp.zeros((4,))), MockParam(jnp.zeros((4,)))]
-    tgt_path = ['layer_0.weight', 'layer_1.weight']
-    src_to_tgt_map = {
-        'scanned.weight': (tgt_param, tgt_path, sharding_spec)
-    }
+    tgt_path = ["layer_0.weight", "layer_1.weight"]
+    src_to_tgt_map = {"scanned.weight": (tgt_param, tgt_path, sharding_spec)}
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
-    self.assertIn(('scanned.weight', 'layer_0.weight'), result)
-    self.assertIn(('scanned.weight', 'layer_1.weight'), result)
-    val0, param0 = result[('scanned.weight', 'layer_0.weight')]
+    self.assertIn(("scanned.weight", "layer_0.weight"), result)
+    self.assertIn(("scanned.weight", "layer_1.weight"), result)
+    val0, param0 = result[("scanned.weight", "layer_0.weight")]
     self.assertTrue(jnp.array_equal(val0, jnp.ones((4,))))
     self.assertIs(param0, tgt_param[0])
 
-  @mock.patch('tunix.generate.utils.nnx.to_flat_state')
+  @mock.patch("tunix.generate.utils.nnx.to_flat_state")
   def test_unroll_scanned_layers_nnx_fallback(self, mock_to_flat_state):
     src_state = "dummy_state"
-    mock_to_flat_state.return_value = [(('layer_0', 'weight'), jnp.ones((2, 4)))]
+    mock_to_flat_state.return_value = [(
+        ("layer_0", "weight"),
+        jnp.ones((2, 4)),
+    )]
     tgt_param = MockParam(jnp.zeros((2, 4)))
     src_to_tgt_map = {
-        'layer_0.weight': (tgt_param, 'decoder.layer_0.weight', None)
+        "layer_0.weight": (tgt_param, "decoder.layer_0.weight", None)
     }
     result = utils._unroll_scanned_layers(src_state, src_to_tgt_map)
-    self.assertIn(('layer_0.weight', 'decoder.layer_0.weight'), result)
-    val, p = result[('layer_0.weight', 'decoder.layer_0.weight')]
+    self.assertIn(("layer_0.weight", "decoder.layer_0.weight"), result)
+    val, p = result[("layer_0.weight", "decoder.layer_0.weight")]
     self.assertTrue(jnp.array_equal(val, jnp.ones((2, 4))))
     mock_to_flat_state.assert_called_once_with("dummy_state")
 
@@ -2248,6 +2353,74 @@ class ResolveParallelismSizesTest(parameterized.TestCase):
         res["vllm_model.lm_head.weight"],
         jnp.ones((4, 8), dtype=jnp.float32),
     )
+
+  def test_interleave_moe_weights_lane_interleaving(self):
+    """Tests 128-lane interleaving of wi_0 and wi_1 per shard."""
+    lane_size = 128
+    n_shards = 2
+    chunk_size = 2 * lane_size  # 256
+    dim = n_shards * chunk_size  # 512
+    wi_0 = jnp.arange(dim, dtype=jnp.float32).reshape(1, dim)
+    wi_1 = (jnp.arange(dim, dtype=jnp.float32) + 10000.0).reshape(1, dim)
+    tgt_shape = (1, dim * 2)
+
+    interleaved = utils._interleave_moe_weights(
+        wi_0,
+        wi_1,
+        tgt_shape=tgt_shape,
+        n_shards=n_shards,
+        axis=-1,
+        lane_size=lane_size,
+    )
+
+    self.assertEqual(interleaved.shape, tgt_shape)
+    reshaped = interleaved.reshape(1, n_shards, 2, 2, lane_size)
+    np.testing.assert_array_equal(reshaped[0, 0, 0, 0], wi_0[0, :lane_size])
+    np.testing.assert_array_equal(reshaped[0, 0, 0, 1], wi_1[0, :lane_size])
+    np.testing.assert_array_equal(
+        reshaped[0, 0, 1, 0], wi_0[0, lane_size : 2 * lane_size]
+    )
+    np.testing.assert_array_equal(
+        reshaped[0, 0, 1, 1], wi_1[0, lane_size : 2 * lane_size]
+    )
+
+  def test_interleave_moe_weights_fallback_when_lane_size_zero(self):
+    """Verifies standard concatenation when lane_size is 0 (e.g. non-v5p TPU)."""
+    dim = 256
+    wi_0 = jnp.arange(dim, dtype=jnp.float32).reshape(1, dim)
+    wi_1 = (jnp.arange(dim, dtype=jnp.float32) + 1000.0).reshape(1, dim)
+    tgt_shape = (1, dim * 2)
+
+    interleaved = utils._interleave_moe_weights(
+        wi_0,
+        wi_1,
+        tgt_shape=tgt_shape,
+        n_shards=1,
+        axis=-1,
+        lane_size=0,
+    )
+    self.assertEqual(interleaved.shape, tgt_shape)
+    expected = jnp.concatenate([wi_0, wi_1], axis=-1)
+    np.testing.assert_array_equal(interleaved, expected)
+
+  def test_interleave_moe_weights_fallback_when_lane_size_none(self):
+    """Verifies standard concatenation when lane_size is None."""
+    dim = 256
+    wi_0 = jnp.arange(dim, dtype=jnp.float32).reshape(1, dim)
+    wi_1 = (jnp.arange(dim, dtype=jnp.float32) + 1000.0).reshape(1, dim)
+    tgt_shape = (1, dim * 2)
+
+    interleaved = utils._interleave_moe_weights(
+        wi_0,
+        wi_1,
+        tgt_shape=tgt_shape,
+        n_shards=1,
+        axis=-1,
+        lane_size=None,
+    )
+    self.assertEqual(interleaved.shape, tgt_shape)
+    expected = jnp.concatenate([wi_0, wi_1], axis=-1)
+    np.testing.assert_array_equal(interleaved, expected)
 
 
 if __name__ == "__main__":

--- a/tunix/generate/utils.py
+++ b/tunix/generate/utils.py
@@ -157,7 +157,8 @@ def np_find_first_non_pad_idx(ids: np.ndarray, pad_id: int) -> int:
 
 
 def np_find_first_eos_idx(
-    ids: np.ndarray, eos_id: int | jax.Array,
+    ids: np.ndarray,
+    eos_id: int | jax.Array,
 ) -> int:
   """Numpy version of find_first_eos_idx. Works on CPU arrays."""
   assert ids.ndim == 1, f'ids should be a 1d array. Got: {ids.shape}'
@@ -663,16 +664,24 @@ def _align_shape(
           new_tgt_shape = tgt_shape[:-1] + (repeated_dim, padded_dim)
     elif re.compile(r'layers\..*\.moe\.gating_einsum').match(src_key):
       tp_size = kwargs['tp_size']
-      num_experts, expert_dim, embed_dim = val.shape[0], val.shape[2], val.shape[3]
+      num_experts, expert_dim, embed_dim = (
+          val.shape[0],
+          val.shape[2],
+          val.shape[3],
+      )
       gate_chunks, up_chunks = val[:, 0, :, :], val[:, 1, :, :]
       chunk_size = expert_dim // tp_size
-      padded_expert_chunk_dim = ((chunk_size + 127)//128)*128
+      padded_expert_chunk_dim = ((chunk_size + 127) // 128) * 128
       pad_amount = padded_expert_chunk_dim - chunk_size
       gate_chunks = gate_chunks.reshape(num_experts, tp_size, -1, embed_dim)
       up_chunks = up_chunks.reshape(num_experts, tp_size, -1, embed_dim)
       if pad_amount > 0:
-        gate_chunks = jnp.pad(gate_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0)))
-        up_chunks = jnp.pad(up_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0)))
+        gate_chunks = jnp.pad(
+            gate_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0))
+        )
+        up_chunks = jnp.pad(
+            up_chunks, ((0, 0), (0, 0), (0, pad_amount), (0, 0))
+        )
       val_chunks = jnp.stack([gate_chunks, up_chunks], axis=2)
       val_chunks = val_chunks.reshape(num_experts, -1, embed_dim)
       val_chunks = val_chunks.transpose(0, 2, 1)
@@ -682,9 +691,7 @@ def _align_shape(
           f'Rank mismatch for {src_key}: {val.shape} vs {tgt_shape}'
       )
   elif re.compile(r'layers\..*\.attn\.(k|v)_bias').match(src_key):
-    logging.debug(
-        'Handling 1-D KV bias for %s in SGLangJAX rollout.', src_key
-    )
+    logging.debug('Handling 1-D KV bias for %s in SGLangJAX rollout.', src_key)
     assert tgt_shape[0] > val.shape[0] and tgt_shape[0] % val.shape[0] == 0, (
         f'Unexpected attention bias shape: {val.shape} and target shape:'
         f' {tgt_shape}'
@@ -957,7 +964,11 @@ def transfer_state_with_mappings(
     return dst_state.from_flat_path(tgt_flat_list)
   elif isinstance(dst_state, dict):
     return {
-        ('.'.join(str(k) for k in key) if isinstance(key, (tuple, list)) else key): val
+        (
+            '.'.join(str(k) for k in key)
+            if isinstance(key, (tuple, list))
+            else key
+        ): val
         for key, val in tgt_flat_list
     }
   else:
@@ -1023,7 +1034,9 @@ def _unstack_scanned_param(
     if scan_axis is not None:
       # Transpose the scanned axis to the 0th position
       if scan_axis != 0:
-        perm = (scan_axis,) + tuple(i for i in range(len(src_shape)) if i != scan_axis)
+        perm = (scan_axis,) + tuple(
+            i for i in range(len(src_shape)) if i != scan_axis
+        )
         if hasattr(src_val, 'transpose'):
           src_val = src_val.transpose(perm)
         elif isinstance(src_val, np.ndarray):
@@ -1037,19 +1050,22 @@ def _unstack_scanned_param(
         elif hasattr(jnp, 'unstack'):
           return jnp.unstack(src_val)
         else:
-           # Fallback for older JAX versions
+          # Fallback for older JAX versions
           return [src_val[i] for i in range(src_val.shape[0])]  # pyrefly: ignore[bad-return]
       except Exception as e:
         logging.debug(
             "Failed to unstack parameter '%s'. Error: %s. Using original.",
-            key_path, e
+            key_path,
+            e,
         )
         return (src_val,)
     else:
       logging.warning(
           "Shape mismatch in scanned param '%s'. Src: %s, Tgt: %s. Cannot"
           ' determine scan axis.',
-          key_path, src_shape, tgt_shape,
+          key_path,
+          src_shape,
+          tgt_shape,
       )
 
   return (src_val,)
@@ -1158,7 +1174,7 @@ def _align_per_axis(
     return arr
   if len(arr.shape) != len(tgt_shape):
     raise ShapeMismatchError(
-        f"Rank mismatch for {key_path}: src={arr.shape} vs tgt={tgt_shape}"
+        f'Rank mismatch for {key_path}: src={arr.shape} vs tgt={tgt_shape}'
     )
 
   mismatches = []
@@ -1167,7 +1183,7 @@ def _align_per_axis(
       continue
     if t < s:
       raise ShapeMismatchError(
-          f"Cannot shrink axis {axis} for {key_path}: src={s} -> tgt={t}"
+          f'Cannot shrink axis {axis} for {key_path}: src={s} -> tgt={t}'
       )
     mismatches.append((axis, s, t))
   if not mismatches:
@@ -1182,16 +1198,16 @@ def _align_per_axis(
         n_shards = _partition_size(_spec_at_axis(tgt_sharding, axis), mesh)  # pyrefly: ignore[bad-argument-type]
         if t % n_shards != 0:
           raise ValueError(
-              f"Target dimension {t} on axis {axis} for {key_path} is not "
-              f"divisible by n_shards={n_shards}; the target shape itself "
-              f"is misconfigured for the requested sharding."
+              f'Target dimension {t} on axis {axis} for {key_path} is not '
+              f'divisible by n_shards={n_shards}; the target shape itself '
+              'is misconfigured for the requested sharding.'
           )
         if (t - s) % n_shards != 0 or s % n_shards != 0:
           raise ValueError(
-              f"Cannot interleave pad axis {axis} for {key_path}: src_dim "
-              f"({s}) or extra ({t - s}) is not cleanly divisible by "
-              f"n_shards ({n_shards}). Ensure the source tensor is evenly "
-              f"partitionable."
+              f'Cannot interleave pad axis {axis} for {key_path}: src_dim '
+              f'({s}) or extra ({t - s}) is not cleanly divisible by '
+              f'n_shards ({n_shards}). Ensure the source tensor is evenly '
+              'partitionable.'
           )
         pad_specs.append((axis, n_shards, (t - s) // n_shards))
     else:
@@ -1202,9 +1218,9 @@ def _align_per_axis(
   for axis, s, t in mismatches:
     if t % s != 0:
       raise ShapeMismatchError(
-          f"Cannot align axis {axis} for {key_path}: src={s} -> tgt={t} "
-          f"is not an integer multiple and the key is not a recognized "
-          f"MoE pattern."
+          f'Cannot align axis {axis} for {key_path}: src={s} -> tgt={t} '
+          'is not an integer multiple and the key is not a recognized '
+          'MoE pattern.'
       )
     repeats.append((axis, t // s))
   return _jit_repeat_axes(arr, tuple(repeats))
@@ -1216,17 +1232,27 @@ def _interleave_moe_weights(
     tgt_shape: Tuple[int, ...],
     n_shards: int,
     axis: Optional[int] = None,
+    lane_size: Optional[int] = 0,
 ) -> jax.Array | np.ndarray:
-  """Interleaves wi_0 and wi_1 per-shard into a single tensor."""
+  """Interleaves wi_0 and wi_1 per-shard into a single tensor matching TPU GMM layout.
+
+  When lane_size > 0, Gate and Up alternate in lane_size chunks along the inner dimension.
+  When lane_size == 0 or None, each TP shard is plain concatenation [local_gate, local_up].
+  """
+  if lane_size is None:
+    lane_size = 0
+
   if axis is None:
     axis = len(tgt_shape) - 1
-    
+  elif axis < 0:
+    axis = len(tgt_shape) + axis
+
   target_half_dim = tgt_shape[axis] // 2
+  target_chunk_size = target_half_dim // n_shards
 
   def _pad_and_chunk(arr):
     current_total_size = arr.shape[axis]
     chunk_size = current_total_size // n_shards
-    target_chunk_size = target_half_dim // n_shards
 
     # Safely reshape to expose per-shard chunk without assuming the last axis
     new_shape = list(arr.shape)
@@ -1244,8 +1270,20 @@ def _interleave_moe_weights(
   p_wi_0 = _pad_and_chunk(wi_0)
   p_wi_1 = _pad_and_chunk(wi_1)
 
-  # Interleave along the chunked dimension
-  combined = jnp.concatenate([p_wi_0, p_wi_1], axis=axis + 1)
+  if lane_size > 0 and target_chunk_size % lane_size == 0:
+    # Interleave in 128-lane chunks within each shard:
+    # [Gate_c0 (128), Up_c0 (128), Gate_c1 (128), Up_c1 (128), ...]
+    num_lanes = target_chunk_size // lane_size
+    shape_lanes = list(p_wi_0.shape)
+    shape_lanes[axis + 1] = num_lanes
+    shape_lanes.insert(axis + 2, lane_size)
+    p_wi_0 = p_wi_0.reshape(shape_lanes)
+    p_wi_1 = p_wi_1.reshape(shape_lanes)
+    combined = jnp.stack([p_wi_0, p_wi_1], axis=axis + 2)
+  else:
+    # Fallback when dimension is not divisible by lane_size:
+    combined = jnp.concatenate([p_wi_0, p_wi_1], axis=axis + 1)
+
   return combined.reshape(tgt_shape)
 
 
@@ -1334,7 +1372,7 @@ def _scanned_sharding_from_per_layer(
   )
 
 
-@functools.partial(jax.jit, static_argnums=(2, 3, 4, 5, 6, 7))
+@functools.partial(jax.jit, static_argnums=(2, 3, 4, 5, 6, 7, 8))
 def _jit_fuse_and_unstack_moe(
     wi_0: jax.Array | np.ndarray,
     wi_1: jax.Array | np.ndarray,
@@ -1344,6 +1382,7 @@ def _jit_fuse_and_unstack_moe(
     tgt_shape: Tuple[int, ...],
     scan_padded_axis: int,
     tgt_padded_axis: int,
+    lane_size: Optional[int] = 0,
 ) -> Tuple[jax.Array | np.ndarray, ...]:
   """Fuses wi_0/wi_1 along the padded axis, then unstacks along scan_axis.
 
@@ -1360,6 +1399,7 @@ def _jit_fuse_and_unstack_moe(
     tgt_shape: Per-layer fused target shape (fused mlp dim on `tgt_padded_axis`).
     scan_padded_axis: Position of the padded axis in the scanned layout.
     tgt_padded_axis: Position of the padded axis in the per-layer layout.
+    lane_size: Subcore lane size for interleaving (defaults to 0 for TPU GMM layout concatenation).
 
   Returns:
     Tuple of `num_layers` per-layer arrays, each with shape `tgt_shape`.
@@ -1369,7 +1409,12 @@ def _jit_fuse_and_unstack_moe(
   fused_shape[scan_padded_axis] = tgt_shape[tgt_padded_axis]
 
   fused = _interleave_moe_weights(
-      wi_0, wi_1, tuple(fused_shape), n_shards, axis=scan_padded_axis
+      wi_0,
+      wi_1,
+      tuple(fused_shape),
+      n_shards,
+      axis=scan_padded_axis,
+      lane_size=lane_size,
   )
   return jnp.unstack(fused, axis=scan_axis)
 
@@ -1377,6 +1422,7 @@ def _jit_fuse_and_unstack_moe(
 def _fuse_moe_weights(
     src_flat: Dict[Tuple[str, ...], jax.Array | np.ndarray],
     tgt_flat: Dict[Tuple[str, ...], jax.Array | np.ndarray],
+    lane_size: Optional[int] = 0,
 ) -> Dict[Tuple[str, ...], jax.Array | np.ndarray]:
   """Fuses unscanned wi_0/wi_1 into wi for unscanned-fused targets.
 
@@ -1389,6 +1435,7 @@ def _fuse_moe_weights(
   Args:
     src_flat: Flat dict of source key tuples to JAX arrays.
     tgt_flat: Flat dict of target key tuples to target leaves.
+    lane_size: Subcore lane size for interleaving (defaults to 0 for TPU GMM layout concatenation).
 
   Returns:
     A new flat dict with wi_0/wi_1 fused into wi at matching prefixes. Any
@@ -1416,10 +1463,13 @@ def _fuse_moe_weights(
     logging.info(
         'Fusing MoE %s: wi_0=%s, wi_1=%s -> %s on axis %d',
         '.'.join(str(k) for k in tgt_key),
-        wi_0.shape, wi_1.shape, tgt_val.shape, axis,
+        wi_0.shape,
+        wi_1.shape,
+        tgt_val.shape,
+        axis,
     )
     new_src_flat[tgt_key] = _interleave_moe_weights(
-        wi_0, wi_1, tgt_val.shape, n_shards, axis=axis
+        wi_0, wi_1, tgt_val.shape, n_shards, axis=axis, lane_size=lane_size
     )
     del wi_0, wi_1  # Free memory immediately after fusion.
   return new_src_flat
@@ -1444,7 +1494,7 @@ def _collect_src_buffer_ids(
       try:
         ids.add(shard.data.unsafe_buffer_pointer())
       except jax.errors.JaxRuntimeError as e:
-        if "PjRt-compatible backend only" in str(e):
+        if 'PjRt-compatible backend only' in str(e):
           # Backend doesn't support unsafe pointers (e.g., disaggregated Pathways setup).
           # Fast-fail and return None to signal that aliasing checks should be skipped.
           return None
@@ -1465,9 +1515,10 @@ def _delete_target_buffers(
   for tgt_val in spec_flat.values():
     tgt_arr = tgt_val.value if hasattr(tgt_val, 'value') else tgt_val
     # Skip if the array cannot be deleted or is already deleted
-    if not hasattr(tgt_arr, 'delete') or getattr(
-        tgt_arr, 'is_deleted', lambda: False
-    )():
+    if (
+        not hasattr(tgt_arr, 'delete')
+        or getattr(tgt_arr, 'is_deleted', lambda: False)()
+    ):
       continue
     # Check for aliasing only if the backend supports buffer pointer tracking
     if src_buffer_ids is not None and hasattr(tgt_arr, 'addressable_shards'):
@@ -1495,7 +1546,9 @@ def _snapshot_dst_sharding(
   ):
     return arr
 
-  assert hasattr(arr, 'sharding'), f'Expected array with sharding, got {type(arr)}'
+  assert hasattr(
+      arr, 'sharding'
+  ), f'Expected array with sharding, got {type(arr)}'
   s = arr.sharding
 
   if isinstance(
@@ -1507,7 +1560,9 @@ def _snapshot_dst_sharding(
 
 def _reshard_in_chunks(
     src_flat: Dict[Union[str, Tuple[str, ...]], jax.Array | np.ndarray],
-    spec_flat: Dict[Union[str, Tuple[str, ...]], jax.Array | np.ndarray | nnx.Variable],
+    spec_flat: Dict[
+        Union[str, Tuple[str, ...]], jax.Array | np.ndarray | nnx.Variable
+    ],
     reshard_fn: Callable[..., Mapping[str, Any]],
     chunk_size: int,
     delete_spec_buffers: bool = False,
@@ -1585,6 +1640,7 @@ def transfer_state_directly(
     scan_axis: int = 1,
     delete_dst_buffers: bool = False,
     reshard_chunk_size: Optional[int] = None,
+    moe_lane_size: Optional[int] = 0,
 ) -> None:
   """Transfers state directly by matching structure, stripping wrappers.
 
@@ -1612,7 +1668,10 @@ def transfer_state_directly(
       start with roughly `10 * num_layers` for a dense transformer and tune
       downward if you still see fragmentation. When None (default) the
       original single-call reshard behavior is preserved.
+    moe_lane_size: Subcore lane size for MoE weight interleaving (defaults to 0
+      for TPU GMM layout concatenation).
   """
+
   def safe_has_key(obj: Mapping[str, Any], key: str) -> bool:
     if isinstance(obj, dict):
       return key in obj
@@ -1620,16 +1679,12 @@ def transfer_state_directly(
     return hasattr(obj, key)
 
   # Unwrap Source (Remove 'base' wrapper from MaxText)
-  if isinstance(src_state, abc.Mapping) and safe_has_key(
-      src_state, 'base'
-  ):
+  if isinstance(src_state, abc.Mapping) and safe_has_key(src_state, 'base'):
     logging.info("Unwrapping 'base' key from source state.")
     src_state = src_state['base']
 
   # Unwrap Target (Remove nested 'model' wrappers from vLLM)
-  while isinstance(dst_state, abc.Mapping) and safe_has_key(
-      dst_state, 'model'
-  ):
+  while isinstance(dst_state, abc.Mapping) and safe_has_key(dst_state, 'model'):
     logging.info("Unwrapping nested 'model' key from target state.")
     dst_state = dst_state['model']
 
@@ -1661,7 +1716,9 @@ def transfer_state_directly(
     Uses flat dictionary traversal for efficiency.
     """
     # Fast path for non-dict inputs (leaves)
-    if not isinstance(src, abc.Mapping) or not isinstance(tgt_spec, abc.Mapping):
+    if not isinstance(src, abc.Mapping) or not isinstance(
+        tgt_spec, abc.Mapping
+    ):
       return src, tgt_spec
 
     # Flatten both structures to (path_tuple) -> value
@@ -1669,7 +1726,7 @@ def transfer_state_directly(
     src_flat = traverse_util.flatten_dict(src)
     tgt_flat = traverse_util.flatten_dict(tgt_spec)
 
-    src_flat = _fuse_moe_weights(src_flat, tgt_flat)
+    src_flat = _fuse_moe_weights(src_flat, tgt_flat, lane_size=moe_lane_size)
 
     filtered_src_flat = {}
     filtered_tgt_flat = {}
@@ -1734,7 +1791,7 @@ def transfer_state_directly(
             # Cast the bulk tensor once before unstacking.
             src_val = _apply_dtype_cast(src_val, tgt_val.dtype, candidate_path)
             scanned_per_layer_shape = (
-                src_val.shape[:scan_axis] + src_val.shape[scan_axis + 1:]
+                src_val.shape[:scan_axis] + src_val.shape[scan_axis + 1 :]
             )
             if scanned_per_layer_shape == tgt_val.shape:
               # Pure unstack — no alignment needed.
@@ -1747,7 +1804,9 @@ def transfer_state_directly(
               # one bulk op + free unstack.
               logging.info(
                   'Bulk-aligning scanned %s: %s -> per-layer %s',
-                  candidate_path, src_val.shape, tgt_val.shape,
+                  candidate_path,
+                  src_val.shape,
+                  tgt_val.shape,
               )
               unstacked_cache[cache_key] = _bulk_align_and_unstack(
                   src_val, scan_axis, tgt_val, candidate_path
@@ -1767,7 +1826,9 @@ def transfer_state_directly(
         # allocations that cause compilation pressure and memory fragmentation.
         if key_tuple and key_tuple[-1] == 'wi':
           scanned_prefix = (
-              key_tuple[:match_index] + ('layers',) + key_tuple[match_index + 1:-1]
+              key_tuple[:match_index]
+              + ('layers',)
+              + key_tuple[match_index + 1 : -1]
           )
           wi_0_key = scanned_prefix + ('wi_0',)
           wi_1_key = scanned_prefix + ('wi_1',)
@@ -1776,28 +1837,54 @@ def transfer_state_directly(
             fused_scanned_key = scanned_prefix + ('wi_fused',)
             if fused_scanned_key not in unstacked_cache:
               scanned_prefix_path = '.'.join(str(k) for k in scanned_prefix)
-              logging.info('Fusing scanned MoE weights for %s', scanned_prefix_path)
+              logging.info(
+                  'Fusing scanned MoE weights for %s', scanned_prefix_path
+              )
               wi_0_full = _apply_dtype_cast(
-                  src_flat[wi_0_key], tgt_val.dtype, '.'.join(str(k) for k in wi_0_key)
+                  src_flat[wi_0_key],
+                  tgt_val.dtype,
+                  '.'.join(str(k) for k in wi_0_key),
               )
               wi_1_full = _apply_dtype_cast(
-                  src_flat[wi_1_key], tgt_val.dtype, '.'.join(str(k) for k in wi_1_key)
+                  src_flat[wi_1_key],
+                  tgt_val.dtype,
+                  '.'.join(str(k) for k in wi_1_key),
               )
               num_layers = src_flat[wi_0_key].shape[scan_axis]
-              
+
               # Remove scan_axis to compare against the per-layer tgt_val shape
-              wi_0_single_shape = wi_0_full.shape[:scan_axis] + wi_0_full.shape[scan_axis + 1:]
+              wi_0_single_shape = (
+                  wi_0_full.shape[:scan_axis] + wi_0_full.shape[scan_axis + 1 :]
+              )
               mismatched_axes = [
-                  i for i, (s, t) in enumerate(zip(wi_0_single_shape, tgt_val.shape)) if s != t
+                  i
+                  for i, (s, t) in enumerate(
+                      zip(wi_0_single_shape, tgt_val.shape)
+                  )
+                  if s != t
               ]
-              tgt_axis = mismatched_axes[-1] if mismatched_axes else len(tgt_val.shape) - 1
+              tgt_axis = (
+                  mismatched_axes[-1]
+                  if mismatched_axes
+                  else len(tgt_val.shape) - 1
+              )
               n_shards = _get_n_shards(tgt_val, tgt_axis)
-              
+
               # Offset the axis by 1 if it falls after the scan axis in the bulk tensor
-              scan_padded_axis = tgt_axis if tgt_axis < scan_axis else tgt_axis + 1
+              scan_padded_axis = (
+                  tgt_axis if tgt_axis < scan_axis else tgt_axis + 1
+              )
 
               unstacked_cache[fused_scanned_key] = _jit_fuse_and_unstack_moe(
-                  wi_0_full, wi_1_full, scan_axis, num_layers, n_shards, tgt_val.shape, scan_padded_axis, tgt_axis
+                  wi_0_full,
+                  wi_1_full,
+                  scan_axis,
+                  num_layers,
+                  n_shards,
+                  tgt_val.shape,
+                  scan_padded_axis,
+                  tgt_axis,
+                  lane_size=moe_lane_size,
               )
               del wi_0_full, wi_1_full
 
@@ -1892,20 +1979,20 @@ def resolve_parallelism_sizes(
 
   if total_mesh_devices % expert_parallel_size != 0:
     raise ValueError(
-        f"Total mesh devices ({total_mesh_devices}) must be divisible by"
-        f" expert_parallel_size ({expert_parallel_size})."
+        f'Total mesh devices ({total_mesh_devices}) must be divisible by'
+        f' expert_parallel_size ({expert_parallel_size}).'
     )
 
   if tensor_parallel_size == -1 and data_parallel_size == -1:
     tensor_parallel_size = total_mesh_devices // expert_parallel_size
     data_parallel_size = 1
   elif tensor_parallel_size == -1:
-    tensor_parallel_size = (
-        total_mesh_devices // (data_parallel_size * expert_parallel_size)
+    tensor_parallel_size = total_mesh_devices // (
+        data_parallel_size * expert_parallel_size
     )
   elif data_parallel_size == -1:
-    data_parallel_size = (
-        total_mesh_devices // (tensor_parallel_size * expert_parallel_size)
+    data_parallel_size = total_mesh_devices // (
+        tensor_parallel_size * expert_parallel_size
     )
 
   return tensor_parallel_size, data_parallel_size, expert_parallel_size
@@ -1943,7 +2030,6 @@ def verify_state_closeness(golden_state, state, atol=1e-2):
   # Check that weights match
   matched = True
   for key in golden_state_flatten.keys():
-
     if golden_state_flatten[key].value.shape != state_flatten[key].value.shape:
       logging.info(
           'Shape mismatch for key %s: golden %s, loaded %s',


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #2083.
**Pairs with MaxText [M2]** (`AI-Hypercomputer/maxtext`).

**Stack:**
- [T1] https://github.com/google/tunix/pull/2146: Multi-host discovery & multi-axis sharding in RaidenHandler
- [T2a] https://github.com/google/tunix/pull/2147: Transport selection, FFI preflight mismatch check, and host-stage normalization
- [T3] https://github.com/google/tunix/pull/2148: Extract RaidenDestinationWeightSyncMixin
- [T4] https://github.com/google/tunix/pull/2149: Cache lifecycle and prefix caching
- **[T5] google/tunix (this PR)**: MoE 128-lane interleaving for TPU GMM layout (pairs with MaxText M2)
- [T6] google/tunix: MaxText trainer configuration plumbing

## Details
- Implements 128-lane interleaving in `_interleave_moe_weights` using `TPU_V5P_SUBCORE_LANE_SIZE = 128` to match TPU GMM kernel expectations (`gmm_v2.py`).
- Supports negative-axis indexing.
- Handles `flat_state` updating in `transfer_state_directly`.
- Adds dedicated unit test in `tests/generate/utils_test.py` verifying 128-lane interleaving per shard.

## Verification
- `pytest tests/generate/utils_test.py` (65/65 passed).