### PR TITLE
[Raiden Weight Sync 6/6] MaxText trainer config plumbing and MoE dimension padding

### DIFF
--- a/requirements/maxtext_requirements.txt
+++ b/requirements/maxtext_requirements.txt
@@ -1,3 +1,4 @@
+# TODO(maxtext-dev): Update the commits after all code changes land.
 maxtext @ git+https://github.com/AI-Hypercomputer/maxtext.git@8c2e29218c01b6287ba85e8d0dc9555561f7634c
 maxtext-vllm-adapter @ git+https://github.com/AI-Hypercomputer/maxtext.git@8c2e29218c01b6287ba85e8d0dc9555561f7634c#subdirectory=src/maxtext/integration/vllm
 aqtp

--- a/tests/utils/maxtext_utils_test.py
+++ b/tests/utils/maxtext_utils_test.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+try:
+  from absl.testing import absltest
+except ImportError:
+  import unittest as absltest
+
+from tunix.utils import maxtext_utils
+
+
+class MaxTextUtilsTest(absltest.TestCase):
+
+  def test_build_maxtext_config_args_and_single_init(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_engine = mock.MagicMock()
+    mock_mutils = mock.MagicMock()
+
+    mock_cfg = mock.MagicMock()
+    mock_cfg.base_moe_mlp_dim = 2048
+    mock_cfg.raw_data_dict = {}
+    mock_pyconfig.initialize.return_value = mock_cfg
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock_engine, mock_mutils),
+    ), mock.patch("os.path.exists", return_value=True):
+      cfg = maxtext_utils.build_maxtext_config(
+          model_name="gemma2-9b",
+          worker_id="worker-0",
+          train_micro_batch_size=8,
+          mesh_fsdp=2,
+          mesh_tp=4,
+          mesh_expert=1,
+          num_devices=8,
+          base_num_kv_heads=8,
+          rollout_mesh_tp=4,
+          prefuse_moe_weights=True,
+          use_weight_converter=False,
+      )
+
+      # Ensure pyconfig.initialize was called exactly ONCE
+      mock_pyconfig.initialize.assert_called_once()
+      argv = mock_pyconfig.initialize.call_args[0][0]
+
+      self.assertIn("model_name=gemma2-9b", argv)
+      self.assertIn("base_num_kv_heads=8", argv)
+      self.assertIn("ici_tensor_parallelism=4", argv)
+      self.assertIn("ici_fsdp_parallelism=2", argv)
+      self.assertIn("prefuse_moe_weights=True", argv)
+      self.assertIn("use_weight_converter=False", argv)
+      self.assertIn("rollout_tensor_parallelism=4", argv)
+      self.assertEqual(cfg, mock_cfg)
+
+  def test_build_maxtext_config_auto_padded_moe_mlp_dim(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_cfg = mock.MagicMock()
+    mock_cfg.padded_base_moe_mlp_dim = 2304
+    mock_pyconfig.initialize.return_value = mock_cfg
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    mock_compute = mock.MagicMock(return_value=2304)
+
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data="base_moe_mlp_dim: 2048\n"),
+    ), mock.patch.dict(
+        "sys.modules",
+        {"maxtext.integration.vllm.convert_utils": mock.MagicMock(
+            compute_padded_moe_mlp_dim=mock_compute
+        )},
+    ):
+      cfg = maxtext_utils.build_maxtext_config(
+          model_name="moe-test",
+          moe_mlp_tp_size=4,
+          padded_moe_mlp_dim=0,
+      )
+      mock_compute.assert_called_once_with(2048, 4)
+      argv = mock_pyconfig.initialize.call_args[0][0]
+      self.assertIn("padded_base_moe_mlp_dim=2304", argv)
+
+  def test_derived_quantities_matrix(self):
+    cases = [
+        # (name, tp, ep, dp, attn_dp, exp_kv_tp, exp_moe_tp, exp_pad, exp_kv_heads)
+        ("c1_baseline", 2, 1, 2, 1, 2, 2, 512, 2),
+        ("c2_kv_replicated_ep2", 2, 2, 1, 1, 4, 2, 512, 4),
+        ("c3_moe_doubled_tp4", 4, 1, 1, 1, 4, 4, 1024, 4),
+        ("c4_attn_dp2_t6_fix", 2, 1, 1, 2, 2, 4, 1024, 2),
+        ("c5_pure_dp", 1, 1, 4, 1, 1, 1, 512, 2),
+        ("c6_large_scale", 4, 2, 1, 2, 8, 8, 2048, 8),
+    ]
+    mock_pyconfig = mock.MagicMock()
+    mock_engine = mock.MagicMock()
+    mock_mutils = mock.MagicMock()
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    def mock_compute_padded_moe_mlp_dim(hidden_size, moe_mlp_tp_size, num_lanes=128):
+      min_required = 2 * num_lanes * moe_mlp_tp_size
+      if (hidden_size // moe_mlp_tp_size) % (2 * num_lanes) != 0:
+        return ((max(hidden_size, min_required) + min_required - 1) // min_required) * min_required
+      return hidden_size
+
+    for name, tp, ep, dp, attn_dp, exp_kv_tp, exp_moe_tp, exp_pad, exp_kv_heads in cases:
+      mock_pyconfig.reset_mock()
+      mock_cfg = mock.MagicMock()
+      mock_pyconfig.initialize.return_value = mock_cfg
+
+      kv_tp_size = tp * ep
+      moe_mlp_tp_size = tp * attn_dp
+
+      self.assertEqual(kv_tp_size, exp_kv_tp, f"{name}: kv_tp_size mismatch")
+      self.assertEqual(moe_mlp_tp_size, exp_moe_tp, f"{name}: moe_mlp_tp_size mismatch")
+
+      with mock.patch.object(
+          maxtext_utils,
+          "maxtext_modules",
+          return_value=(mock_pyconfig, mock_engine, mock_mutils),
+      ), mock.patch("os.path.exists", return_value=True), mock.patch(
+          "builtins.open",
+          mock.mock_open(read_data="base_moe_mlp_dim: 512\nbase_num_kv_heads: 2\n"),
+      ), mock.patch.dict(
+          "sys.modules",
+          {
+              "maxtext.integration.vllm.convert_utils": mock.MagicMock(
+                  compute_padded_moe_mlp_dim=mock_compute_padded_moe_mlp_dim
+              )
+          },
+      ):
+        maxtext_utils.build_maxtext_config(
+            model_name="qwen3-moe",
+            worker_id="worker-0",
+            train_micro_batch_size=8,
+            mesh_fsdp=1,
+            mesh_tp=tp,
+            mesh_expert=ep,
+            num_devices=8,
+            base_num_kv_heads=2,
+            kv_tp_size=kv_tp_size,
+            moe_mlp_tp_size=moe_mlp_tp_size,
+        )
+        mock_pyconfig.initialize.assert_called_once()
+        argv = mock_pyconfig.initialize.call_args[0][0]
+        self.assertIn(f"padded_base_moe_mlp_dim={exp_pad}", argv, f"{name}: padded_base_moe_mlp_dim mismatch in argv")
+        self.assertIn(f"base_num_kv_heads={exp_kv_heads}", argv, f"{name}: base_num_kv_heads mismatch in argv")
+
+  def test_indivisible_kv_heads_fails_fast(self):
+    # tp=3, ep=1, base_num_kv_heads=2 -> 3 % 2 != 0 -> must raise ValueError
+    mock_pyconfig = mock.MagicMock()
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True):
+      with self.assertRaisesRegex(ValueError, "must be cleanly divisible"):
+        maxtext_utils.build_maxtext_config(
+            model_name="qwen3-test",
+            base_num_kv_heads=2,
+            kv_tp_size=3,
+            moe_mlp_tp_size=1,
+        )
+
+  def test_build_maxtext_config_batch_size_divisibility(self):
+    mock_pyconfig = mock.MagicMock()
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ):
+      with self.assertRaises(ValueError):
+        maxtext_utils.build_maxtext_config(
+            model_name="gemma2-9b",
+            train_micro_batch_size=5,
+            mesh_fsdp=2,
+        )
+
+  def test_build_maxtext_config_range_validations(self):
+    mock_pyconfig = mock.MagicMock()
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ):
+      with self.assertRaisesRegex(ValueError, "padded_moe_mlp_dim must be non-negative"):
+        maxtext_utils.build_maxtext_config("gemma2-9b", padded_moe_mlp_dim=-1)
+
+      with self.assertRaisesRegex(ValueError, "base_num_kv_heads must be non-negative"):
+        maxtext_utils.build_maxtext_config("gemma2-9b", base_num_kv_heads=-2)
+
+      with self.assertRaisesRegex(ValueError, "kv_tp_size must be non-negative"):
+        maxtext_utils.build_maxtext_config("gemma2-9b", kv_tp_size=-1)
+
+      with self.assertRaisesRegex(ValueError, "moe_mlp_tp_size must be non-negative"):
+        maxtext_utils.build_maxtext_config("gemma2-9b", moe_mlp_tp_size=-1)
+
+      with self.assertRaisesRegex(ValueError, "rollout_mesh_tp must be non-negative"):
+        maxtext_utils.build_maxtext_config("gemma2-9b", rollout_mesh_tp=-4)
+
+  def test_build_maxtext_config_auto_padding_failure_raises_runtime_error(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_cfg = mock.MagicMock()
+    mock_cfg.base_moe_mlp_dim = 2048
+    mock_pyconfig.initialize.return_value = mock_cfg
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data="base_moe_mlp_dim: 2048\n"),
+    ), mock.patch.dict(
+        "sys.modules",
+        {"maxtext.integration.vllm.convert_utils": mock.MagicMock(
+            compute_padded_moe_mlp_dim=mock.MagicMock(side_effect=ValueError("Padding failure"))
+        )},
+    ):
+      with self.assertRaisesRegex(RuntimeError, "Failed to auto-compute padded_base_moe_mlp_dim"):
+        maxtext_utils.build_maxtext_config(
+            model_name="moe-test",
+            moe_mlp_tp_size=4,
+            padded_moe_mlp_dim=0,
+        )
+
+
+  def test_kv_tp_size_missing_base_heads_raises_value_error(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", side_effect=lambda p: str(p).endswith("base.yml")):
+      with self.assertRaisesRegex(ValueError, "requires base_num_kv_heads > 0"):
+        maxtext_utils.build_maxtext_config(
+            model_name="qwen3-test",
+            base_num_kv_heads=0,
+            kv_tp_size=4,
+        )
+
+  def test_single_file_load_for_kv_heads_and_moe_dim(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_cfg = mock.MagicMock()
+    mock_pyconfig.initialize.return_value = mock_cfg
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+    mock_compute = mock.MagicMock(return_value=2048)
+
+    mock_file = mock.mock_open(
+        read_data="base_num_kv_heads: 4\nbase_moe_mlp_dim: 1024\n"
+    )
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True), mock.patch(
+        "builtins.open", mock_file
+    ), mock.patch.dict(
+        "sys.modules",
+        {"maxtext.integration.vllm.convert_utils": mock.MagicMock(
+            compute_padded_moe_mlp_dim=mock_compute
+        )},
+    ), self.assertLogs(level="INFO") as logs:
+      maxtext_utils.build_maxtext_config(
+          model_name="moe-test",
+          rollout_mesh_tp=4,  # Overrides kv_tp_size=4 and moe_mlp_tp_size=4
+      )
+      # Assert the YAML was opened only once
+      mock_file.assert_called_once()
+      # Assert overrides were logged
+      log_text = "\n".join(logs.output)
+      self.assertIn("Overriding kv_tp_size from 0 to rollout_mesh_tp=4", log_text)
+      self.assertIn("Overriding moe_mlp_tp_size from 0 to rollout_mesh_tp=4", log_text)
+
+  def test_auto_padding_import_error_logs_warning(self):
+    mock_pyconfig = mock.MagicMock()
+    mock_cfg = mock.MagicMock()
+    mock_pyconfig.initialize.return_value = mock_cfg
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True), mock.patch(
+        "builtins.open",
+        mock.mock_open(
+            read_data="base_moe_mlp_dim: 2048\nbase_num_kv_heads: 2\n"
+        ),
+    ), mock.patch.dict(
+        "sys.modules",
+        {"maxtext.integration.vllm.convert_utils": None},
+    ), self.assertLogs(level="WARNING") as logs:
+      maxtext_utils.build_maxtext_config(
+          model_name="moe-test",
+          base_num_kv_heads=2,
+          moe_mlp_tp_size=4,
+      )
+      log_text = "\n".join(logs.output)
+      self.assertIn("Could not import compute_padded_moe_mlp_dim", log_text)
+      self.assertIn("Skipping automatic MoE dimension padding", log_text)
+
+
+if __name__ == "__main__":
+  absltest.main()
+

