### PR TITLE
fix: make TPU support an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "importlib_resources",
   # Jax 0.7.2 has performance regression on OSS
   # Jax 0.11.1 removed jax.experimental.hijax.MutableHiType, which flax (through 0.12.8, the newest release) still subclasses
-  "jax[tpu]>=0.6.0,!=0.7.2,<0.11.1",
+  "jax>=0.6.0,!=0.7.2,<0.11.1",
   "jaxtyping",
   "jinja2",  # Huggingface chat template
   "kagglehub",
@@ -62,6 +62,9 @@ docs = [
     "sphinx_contributors",
 ]
 prod = [
+]
+tpu = [
+  "jax[tpu]>=0.6.0,!=0.7.2,<0.11.1",
 ]
 dev = [
   # Manully install vLLM & tpu-inferece, which depends on jax[tpu]==0.7.2


### PR DESCRIPTION
## Summary

- Install plain JAX for the default Tunix package
- Add a 	pu optional dependency extra for TPU installations

## Motivation

The current hard dependency on jax[tpu] makes installation fail on platforms without a compatible libtpu wheel and installs an unnecessary TPU runtime for CPU and GPU users. This follows the existing issue discussion in #2047 while preserving the TPU dependency for users who explicitly install google-tunix[tpu].

## Validation

- pyproject.toml parses successfully as TOML.
- The change is limited to dependency metadata.