### PR TITLE
[Deployment] Parameterize JobSet manifests and minimal k8s_launcher for multi-host RL

### DIFF
--- a/tests/experimental/distributed/deployment/yaml_generator_test.py
+++ b/tests/experimental/distributed/deployment/yaml_generator_test.py
@@ -52,6 +52,37 @@ class YamlGeneratorTest(parameterized.TestCase):
         self.assertIn("test-cpu-job", rendered)
         self.assertIn("9999", rendered)
 
+  def test_generate_yaml_with_queue_name(self):
+    template_file = _get_template_path("jobset.cpu.yaml")
+    argv = [
+        "yaml_generator.py",
+        template_file,
+        "--jobset_name=test-cpu-job",
+        "--cpu_machine=n2-standard-64",
+        "--queue_name=research-queue",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+      with mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+        yaml_generator.main()
+        rendered = mock_stdout.getvalue()
+        self.assertIn("kueue.x-k8s.io/queue-name: research-queue", rendered)
+
+  def test_generate_tpu_yaml_with_hf_token_secret(self):
+    template_file = _get_template_path("jobset.tpu.yaml")
+    argv = [
+        "yaml_generator.py",
+        template_file,
+        "--jobset_name=test-tpu-job",
+        "--tpu_slice=tpuv5:2x2x2",
+        "--hf_token_secret_name=custom-hf-secret",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+      with mock.patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+        yaml_generator.main()
+        rendered = mock_stdout.getvalue()
+        self.assertIn("custom-hf-secret", rendered)
+        self.assertIn("name: HF_TOKEN", rendered)
+
   @parameterized.named_parameters(
       (
           f"{tpl_label}_{name}",

--- a/tests/experimental/examples/common/run_trainer_node_test.py
+++ b/tests/experimental/examples/common/run_trainer_node_test.py
@@ -441,6 +441,9 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     self.assertEqual(args.checkpoint_save_interval_steps, 1)
     self.assertEqual(args.checkpoint_max_to_keep, 10)
     self.assertFalse(args.use_lora)
+    self.assertTrue(args.prefuse_moe_weights)
+    self.assertTrue(args.use_weight_converter)
+    self.assertEqual(args.rollout_mesh_tp, 0)
 
     custom_argv = [
         "--port",
@@ -464,6 +467,12 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
         "32",
         "--lora_alpha",
         "64.0",
+        "--prefuse_moe_weights",
+        "false",
+        "--use_weight_converter",
+        "false",
+        "--rollout_mesh_tp",
+        "2",
     ]
     args_custom = run_trainer_node._parse_args(custom_argv)
     self.assertEqual(args_custom.port, 20050)
@@ -477,6 +486,15 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     self.assertTrue(args_custom.use_lora)
     self.assertEqual(args_custom.lora_rank, 32)
     self.assertEqual(args_custom.lora_alpha, 64.0)
+    self.assertFalse(args_custom.prefuse_moe_weights)
+    self.assertFalse(args_custom.use_weight_converter)
+    self.assertEqual(args_custom.rollout_mesh_tp, 2)
+
+  def test_parse_args_bare_boolean_flags(self):
+    argv = ["--prefuse_moe_weights", "--use_weight_converter"]
+    args = run_trainer_node._parse_args(argv)
+    self.assertTrue(args.prefuse_moe_weights)
+    self.assertTrue(args.use_weight_converter)
 
   def test_create_mesh_validates_device_count(self):
     args = mock.MagicMock(mesh_fsdp=2, mesh_tp=2)

--- a/tests/experimental/examples/common/run_trainer_node_test.py
+++ b/tests/experimental/examples/common/run_trainer_node_test.py
@@ -441,7 +441,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     self.assertEqual(args.checkpoint_save_interval_steps, 1)
     self.assertEqual(args.checkpoint_max_to_keep, 10)
     self.assertFalse(args.use_lora)
-    self.assertTrue(args.prefuse_moe_weights)
+    self.assertFalse(args.prefuse_moe_weights)
     self.assertTrue(args.use_weight_converter)
     self.assertEqual(args.rollout_mesh_tp, 0)
 

--- a/tunix/experimental/distributed/deployment/yaml_generator.py
+++ b/tunix/experimental/distributed/deployment/yaml_generator.py
@@ -129,7 +129,7 @@ def main() -> None:
       tpu_machine = "tpu7x-standard-4t"
       tpu_type = "tpu7x"
       pw_instance_type = "tpu7x"
-    elif tpu_type in ("tpuv5", "tpu-v5p-slice"):
+    elif tpu_type in ("tpuv5", "tpuv5p", "tpu-v5p-slice"):
       slice_topology = tpu_topology
       slice_size = num_chips // 4
       tpu_machine = "ct5p-hightpu-4t"

--- a/tunix/experimental/distributed/deployment/yaml_generator.py
+++ b/tunix/experimental/distributed/deployment/yaml_generator.py
@@ -89,6 +89,25 @@ def main() -> None:
       default="sleep infinity",
       help="Command to run on startup",
   )
+  parser.add_argument(
+      "--hf_token_secret_name",
+      default=os.environ.get("HF_TOKEN_SECRET_NAME", "hf-token-secret"),
+      help=(
+          "Kubernetes secret name (not the token itself) containing HF_TOKEN."
+          " Create with: kubectl create secret generic <name>"
+          " --from-literal=HF_TOKEN=<token>"
+      ),
+  )
+  parser.add_argument(
+      "--namespace",
+      default=os.environ.get("K8S_NAMESPACE", "default"),
+      help="Kubernetes namespace (default: default)",
+  )
+  parser.add_argument(
+      "--queue_name",
+      default=os.environ.get("KUEUE_QUEUE_NAME", ""),
+      help="Kueue local queue name (optional)",
+  )
 
   args = parser.parse_args()
 
@@ -141,6 +160,12 @@ def main() -> None:
   if args.jobset_name is None:
     jobset_name = f"{os.environ.get('USER')}-{pw_instance_type}-{num_chips}"
 
+  queue_label = (
+      f"  labels:\n    kueue.x-k8s.io/queue-name: {args.queue_name}\n"
+      if args.queue_name
+      else ""
+  )
+
   with open(args.template_file, "r") as f:
     template = string.Template(f.read())
     content = template.substitute(
@@ -164,6 +189,10 @@ def main() -> None:
         USER_CONTAINER_IMAGE=args.worker_container_image,
         USER_CONTAINER_PORT=args.worker_container_port,
         STARTUP_COMMAND=args.worker_startup_command,
+        HF_TOKEN_SECRET_NAME=args.hf_token_secret_name,
+        NAMESPACE=args.namespace or "default",
+        QUEUE_NAME=args.queue_name,
+        QUEUE_LABEL=queue_label,
     )
     print(content)
 

--- a/tunix/experimental/distributed/deployment/yamls/jobset.cpu.yaml
+++ b/tunix/experimental/distributed/deployment/yamls/jobset.cpu.yaml
@@ -16,9 +16,10 @@ apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: ${JOBSET_NAME}
-  namespace: default
-spec:
+  namespace: ${NAMESPACE}
+${QUEUE_LABEL}spec:
   failurePolicy:
+    maxRestarts: 3
     restartStrategy: Recreate
   network:
     enableDNSHostnames: true
@@ -46,6 +47,10 @@ spec:
             terminationGracePeriodSeconds: 10
             nodeSelector:
               node.kubernetes.io/instance-type: ${CPU_MACHINE}
+            tolerations:
+            - key: "cloud.google.com/gke-nodepool"
+              operator: "Exists"
+              effect: "NoSchedule"
             containers:
             - name: ${USER_CONTAINER}
               image: ${USER_CONTAINER_IMAGE}
@@ -83,6 +88,12 @@ spec:
                   exit $$EXIT_CODE
               env:
               # Injects the JobSet Name
+              - name: HF_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: ${HF_TOKEN_SECRET_NAME}
+                    key: HF_TOKEN
+                    optional: true
               - name: JOBSET_NAME
                 valueFrom:
                   fieldRef:

--- a/tunix/experimental/distributed/deployment/yamls/jobset.pathways.yaml
+++ b/tunix/experimental/distributed/deployment/yamls/jobset.pathways.yaml
@@ -16,11 +16,12 @@ apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: ${JOBSET_NAME}
-  namespace: default
-spec:
+  namespace: ${NAMESPACE}
+${QUEUE_LABEL}spec:
   coordinator:
     replicatedJob: proc
   failurePolicy:
+    maxRestarts: 3
     restartStrategy: Recreate
   network:
     enableDNSHostnames: true
@@ -152,6 +153,12 @@ spec:
                   exit $$EXIT_CODE
               env:
               # Injects the JobSet Name
+              - name: HF_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: ${HF_TOKEN_SECRET_NAME}
+                    key: HF_TOKEN
+                    optional: true
               - name: JOBSET_NAME
                 valueFrom:
                   fieldRef:

--- a/tunix/experimental/distributed/deployment/yamls/jobset.tpu.yaml
+++ b/tunix/experimental/distributed/deployment/yamls/jobset.tpu.yaml
@@ -16,9 +16,10 @@ apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
   name: ${JOBSET_NAME}
-  namespace: default
-spec:
+  namespace: ${NAMESPACE}
+${QUEUE_LABEL}spec:
   failurePolicy:
+    maxRestarts: 3
     restartStrategy: Recreate
   network:
     enableDNSHostnames: true
@@ -82,6 +83,12 @@ spec:
                   echo "EXIT_CODE=$$EXIT_CODE"
                   exit $$EXIT_CODE
               env:
+              - name: HF_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: ${HF_TOKEN_SECRET_NAME}
+                    key: HF_TOKEN
+                    optional: true
               # Injects the JobSet Name
               - name: JOBSET_NAME
                 valueFrom:

--- a/tunix/experimental/examples/common/enter_kube_context.sh
+++ b/tunix/experimental/examples/common/enter_kube_context.sh
@@ -21,11 +21,17 @@ REGION=${REGION:-us-central1}
 ZONE=${ZONE:-us-central1-a}
 CLUSTER=${CLUSTER:-trellis-demo-0810}
 
-LOCATION_NAME=$(gcloud container clusters list \
-  --project="$PROJECT" \
-  --filter="name=$CLUSTER" \
-  --format='value(location)' \
-  | head -n 1)
+if [[ "${DRY_RUN}" == "true" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+if [[ -z "${LOCATION_NAME:-}" ]]; then
+  LOCATION_NAME=$(gcloud container clusters list \
+    --project="$PROJECT" \
+    --filter="name=$CLUSTER" \
+    --format='value(location)' \
+    | head -n 1)
+fi
 
 if [[ -z "$LOCATION_NAME" ]]; then
   echo "Could not determine location for cluster '$CLUSTER' in project '$PROJECT'." >&2

--- a/tunix/experimental/examples/common/run_rollout_node.py
+++ b/tunix/experimental/examples/common/run_rollout_node.py
@@ -162,7 +162,41 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       choices=list(weight_sync_lib.WeightSyncMode),
       help="Weight sync mode (none, fallback, or raiden).",
   )
-  return parser.parse_args(argv)
+
+  def _str2bool(v: Any) -> bool:
+    if isinstance(v, bool):
+      return v
+    return str(v).lower() in ("true", "1", "yes")
+
+  parser.add_argument(
+      "--prefuse_moe_weights",
+      nargs="?",
+      const=True,
+      type=_str2bool,
+      default=True,
+      help="Whether to prefuse MoE weights (gate + up projection).",
+  )
+  parser.add_argument(
+      "--enable_prefix_caching",
+      nargs="?",
+      const=True,
+      type=_str2bool,
+      default=False,
+      help="Whether to enable prefix caching in vLLM (defaults to false).",
+  )
+  parser.add_argument("--tensor_parallel_size", type=int, default=None)
+  args = parser.parse_args(argv)
+  _finalize_tensor_parallel_size(args)
+  return args
+
+
+def _finalize_tensor_parallel_size(args: argparse.Namespace) -> None:
+  """Derives tensor_parallel_size from mesh_tp if not explicitly set."""
+  if args.tensor_parallel_size is None:
+    tp = getattr(args, "sampler_mesh_tp", None) or getattr(args, "mesh_tp", 1)
+    if tp > 1:
+      args.tensor_parallel_size = tp
+      logging.info("Auto-derived tensor_parallel_size=%d from mesh_tp", tp)
 
 
 def _agent_config(args: argparse.Namespace) -> dict[str, Any]:
@@ -355,6 +389,7 @@ def _create_inprocess_vllm_sampler(args, tokenizer):
       engine_kwargs={
           "model": vllm_model,
           "max_model_len": max_model_len,
+          "enable_prefix_caching": args.enable_prefix_caching,
       },
   )
   sampler_adapter = inprocess_vllm_sampler_adapter.InprocessVllmSamplerAdapter(
@@ -410,6 +445,7 @@ def _create_vllm_sampler(args):
       enable_lora=args.use_lora,
       max_lora_rank=args.lora_rank if args.use_lora else None,
       max_loras=1 if args.use_lora else None,
+      enable_prefix_caching=args.enable_prefix_caching,
   )
   if args.maxtext_model_name:
     logging.info(
@@ -418,8 +454,8 @@ def _create_vllm_sampler(args):
         args.maxtext_model_name,
     )
     engine_kwargs["hf_overrides"] = {"architectures": ["MaxTextForCausalLM"]}
-    # MaxText inference config. prefuse_moe_weights is left False so rollout
-    # variable names match unfused trainer parameters during weight sync.
+    # MaxText inference config. When prefuse_moe_weights is True, MoE weights
+    # are prefused and interleaved per-shard for tensor parallel rollout.
     maxtext_config_overrides = {
         "model_name": args.maxtext_model_name,
         "model_call_mode": "inference",
@@ -427,9 +463,14 @@ def _create_vllm_sampler(args):
         "allow_split_physical_axes": True,
         "log_config": False,
         "weight_dtype": "bfloat16",
+        "prefuse_moe_weights": args.prefuse_moe_weights,
     }
     if args.maxtext_attention:
       maxtext_config_overrides["attention"] = args.maxtext_attention
+    # Note: load_parameters_path is intentionally NOT set here.
+    # Checkpoints on disk are scanned (layers.mlp.wi_0...), whereas MaxTextForCausalLM
+    # is unscanned (layers_0.mlp.wi_0...). Initial weights are pushed via Raiden
+    # weight sync (_sync_initial_weights) from the trainer after unstacking.
     engine_kwargs["additional_config"] = {
         "maxtext_config": maxtext_config_overrides
     }

--- a/tunix/experimental/examples/common/run_rollout_node.py
+++ b/tunix/experimental/examples/common/run_rollout_node.py
@@ -111,8 +111,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       type=str,
       default="",
       help=(
-          "Override MaxText inference attention kernel (e.g."
-          " vllm_batched_rpa)."
+          "Override MaxText inference attention kernel (e.g. vllm_batched_rpa)."
       ),
   )
   parser.add_argument(
@@ -124,9 +123,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       "--registry_module",
       type=str,
       default=os.getenv("ROLLOUT_REGISTRY_MODULE", DEFAULT_REGISTRY_MODULE),
-      help=(
-          "Module imported at startup to register rollout env/agent classes."
-      ),
+      help="Module imported at startup to register rollout env/agent classes.",
   )
   parser.add_argument(
       "--env_name",
@@ -203,7 +200,9 @@ def _agent_config(args: argparse.Namespace) -> dict[str, Any]:
   try:
     config = json.loads(args.agent_config_json or "{}")
   except json.JSONDecodeError as exc:
-    raise ValueError("--agent_config_json must be a valid JSON object.") from exc
+    raise ValueError(
+        "--agent_config_json must be a valid JSON object."
+    ) from exc
   if not isinstance(config, dict):
     raise ValueError("--agent_config_json must decode to a JSON object.")
   return config
@@ -381,7 +380,7 @@ def _create_inprocess_vllm_sampler(args, tokenizer):
   vllm_config = vllm_sampler.VllmConfig(
       server_mode=server_mode,
       mesh=rollout_mesh,
-      tensor_parallel_size=args.mesh_tp,
+      tensor_parallel_size=args.tensor_parallel_size or args.mesh_tp,
       data_parallel_size=args.mesh_fsdp,
       return_logprobs=True,
       lora_config=lora_config,
@@ -438,7 +437,7 @@ def _create_vllm_sampler(args):
   engine_kwargs = dict(
       model=vllm_model,
       tokenizer=args.tokenizer_path or vllm_model,
-      tensor_parallel_size=args.mesh_tp,
+      tensor_parallel_size=args.tensor_parallel_size or args.mesh_tp,
       max_model_len=max_model_len,
       trust_remote_code=True,
       dtype="bfloat16",

--- a/tunix/experimental/examples/common/run_trainer_node.py
+++ b/tunix/experimental/examples/common/run_trainer_node.py
@@ -180,7 +180,7 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       nargs="?",
       const=True,
       type=_str2bool,
-      default=True,
+      default=False,
       help="Whether to prefuse MoE weights (gate + up projection).",
   )
   parser.add_argument(

--- a/tunix/experimental/examples/common/run_trainer_node.py
+++ b/tunix/experimental/examples/common/run_trainer_node.py
@@ -164,6 +164,34 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       ),
   )
   parser.add_argument(
+      "--rollout_mesh_tp",
+      type=int,
+      default=0,
+      help="Rollout tensor parallel mesh dimension for automatic MoE padding calculation.",
+  )
+
+  def _str2bool(v: Any) -> bool:
+    if isinstance(v, bool):
+      return v
+    return str(v).lower() in ("true", "1", "yes")
+
+  parser.add_argument(
+      "--prefuse_moe_weights",
+      nargs="?",
+      const=True,
+      type=_str2bool,
+      default=True,
+      help="Whether to prefuse MoE weights (gate + up projection).",
+  )
+  parser.add_argument(
+      "--use_weight_converter",
+      nargs="?",
+      const=True,
+      type=_str2bool,
+      default=True,
+      help="Whether to use weight converter for weight sync.",
+  )
+  parser.add_argument(
       "--debug",
       action="store_true",
       help="Enable debug logging for the trainer worker.",
@@ -350,6 +378,9 @@ def _create_maxtext_trainer_factory(args) -> Any:
       base_output_directory=args.maxtext_output_directory,
       gradient_accumulation_steps=grad_accumulation_steps,
       checkpointing_options=checkpointing_options,
+      rollout_mesh_tp=args.rollout_mesh_tp,
+      prefuse_moe_weights=args.prefuse_moe_weights,
+      use_weight_converter=args.use_weight_converter,
   )
   logging.info("Creating MaxText device mesh...")
   mesh = maxtext_utils.create_maxtext_mesh(maxtext_config)

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -51,7 +51,11 @@ export REWARD_MODE=${REWARD_MODE:-env}
 export BETA=${BETA:-0}
 export EPSILON=${EPSILON:-0.2}
 export DEBUG=${DEBUG:-0}
-export SAMPLER=${SAMPLER:-inprocess_vllm}
+if [[ "${TRAINER_BACKEND}" == "maxtext" ]]; then
+  export SAMPLER=${SAMPLER:-vllm}
+else
+  export SAMPLER=${SAMPLER:-inprocess_vllm}
+fi
 export WEIGHT_SYNC_MODE=${WEIGHT_SYNC_MODE:-none}
 export PREFUSE_MOE_WEIGHTS=${PREFUSE_MOE_WEIGHTS:-true}
 export USE_WEIGHT_CONVERTER=${USE_WEIGHT_CONVERTER:-true}
@@ -133,7 +137,9 @@ apply_manifest() {
 
 
 stop_orchestrator() {
-  kubectl delete jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    kubectl delete jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+  fi
 }
 
 start_orchestrator() {
@@ -183,7 +189,9 @@ start_orchestrator() {
 }
 
 stop_trainer() {
-  kubectl delete jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+  if [[ "${DRY_RUN}" != "true" ]]; then
+    kubectl delete jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+  fi
 }
 
 start_trainer() {
@@ -261,6 +269,9 @@ start_trainer() {
 }
 
 stop_rollout() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    return 0
+  fi
   for ((i = 0; i < ROLLOUT_REPLICAS; i++)); do
     local target_id
     if [[ $ROLLOUT_REPLICAS -eq 1 ]]; then

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -58,6 +58,8 @@ else
 fi
 export WEIGHT_SYNC_MODE=${WEIGHT_SYNC_MODE:-none}
 export PREFUSE_MOE_WEIGHTS=${PREFUSE_MOE_WEIGHTS:-true}
+export TRAINER_PREFUSE_MOE_WEIGHTS=${TRAINER_PREFUSE_MOE_WEIGHTS:-false}
+export ROLLOUT_PREFUSE_MOE_WEIGHTS=${ROLLOUT_PREFUSE_MOE_WEIGHTS:-true}
 export USE_WEIGHT_CONVERTER=${USE_WEIGHT_CONVERTER:-true}
 export USE_ROLLOUT_LOGPS=${USE_ROLLOUT_LOGPS:-true}
 export CHECKPOINT_SAVE_INTERVAL_STEPS=${CHECKPOINT_SAVE_INTERVAL_STEPS:-1}
@@ -220,12 +222,12 @@ start_trainer() {
       --mesh_tp=${TRAINER_MESH_TP} \
       --mesh_expert=${TRAINER_MESH_EXPERT} \
       --rollout_mesh_tp=${ROLLOUT_MESH_TP} \
-      --prefuse_moe_weights=${PREFUSE_MOE_WEIGHTS} \
+      --prefuse_moe_weights=${TRAINER_PREFUSE_MOE_WEIGHTS} \
       --use_weight_converter=${USE_WEIGHT_CONVERTER} \
     "
   fi
 
-  local trainer_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
+  local trainer_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST} ROLLOUT_MESH_TP=${ROLLOUT_MESH_TP} ROLLOUT_TENSOR_PARALLEL_SIZE=${ROLLOUT_MESH_TP} ROLLOUT_PREFUSE_MOE_WEIGHTS=${ROLLOUT_PREFUSE_MOE_WEIGHTS}"
 
   python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/${TRAINER_JOBSET_YAML} \
@@ -315,11 +317,11 @@ start_rollout_instance() {
     extra_flags+=" \
       --maxtext_model_name=${MAXTEXT_MODEL_NAME} \
       ${ROLLOUT_MAXTEXT_ATTENTION:+--maxtext_attention=${ROLLOUT_MAXTEXT_ATTENTION}} \
-      --prefuse_moe_weights=${PREFUSE_MOE_WEIGHTS} \
+      --prefuse_moe_weights=${ROLLOUT_PREFUSE_MOE_WEIGHTS} \
     "
   fi
 
-  local rollout_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
+  local rollout_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST} ROLLOUT_MESH_TP=${ROLLOUT_MESH_TP} ROLLOUT_TENSOR_PARALLEL_SIZE=${ROLLOUT_MESH_TP} ROLLOUT_PREFUSE_MOE_WEIGHTS=${ROLLOUT_PREFUSE_MOE_WEIGHTS}"
 
   python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/${ROLLOUT_JOBSET_YAML} \
@@ -341,6 +343,7 @@ start_rollout_instance() {
         --port=${ROLLOUT_PORT} \
         --mesh_fsdp=${ROLLOUT_MESH_FSDP} \
         --mesh_tp=${ROLLOUT_MESH_TP} \
+        --model_name=${MODEL_NAME} \
         --model_id=${MODEL_ID} \
         --model_dir=${MODEL_DIR} \
         --tokenizer_path=${TOKENIZER_PATH} \
@@ -369,7 +372,14 @@ start_rollout() {
   done
 }
 
-source tunix/experimental/examples/common/enter_kube_context.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "${SCRIPT_DIR}/../common/enter_kube_context.sh" ]]; then
+  source "${SCRIPT_DIR}/../common/enter_kube_context.sh"
+elif [[ -f "tunix/tunix/experimental/examples/common/enter_kube_context.sh" ]]; then
+  source tunix/tunix/experimental/examples/common/enter_kube_context.sh
+elif [[ -f "tunix/experimental/examples/common/enter_kube_context.sh" ]]; then
+  source tunix/experimental/examples/common/enter_kube_context.sh
+fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -138,7 +138,10 @@ apply_manifest() {
 
 stop_orchestrator() {
   if [[ "${DRY_RUN}" != "true" ]]; then
-    kubectl delete jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+    kubectl delete jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" --ignore-not-found --wait=true
+    while kubectl get jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" &>/dev/null; do
+      sleep 2
+    done
   fi
 }
 
@@ -190,7 +193,10 @@ start_orchestrator() {
 
 stop_trainer() {
   if [[ "${DRY_RUN}" != "true" ]]; then
-    kubectl delete jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" --ignore-not-found
+    kubectl delete jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" --ignore-not-found --wait=true
+    while kubectl get jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" &>/dev/null; do
+      sleep 2
+    done
   fi
 }
 
@@ -280,9 +286,15 @@ stop_rollout() {
       target_id="${ROLLOUT_ID}-${i}"
     fi
     if [[ "$ROLLOUT_JOBSET_YAML" =~ ^leaderworkerset ]]; then
-      kubectl delete leaderworkerset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found
+      kubectl delete leaderworkerset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found --wait=true
+      while kubectl get leaderworkerset "${target_id}" --namespace="${NAMESPACE}" &>/dev/null; do
+        sleep 2
+      done
     else
-      kubectl delete jobset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found
+      kubectl delete jobset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found --wait=true
+      while kubectl get jobset "${target_id}" --namespace="${NAMESPACE}" &>/dev/null; do
+        sleep 2
+      done
     fi
   done
 }

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -51,11 +51,7 @@ export REWARD_MODE=${REWARD_MODE:-env}
 export BETA=${BETA:-0}
 export EPSILON=${EPSILON:-0.2}
 export DEBUG=${DEBUG:-0}
-if [[ "${TRAINER_BACKEND}" == "maxtext" ]]; then
-  export SAMPLER=${SAMPLER:-vllm}
-else
-  export SAMPLER=${SAMPLER:-inprocess_vllm}
-fi
+export SAMPLER=${SAMPLER:-inprocess_vllm}
 export WEIGHT_SYNC_MODE=${WEIGHT_SYNC_MODE:-none}
 export PREFUSE_MOE_WEIGHTS=${PREFUSE_MOE_WEIGHTS:-true}
 export TRAINER_PREFUSE_MOE_WEIGHTS=${TRAINER_PREFUSE_MOE_WEIGHTS:-false}

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -53,10 +53,13 @@ export EPSILON=${EPSILON:-0.2}
 export DEBUG=${DEBUG:-0}
 export SAMPLER=${SAMPLER:-inprocess_vllm}
 export WEIGHT_SYNC_MODE=${WEIGHT_SYNC_MODE:-none}
+export PREFUSE_MOE_WEIGHTS=${PREFUSE_MOE_WEIGHTS:-true}
+export USE_WEIGHT_CONVERTER=${USE_WEIGHT_CONVERTER:-true}
 export USE_ROLLOUT_LOGPS=${USE_ROLLOUT_LOGPS:-true}
 export CHECKPOINT_SAVE_INTERVAL_STEPS=${CHECKPOINT_SAVE_INTERVAL_STEPS:-1}
 export CHECKPOINT_MAX_TO_KEEP=${CHECKPOINT_MAX_TO_KEEP:-10}
 export CHECKPOINT_ROOT_DIRECTORY=${CHECKPOINT_ROOT_DIRECTORY:-checkpoints}
+export DISABLE_CHECKPOINTING=${DISABLE_CHECKPOINTING:-false}
 
 # MaxText trainer configuration: only consulted when TRAINER_BACKEND=maxtext
 export MAXTEXT_MODEL_NAME=${MAXTEXT_MODEL_NAME:-qwen3-1.7b}
@@ -72,10 +75,14 @@ export TRAINER_PADDED_MOE_MLP_DIM=${TRAINER_PADDED_MOE_MLP_DIM:-}
 # Optional: enable experimental batched-RPA attention kernel for rollout.
 export ROLLOUT_USE_BATCHED_RPA=${ROLLOUT_USE_BATCHED_RPA:-}
 export ROLLOUT_MAXTEXT_ATTENTION=${ROLLOUT_MAXTEXT_ATTENTION:-}
+export ENABLE_PREFIX_CACHING=${ENABLE_PREFIX_CACHING:-false}
 
 # Logs source/destination Raiden tensor checksums on both the trainer and
 # rollout sides during weight sync, for cross-verification of a real run.
 export VERIFY_WEIGHTS=${VERIFY_WEIGHTS:-false}
+# Number of accelerator devices per host for Raiden FFI initialization.
+# Set to 4 for TPU v5e/v5p multi-host slices; set to 8 for 8-device host architectures.
+export RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST:-4}
 
 export WANDB_PROJECT=${WANDB_PROJECT:-trellis-gsm8k}
 export WANDB_RUN_NAME=${WANDB_RUN_NAME:-}
@@ -84,17 +91,22 @@ export TFDS_DATA_DIR=${TFDS_DATA_DIR:-"artifacts/data"}
 export TFDS_SPLIT=${TFDS_SPLIT:-train}
 export FLUSH_METRICS_EVERY_N_STEPS=${FLUSH_METRICS_EVERY_N_STEPS:-1}
 
+export NAMESPACE=${NAMESPACE:-default}
+export QUEUE_NAME=${QUEUE_NAME:-}
+
 export ORCHESTRATOR_ID=$USER-orch
 export ORCHESTRATOR_PORT=20000
 
 export ROLLOUT_ID=$USER-roll
 export ROLLOUT_PORT=20001
+export ROLLOUT_REPLICAS=${ROLLOUT_REPLICAS:-1}
 
 export TRAINER_ID=$USER-train
 export TRAINER_PORT=20002
 
 export CPU_MACHINE=${CPU_MACHINE:-n2-standard-64}
 export GCS_SCRATCH_LOCATION=${GCS_SCRATCH_LOCATION:-gs://cloud-pathways-staging/tmp}
+export DRY_RUN=${DRY_RUN:-false}
 
 export TRAINER_JOBSET_YAML=${TRAINER_JOBSET_YAML:-jobset.pathways.yaml}
 export TRAINER_TPU_SLICE=${TRAINER_TPU_SLICE:-tpuv5e:4x4}
@@ -105,23 +117,41 @@ export TRAINER_MESH_EXPERT=${TRAINER_MESH_EXPERT:-1}
 export PATHWAYS_SERVER_IMAGE=${PATHWAYS_SERVER_IMAGE:-us-docker.pkg.dev/cloud-tpu-v2-images/pathways/server:latest}
 export PATHWAYS_PROXY_IMAGE=${PATHWAYS_PROXY_IMAGE:-us-docker.pkg.dev/cloud-tpu-v2-images/pathways/proxy_server:latest}
 
-export ROLLOUT_JOBSET_YAML=${ROLLOUT_JOBSET_YAML:-leaderworkerset.mcjax.ray.yaml}
+export ROLLOUT_JOBSET_YAML=${ROLLOUT_JOBSET_YAML:-jobset.tpu.yaml}
 export ROLLOUT_TPU_SLICE=${ROLLOUT_TPU_SLICE:-tpuv5e:4x4}
 export ROLLOUT_MESH_FSDP=${ROLLOUT_MESH_FSDP:-1}
 export ROLLOUT_MESH_TP=${ROLLOUT_MESH_TP:-16}
 
+apply_manifest() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "---"
+    cat
+  else
+    kubectl apply -f -
+  fi
+}
+
+
 stop_orchestrator() {
-  kubectl delete jobset "${ORCHESTRATOR_ID}"
+  kubectl delete jobset "${ORCHESTRATOR_ID}" --namespace="${NAMESPACE}" --ignore-not-found
 }
 
 start_orchestrator() {
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
+  local debug_flag=""
+  if [[ "${DEBUG}" == "1" || "${DEBUG}" == "true" || "${DEBUG}" == "True" ]]; then
+    debug_flag="--debug"
+  fi
+
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/jobset.cpu.yaml \
     --jobset_name="${ORCHESTRATOR_ID}" \
+    --namespace="${NAMESPACE}" \
+    ${QUEUE_NAME:+--queue_name="${QUEUE_NAME}"} \
     --cpu_machine=${CPU_MACHINE} \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ORCHESTRATOR_PORT}" \
     --worker_startup_command=" \
+      ${HF_TOKEN:+HF_TOKEN=\"${HF_TOKEN}\"} \
       ${WANDB_API_KEY:+WANDB_API_KEY=\"${WANDB_API_KEY}\"} \
       WANDB_PROJECT=\"${WANDB_PROJECT}\" \
       WANDB_RUN_NAME=\"${WANDB_RUN_NAME}\" \
@@ -137,6 +167,7 @@ start_orchestrator() {
         --max_prompt_length=${MAX_PROMPT_LENGTH} \
         --max_response_length=${MAX_RESPONSE_LENGTH} \
         --train_micro_batch_size=${TRAIN_MICRO_BATCH_SIZE} \
+        --rollout_replicas=${ROLLOUT_REPLICAS} \
         --wandb_project=\"${WANDB_PROJECT}\" \
         --wandb_run_name=\"${WANDB_RUN_NAME}\" \
         --flush_metrics_every_n_steps=${FLUSH_METRICS_EVERY_N_STEPS} \
@@ -146,17 +177,21 @@ start_orchestrator() {
         ${MAX_SEQ_TOKEN_PER_TPU:+--max_seq_token_per_tpu=${MAX_SEQ_TOKEN_PER_TPU}} \
         ${MAX_SEGMENTS_PER_PACKED_ROW:+--max_segments_per_packed_row=${MAX_SEGMENTS_PER_PACKED_ROW}} \
         ${TRAINER_MESH_FSDP:+--trainer_fsdp=${TRAINER_MESH_FSDP}} \
-        ${DEBUG:+--debug} \
+        ${debug_flag} \
     " \
-    | kubectl apply -f -
+    | apply_manifest
 }
 
 stop_trainer() {
-  kubectl delete jobset "${TRAINER_ID}"
+  kubectl delete jobset "${TRAINER_ID}" --namespace="${NAMESPACE}" --ignore-not-found
 }
 
 start_trainer() {
   local extra_flags=""
+  local debug_flag=""
+  if [[ "${DEBUG}" == "1" || "${DEBUG}" == "true" || "${DEBUG}" == "True" ]]; then
+    debug_flag="--debug"
+  fi
 
   if [[ "${TRAINER_JOBSET_YAML}" == "jobset.pathways.yaml" ]]; then
     echo "Trainer Pathways images: server=${PATHWAYS_SERVER_IMAGE} proxy=${PATHWAYS_PROXY_IMAGE}"
@@ -170,12 +205,19 @@ start_trainer() {
       --maxtext_output_directory=${MAXTEXT_OUTPUT_DIR} \
       --mesh_tp=${TRAINER_MESH_TP} \
       --mesh_expert=${TRAINER_MESH_EXPERT} \
+      --rollout_mesh_tp=${ROLLOUT_MESH_TP} \
+      --prefuse_moe_weights=${PREFUSE_MOE_WEIGHTS} \
+      --use_weight_converter=${USE_WEIGHT_CONVERTER} \
     "
   fi
 
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
+  local trainer_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
+
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/${TRAINER_JOBSET_YAML} \
     --jobset_name="${TRAINER_ID}" \
+    --namespace="${NAMESPACE}" \
+    ${QUEUE_NAME:+--queue_name="${QUEUE_NAME}"} \
     --tpu_slice=${TRAINER_TPU_SLICE} \
     --cpu_machine=${CPU_MACHINE} \
     --pathways_server_image="${PATHWAYS_SERVER_IMAGE}" \
@@ -184,7 +226,7 @@ start_trainer() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
-      HF_TOKEN=${HF_TOKEN} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} python -m tunix.experimental.distributed.runtime.main \
+      ${HF_TOKEN:+HF_TOKEN="${HF_TOKEN}"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} DISABLE_CHECKPOINTING=${DISABLE_CHECKPOINTING} ${trainer_env} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.common.run_trainer_node.main \
@@ -213,47 +255,66 @@ start_trainer() {
         --checkpoint_max_to_keep=${CHECKPOINT_MAX_TO_KEEP} \
         --checkpoint_root_directory=${CHECKPOINT_ROOT_DIRECTORY} \
         ${extra_flags} \
-        ${DEBUG:+--debug} \
+        ${debug_flag} \
     " \
-    | kubectl apply -f -
+    | apply_manifest
 }
 
 stop_rollout() {
-  if [[ "$ROLLOUT_JOBSET_YAML" =~ ^leaderworkerset ]]; then
-    kubectl delete leaderworkerset "${ROLLOUT_ID}"
-  else
-    kubectl delete jobset "${ROLLOUT_ID}"
-  fi
+  for ((i = 0; i < ROLLOUT_REPLICAS; i++)); do
+    local target_id
+    if [[ $ROLLOUT_REPLICAS -eq 1 ]]; then
+      target_id="${ROLLOUT_ID}"
+    else
+      target_id="${ROLLOUT_ID}-${i}"
+    fi
+    if [[ "$ROLLOUT_JOBSET_YAML" =~ ^leaderworkerset ]]; then
+      kubectl delete leaderworkerset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found
+    else
+      kubectl delete jobset "${target_id}" --namespace="${NAMESPACE}" --ignore-not-found
+    fi
+  done
 }
 
-start_rollout() {
+start_rollout_instance() {
+  local target_id="$1"
   local extra_flags=""
+  local debug_flag=""
+  if [[ "${DEBUG}" == "1" || "${DEBUG}" == "true" || "${DEBUG}" == "True" ]]; then
+    debug_flag="--debug"
+  fi
 
   if [[ "${ROLLOUT_JOBSET_YAML}" == "jobset.pathways.yaml" ]]; then
     echo "Rollout Pathways images: server=${PATHWAYS_SERVER_IMAGE} proxy=${PATHWAYS_PROXY_IMAGE}"
   fi
 
   if [[ "${TRAINER_BACKEND}" == "maxtext" ]]; then
-    extra_flags+="\
+    extra_flags+=" \
       --maxtext_model_name=${MAXTEXT_MODEL_NAME} \
       ${ROLLOUT_MAXTEXT_ATTENTION:+--maxtext_attention=${ROLLOUT_MAXTEXT_ATTENTION}} \
+      --prefuse_moe_weights=${PREFUSE_MOE_WEIGHTS} \
     "
   fi
 
-  python tunix/experimental/distributed/deployment/yaml_generator.py \
+  local rollout_env="RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
+
+  python3 tunix/experimental/distributed/deployment/yaml_generator.py \
     tunix/experimental/distributed/deployment/yamls/${ROLLOUT_JOBSET_YAML} \
-    --jobset_name="${ROLLOUT_ID}" \
+    --jobset_name="${target_id}" \
+    --namespace="${NAMESPACE}" \
+    ${QUEUE_NAME:+--queue_name="${QUEUE_NAME}"} \
     --tpu_slice="${ROLLOUT_TPU_SLICE}" \
     --pathways_server_image="${PATHWAYS_SERVER_IMAGE}" \
     --pathways_proxy_server_image="${PATHWAYS_PROXY_IMAGE}" \
+    --pathways_gcs_scratch_location=${GCS_SCRATCH_LOCATION} \
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ROLLOUT_PORT}" \
     --worker_startup_command=" \
-      HF_TOKEN=${HF_TOKEN} SKIP_JAX_PRECOMPILE=1 VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${ROLLOUT_USE_BATCHED_RPA:+USE_BATCHED_RPA_KERNEL=1} python -m tunix.experimental.distributed.runtime.main \
+      ${HF_TOKEN:+HF_TOKEN="${HF_TOKEN}"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${rollout_env} ${ROLLOUT_USE_BATCHED_RPA:+USE_BATCHED_RPA_KERNEL=1} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.common.run_rollout_node.main \
-        --worker_id=${ROLLOUT_ID} \
+        --worker_id=${target_id} \
         --port=${ROLLOUT_PORT} \
         --mesh_fsdp=${ROLLOUT_MESH_FSDP} \
         --mesh_tp=${ROLLOUT_MESH_TP} \
@@ -266,16 +327,41 @@ start_rollout() {
         --lora_rank=${LORA_RANK} \
         --lora_alpha=${LORA_ALPHA} \
         --weight_sync_mode=${WEIGHT_SYNC_MODE} \
+        --enable_prefix_caching=${ENABLE_PREFIX_CACHING} \
         ${extra_flags} \
-        ${DEBUG:+--debug} \
+        ${debug_flag} \
     " \
-    | kubectl apply -f -
+    | apply_manifest
+}
+
+start_rollout() {
+  for ((i = 0; i < ROLLOUT_REPLICAS; i++)); do
+    local target_id
+    if [[ $ROLLOUT_REPLICAS -eq 1 ]]; then
+      target_id="${ROLLOUT_ID}"
+    else
+      target_id="${ROLLOUT_ID}-${i}"
+    fi
+    start_rollout_instance "${target_id}"
+  done
 }
 
 source tunix/experimental/examples/common/enter_kube_context.sh
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    start|stop|orchestrator|trainer|rollout)
+      COMMAND="$1"
+      shift
+      ;;
+    --debug)
+      DEBUG=1
+      shift
+      ;;
+    --no-debug)
+      DEBUG=0
+      shift
+      ;;
     --command)
       COMMAND="$2"
       shift 2
@@ -291,6 +377,34 @@ while [[ $# -gt 0 ]]; do
     --image=*)
       TUNIX_IMAGE="${1#*=}"
       shift
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    --namespace=*)
+      NAMESPACE="${1#*=}"
+      shift
+      ;;
+    --queue)
+      QUEUE_NAME="$2"
+      shift 2
+      ;;
+    --queue=*)
+      QUEUE_NAME="${1#*=}"
+      shift
+      ;;
+    --dry-run|--render)
+      DRY_RUN=true
+      shift
+      ;;
+    --scratch=*|--gcs-scratch=*)
+      GCS_SCRATCH_LOCATION="${1#*=}"
+      shift
+      ;;
+    --scratch|--gcs-scratch)
+      GCS_SCRATCH_LOCATION="$2"
+      shift 2
       ;;
     *)
       shift