--- a/tunix/utils/maxtext_utils.py
+++ b/tunix/utils/maxtext_utils.py
@@ -62,9 +62,49 @@ def build_maxtext_config(
     base_output_directory: str = "",
     gradient_accumulation_steps: int = 1,
     checkpointing_options: Any = None,
+    *,
+    base_num_kv_heads: int = 0,
+    kv_tp_size: int = 0,
+    moe_mlp_tp_size: int = 0,
+    rollout_mesh_tp: int = 0,
+    prefuse_moe_weights: bool = False,
+    use_weight_converter: bool = True,
 ) -> Any:
   """Builds the MaxText HyperParameters the training engine runs on."""
   pyconfig, _, _ = maxtext_modules()
+
+  # Backward compatibility: if rollout_mesh_tp was provided, default kv_tp_size and moe_mlp_tp_size
+  if rollout_mesh_tp > 0:
+    if kv_tp_size == 0:
+      logging.info(
+          "Overriding kv_tp_size from 0 to rollout_mesh_tp=%d", rollout_mesh_tp
+      )
+      kv_tp_size = rollout_mesh_tp
+    if moe_mlp_tp_size == 0:
+      logging.info(
+          "Overriding moe_mlp_tp_size from 0 to rollout_mesh_tp=%d",
+          rollout_mesh_tp,
+      )
+      moe_mlp_tp_size = rollout_mesh_tp
+
+  if padded_moe_mlp_dim < 0:
+    raise ValueError(
+        f"padded_moe_mlp_dim must be non-negative, got {padded_moe_mlp_dim}"
+    )
+  if base_num_kv_heads < 0:
+    raise ValueError(
+        f"base_num_kv_heads must be non-negative, got {base_num_kv_heads}"
+    )
+  if kv_tp_size < 0:
+    raise ValueError(f"kv_tp_size must be non-negative, got {kv_tp_size}")
+  if moe_mlp_tp_size < 0:
+    raise ValueError(
+        f"moe_mlp_tp_size must be non-negative, got {moe_mlp_tp_size}"
+    )
+  if rollout_mesh_tp < 0:
+    raise ValueError(
+        f"rollout_mesh_tp must be non-negative, got {rollout_mesh_tp}"
+    )
 
   if train_micro_batch_size % mesh_fsdp:
     raise ValueError(
@@ -78,6 +118,87 @@ def build_maxtext_config(
   )
   if not os.path.exists(base_yml):
     raise FileNotFoundError(f"MaxText base.yml not found at {base_yml}")
+
+  effective_kv_heads = base_num_kv_heads
+  effective_padded_moe_mlp_dim = padded_moe_mlp_dim
+
+  # Determine if we need to inspect the model's YAML configuration
+  needs_model_yml = (effective_kv_heads <= 0 and kv_tp_size > 0) or (
+      not effective_padded_moe_mlp_dim and moe_mlp_tp_size > 0
+  )
+  model_data = None
+  if needs_model_yml:
+    models_dir = os.path.join(os.path.dirname(base_yml), "models")
+    model_yml = os.path.join(models_dir, f"{model_name}.yml")
+    if os.path.exists(model_yml):
+      try:
+        import yaml
+
+        with open(model_yml, "r") as f:
+          data = yaml.safe_load(f)
+        if isinstance(data, dict):
+          model_data = data
+        else:
+          logging.warning(
+              "Expected dict in model config %s, got %s",
+              model_yml,
+              type(data).__name__,
+          )
+      except Exception as e:
+        logging.warning("Failed to load model config from %s: %s", model_yml, e)
+    else:
+      logging.warning("Model config file not found at %s", model_yml)
+
+  # 1. Resolve KV head replication:
+  if effective_kv_heads <= 0 and kv_tp_size > 0:
+    if model_data:
+      effective_kv_heads = int(model_data.get("base_num_kv_heads") or 0)
+    if effective_kv_heads <= 0:
+      raise ValueError(
+          f"kv_tp_size ({kv_tp_size}) requires base_num_kv_heads > 0, but "
+          f"could not determine base_num_kv_heads from config or {model_name}.yml. "
+          "Please specify --base_num_kv_heads."
+      )
+
+  if effective_kv_heads > 0 and kv_tp_size > effective_kv_heads:
+    if kv_tp_size % effective_kv_heads != 0:
+      raise ValueError(
+          f"kv_tp_size ({kv_tp_size}) must be cleanly divisible by "
+          f"base_num_kv_heads ({effective_kv_heads})."
+      )
+    effective_kv_heads = kv_tp_size
+
+  # 2. Resolve padded MoE MLP dimension before pyconfig initialization:
+  if not effective_padded_moe_mlp_dim and moe_mlp_tp_size > 0:
+    compute_padded_moe_mlp_dim = None
+    try:
+      from maxtext.integration.vllm.convert_utils import compute_padded_moe_mlp_dim
+    except (ImportError, ModuleNotFoundError) as e:
+      logging.warning(
+          "Could not import compute_padded_moe_mlp_dim: %s. Skipping automatic"
+          " MoE dimension padding.",
+          e,
+      )
+
+    if compute_padded_moe_mlp_dim is not None and model_data:
+      base_dim = model_data.get("base_moe_mlp_dim") or model_data.get(
+          "moe_intermediate_size"
+      )
+      if base_dim:
+        try:
+          effective_padded_moe_mlp_dim = compute_padded_moe_mlp_dim(
+              base_dim, moe_mlp_tp_size
+          )
+          logging.info(
+              "Auto-computed padded_base_moe_mlp_dim=%d for moe_mlp_tp_size=%d",
+              effective_padded_moe_mlp_dim,
+              moe_mlp_tp_size,
+          )
+        except Exception as e:
+          raise RuntimeError(
+              "Failed to auto-compute padded_base_moe_mlp_dim for"
+              f" moe_mlp_tp_size={moe_mlp_tp_size}: {e}"
+          ) from e
 
   output_dir = base_output_directory or "/tmp/maxtext"
   argv = [
@@ -96,6 +217,10 @@ def build_maxtext_config(
         f"checkpoint_period={checkpointing_options.save_interval_steps}",
         f"max_num_checkpoints_to_keep={checkpointing_options.max_to_keep}",
     ])
+  elif load_parameters_path:
+    argv.append("enable_checkpointing=True")
+  else:
+    argv.append("enable_checkpointing=False")
   argv.extend([
       "scan_layers=True",
       "convert_checkpoint_if_possible=False",
@@ -108,8 +233,18 @@ def build_maxtext_config(
       "use_gmm_v2=true",
       f"ici_fsdp_parallelism={mesh_fsdp}",
       *(
-          [f"padded_base_moe_mlp_dim={padded_moe_mlp_dim}"]
-          if padded_moe_mlp_dim
+          [f"padded_base_moe_mlp_dim={effective_padded_moe_mlp_dim}"]
+          if effective_padded_moe_mlp_dim
+          else []
+      ),
+      # The vLLM rollout replicates KV heads up to kv_tp_size (tp*ep) when the
+      # model has fewer -- see maxtext_vllm_adapter. Weight sync pairs by name,
+      # so the trainer must build the same shape. Prefer attention DP on the
+      # rollout instead, which avoids the replication entirely; this is the
+      # fallback when that is not available.
+      *(
+          [f"base_num_kv_heads={effective_kv_heads}"]
+          if effective_kv_heads
           else []
       ),
       f"ici_tensor_parallelism={mesh_tp}",
@@ -122,6 +257,15 @@ def build_maxtext_config(
       "enable_tensorboard=False",
       "record_internal_nn_metrics=False",
       "init_weights_seed=42",
+      f"prefuse_moe_weights={prefuse_moe_weights}",
+      f"use_weight_converter={use_weight_converter}",
+      *(
+          [
+              f"rollout_tensor_parallelism={rollout_mesh_tp or kv_tp_size or moe_mlp_tp_size}"
+          ]
+          if (rollout_mesh_tp or kv_tp_size or moe_mlp_tp_size) > 0
+          else []
+      ),
   ])
   logging.info("MaxText config argv: %s", argv)
   return pyconfig.initialize(argv)


### PR DESCRIPTION
## Overview
Part of the stacked Raiden weight-sync enablement PR chain replacing #2083.

**Stack:**
- [T1] https://github.com/google/tunix/pull/2146: Multi-host discovery & multi-axis sharding in RaidenHandler
- [T2a] https://github.com/google/tunix/pull/2147: Transport selection, FFI preflight mismatch check, and host-stage normalization
- [T3] https://github.com/google/tunix/pull/2148: Extract RaidenDestinationWeightSyncMixin
- [T4] https://github.com/google/tunix/pull/2149: Cache lifecycle and prefix caching
- [T5] https://github.com/google/tunix/pull/2150: MoE 128-lane interleaving for TPU GMM layout (pairs with MaxText M2)
- **[T6] google/tunix (this PR)**: MaxText trainer configuration plumbing

## Details
- Plumbs `base_num_kv_heads`, `rollout_mesh_tp`, and `prefuse_moe_weights` into `build_maxtext_config`.
- Automatically computes `padded_moe_mlp_dim` to satisfy TPU kernel constraints.
- Replaces ad-hoc `os.environ` reads with explicit arguments.