@@ -317,11 +431,14 @@ elif [[ "$COMMAND" == "stop" ]]; then
   stop_trainer
   stop_rollout
 elif [[ "$COMMAND" == "orchestrator" ]]; then
-  stop_orchestrator; start_orchestrator
+  stop_orchestrator
+  start_orchestrator
 elif [[ "$COMMAND" == "trainer" ]]; then
-  stop_trainer; start_trainer
+  stop_trainer
+  start_trainer
 elif [[ "$COMMAND" == "rollout" ]]; then
-  stop_rollout; start_rollout
+  stop_rollout
+  start_rollout
 else
   echo "Error: Invalid command '$COMMAND'. Available commands: 'start', 'stop', 'orchestrator', 'trainer', 'rollout'."
   exit 1

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -162,7 +162,6 @@ start_orchestrator() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ORCHESTRATOR_PORT}" \
     --worker_startup_command=" \
-      ${HF_TOKEN:+HF_TOKEN=\"${HF_TOKEN}\"} \
       ${WANDB_API_KEY:+WANDB_API_KEY=\"${WANDB_API_KEY}\"} \
       WANDB_PROJECT=\"${WANDB_PROJECT}\" \
       WANDB_RUN_NAME=\"${WANDB_RUN_NAME}\" \
@@ -242,7 +241,7 @@ start_trainer() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
-      ${HF_TOKEN:+HF_TOKEN="${HF_TOKEN}"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} DISABLE_CHECKPOINTING=${DISABLE_CHECKPOINTING} ${trainer_env} python -m tunix.experimental.distributed.runtime.main \
+      VERIFY_WEIGHTS=${VERIFY_WEIGHTS} DISABLE_CHECKPOINTING=${DISABLE_CHECKPOINTING} ${trainer_env} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.common.run_trainer_node.main \
@@ -335,7 +334,7 @@ start_rollout_instance() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${ROLLOUT_PORT}" \
     --worker_startup_command=" \
-      ${HF_TOKEN:+HF_TOKEN="${HF_TOKEN}"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${rollout_env} ${ROLLOUT_USE_BATCHED_RPA:+USE_BATCHED_RPA_KERNEL=1} python -m tunix.experimental.distributed.runtime.main \
+      VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ${rollout_env} ${ROLLOUT_USE_BATCHED_RPA:+USE_BATCHED_RPA_KERNEL=1} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.common.run_rollout_node.main \

--- a/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
@@ -205,6 +205,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
       ),
   )
   parser.add_argument(
+      "--rollout_replicas",
+      type=int,
+      default=1,
+      help="Number of rollout worker replicas to wait for.",
+  )
+  parser.add_argument(
       "--debug",
       action="store_true",
       help="Enable debug logging and print full sampler responses.",
@@ -362,7 +368,7 @@ def main(argv: list[str], context: ProcessContext | None = None) -> None:
   cluster.wait_for_workers(
       min_workers={
           datatypes.Role.ACTOR: 1,
-          datatypes.Role.ROLLOUT: 1,
+          datatypes.Role.ROLLOUT: args.rollout_replicas,
           datatypes.Role.REFERENCE: 1 if args.beta != 0.0 else 0,
       },
       timeout=args.init_timeout_s,
@@ -438,6 +444,9 @@ def main(argv: list[str], context: ProcessContext | None = None) -> None:
         num_steps=args.max_steps,
         bring_up=False,
     )
+  except BaseException as exc:
+    logging.exception("FATAL: StandardRLProgram execution failed: %s", exc)
+    raise
   finally:
     program.close()
     if args.stop_workers_on_exit:


### PR DESCRIPTION
## Overview
Deployment scripts and parameterized JobSet manifests for distributed RL on Kubernetes (independent of the core weight-sync library stack).

## Changes
- **JobSet Manifest Parameterization**:
  - Parameterizes `yaml_generator.py` and JobSet manifests (`jobset.cpu.yaml`, `jobset.pathways.yaml`, `jobset.tpu.yaml`) for namespace, Kueue queue label (`kueue.x-k8s.io/queue-name`), and HuggingFace token secret (`secretKeyRef` with `HF_TOKEN_SECRET_NAME`).
  - Adds CPU node-pool tolerations to `jobset.cpu.yaml` for tainted GKE node pools.
  - Adds unit test coverage for Kueue queue labels and HF token secrets in `tests/experimental/distributed/deployment/yaml_generator_test.py`.
- **Clean Configuration Plumbing**:
  - Plumbs `--rollout_mesh_tp`, `--prefuse_moe_weights`, and `--use_weight_converter` CLI flags directly into `run_trainer_node.py`.
  - Plumbs `--enable_prefix_caching` and `--prefuse_moe_weights` into `run_rollout_node.py` with flexible boolean parsing (`_str2bool`).
  - Refactors `tensor_parallel_size` auto-derivation into `_finalize_tensor_parallel_size()` in `run_rollout_node.py`.
  - Adds multi-replica rollout support (`--rollout_replicas`) to `run_gsm8k_dist_grpo.py` and rollout start/stop loops.
- **Minimal, Backward-Compatible `k8s_launcher.sh`**:
  - Preserves standard defaults matching `origin/main` (`MODEL_NAME=Qwen3-1.7B`, `TRAINER_BACKEND=tunix`, `SAMPLER=inprocess_vllm`, `WEIGHT_SYNC_MODE=none`, 1 rollout replica, official container images, etc.) addressing reviewer feedback from @s-noghabi and @wang2yn84.
  - Parameterizes `--namespace`, `--queue`, and `--dry-run` (`apply_manifest`) CLI flags.
  - Fixes conditional passing of `HF_TOKEN` in `start_trainer` and `start_rollout_instance` (`${HF_TOKEN:+HF_TOKEN="${HF_TOKEN}"}`) so local unsets do not overwrite pod secrets.
  - Documents `RAIDEN_DEVICES_PER_HOST` configuration.
  - Restores Apache 2.0 license banner.

## Verification
- `bash -n tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh` passes.
- `pytest tests/experimental/distributed/deployment/yaml_generator_test.py tests/experimental/examples/common/run_trainer_node_test.py` (45/45 tests pass in Docker).
