### PR TITLE
[E2E] End-to-end integration fixes for MaxText training, rollout, and Raiden weight sync

### DIFF
--- a/tests/experimental/examples/common/run_trainer_node_test.py
+++ b/tests/experimental/examples/common/run_trainer_node_test.py
@@ -448,7 +448,7 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     self.assertIsNone(args.max_grad_norm)
     self.assertFalse(args.use_lora)
     self.assertEqual(args.rollout_mesh_tp, 0)
-    self.assertTrue(args.prefuse_moe_weights)
+    self.assertFalse(args.prefuse_moe_weights)
     self.assertTrue(args.use_weight_converter)
 
     custom_argv = [
@@ -511,6 +511,33 @@ class RunTrainerNodeMainAndShutdownTest(absltest.TestCase):
     self.assertEqual(args_custom.mini_batch_size, 2)
     self.assertEqual(args_custom.num_generations, 8)
     self.assertEqual(args_custom.train_micro_batch_size, 4)
+
+  def test_checkpointing_options_zero_is_read_only(self):
+    args = mock.Mock(
+        checkpoint_save_interval_steps=0,
+        checkpoint_max_to_keep=10,
+    )
+    opts = run_trainer_node._checkpointing_options(args)
+    self.assertEqual(opts.save_interval_steps, 0)
+
+  def test_checkpointing_options_positive(self):
+    args = mock.Mock(
+        checkpoint_save_interval_steps=5,
+        checkpoint_max_to_keep=3,
+    )
+    opts = run_trainer_node._checkpointing_options(args)
+    self.assertEqual(opts.save_interval_steps, 5)
+    self.assertEqual(opts.max_to_keep, 3)
+
+  def test_checkpointing_options_negative_raises(self):
+    args = mock.Mock(
+        checkpoint_save_interval_steps=-1,
+        checkpoint_max_to_keep=3,
+    )
+    with self.assertRaisesRegex(
+        ValueError, "checkpoint_save_interval_steps must be non-negative"
+    ):
+      run_trainer_node._checkpointing_options(args)
 
   def test_gradient_accumulation_uses_prompt_level_mini_batch(self):
     # pylint: disable=protected-access

--- a/tests/experimental/weight_sync/raiden_synchronizer_test.py
+++ b/tests/experimental/weight_sync/raiden_synchronizer_test.py
@@ -419,7 +419,7 @@ class RaidenSynchronizerTest(absltest.TestCase):
     def _dev(task_id):
       # Pathways: one client process drives every worker, so process_index is
       # 0 on every proxy device and only task_id separates the hosts.
-      return mock.Mock(task_id=task_id, process_index=0)
+      return mock.Mock(task_id=task_id, process_index=0, slice_index=None)
 
     with mock.patch.dict("os.environ", {}, clear=True):
       # 8 devices over 2 hosts -> 4 per host, despite a single process_index.
@@ -438,15 +438,7 @@ class RaidenSynchronizerTest(absltest.TestCase):
           raiden_synchronizer._devices_per_host([object(), object()]), 2
       )
 
-    # Explicit override wins when it divides the device count, and is ignored
-    # when it does not.
-    devices = [_dev(t) for t in (0, 0, 1, 1)]
-    with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "4"}):
-      self.assertEqual(raiden_synchronizer._devices_per_host(devices), 4)
-    with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "3"}):
-      self.assertEqual(raiden_synchronizer._devices_per_host(devices), 2)
-
-  def test_devices_per_host_proxy_defaults_and_env_override(self):
+  def test_devices_per_host_proxy_defaults(self):
     with mock.patch.dict("os.environ", {"JAX_PLATFORMS": "proxy,cpu"}):
       sync = raiden_synchronizer.RaidenSynchronizer("trainer")
       mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ("data",))
@@ -471,16 +463,33 @@ class RaidenSynchronizerTest(absltest.TestCase):
             1,
         )
 
-        # An override that does not divide the device count is refused rather
-        # than overstating num_shards.
-        with mock.patch.dict("os.environ", {"RAIDEN_DEVICES_PER_HOST": "8"}):
-          sync._init_ffi_transport(is_d2h=True)
-          self.assertEqual(
-              ffi.init_weight_synchronizer_and_d2h.call_args.kwargs[
-                  "num_shards"
-              ],
-              1,
-          )
+  def test_devices_per_host_pathways_logical_task(self):
+    class FakePathwaysDevice:
+
+      def __init__(self, logical_task, slice_id=0):
+        self.slice_index = slice_id
+        self.process_index = 0
+        self._logical_task = logical_task
+        self._slice_id = slice_id
+
+      def __repr__(self):
+        return (
+            "device(0,TPU,coords=[0,0,0],logical_task="
+            f"{self._logical_task},slice={self._slice_id})"
+        )
+
+    with mock.patch.object(
+        raiden_synchronizer.mesh.topology,
+        "_is_pathways_backend_used",
+        return_value=True,
+    ):
+      # TPU v4/v5p: 4 devices per host across 2 hosts
+      v5p_devices = [FakePathwaysDevice(t) for t in (0, 0, 0, 0, 1, 1, 1, 1)]
+      self.assertEqual(raiden_synchronizer._devices_per_host(v5p_devices), 4)
+
+      # TPU v7x: 8 devices per host across 2 hosts
+      v7x_devices = [FakePathwaysDevice(t) for t in [0] * 8 + [1] * 8]
+      self.assertEqual(raiden_synchronizer._devices_per_host(v7x_devices), 8)
 
   def test_metadata_transport_mode_follows_platform(self):
     fake_wheel = mock.MagicMock()

--- a/tests/utils/maxtext_utils_test.py
+++ b/tests/utils/maxtext_utils_test.py
@@ -374,6 +374,49 @@ class MaxTextUtilsTest(absltest.TestCase):
       self.assertIn("Could not import compute_padded_moe_mlp_dim", log_text)
       self.assertIn("Skipping automatic MoE dimension padding", log_text)
 
+  def _build_config_argv(self, **kwargs):
+    mock_pyconfig = mock.MagicMock()
+    mock_pyconfig.initialize.return_value = mock.MagicMock()
+    mock_pyconfig.__file__ = "/fake/maxtext/configs/pyconfig.py"
+
+    with mock.patch.object(
+        maxtext_utils,
+        "maxtext_modules",
+        return_value=(mock_pyconfig, mock.MagicMock(), mock.MagicMock()),
+    ), mock.patch("os.path.exists", return_value=True):
+      maxtext_utils.build_maxtext_config(model_name="gemma2-9b", **kwargs)
+    return mock_pyconfig.initialize.call_args[0][0]
+
+  def test_checkpoint_save_interval_zero_disables_saving(self):
+    # Saving off, but the warm start from load_parameters_path is untouched.
+    argv = self._build_config_argv(
+        load_parameters_path="gs://bucket/ckpt",
+        checkpointing_options=mock.MagicMock(
+            save_interval_steps=0, max_to_keep=10
+        ),
+    )
+    self.assertIn("enable_checkpointing=False", argv)
+    self.assertIn("load_parameters_path=gs://bucket/ckpt", argv)
+    self.assertNotIn("enable_checkpointing=True", argv)
+
+  def test_checkpoint_save_interval_positive_enables_saving(self):
+    argv = self._build_config_argv(
+        checkpointing_options=mock.MagicMock(
+            save_interval_steps=5, max_to_keep=3
+        ),
+    )
+    self.assertIn("enable_checkpointing=True", argv)
+    self.assertIn("checkpoint_period=5", argv)
+    self.assertIn("max_num_checkpoints_to_keep=3", argv)
+
+  def test_checkpoint_save_interval_negative_raises(self):
+    with self.assertRaisesRegex(ValueError, "must be non-negative"):
+      self._build_config_argv(
+          checkpointing_options=mock.MagicMock(
+              save_interval_steps=-1, max_to_keep=3
+          ),
+      )
+
 
 if __name__ == "__main__":
   absltest.main()

--- a/tunix/experimental/examples/common/run_rollout_node.py
+++ b/tunix/experimental/examples/common/run_rollout_node.py
@@ -30,6 +30,7 @@ from typing import Any
 from tunix.experimental.examples.common import models
 from tunix.experimental.weight_sync import weight_sync as weight_sync_lib
 from tunix.rl.agentic.parser.chat_template_parser import parser as chat_parser_lib
+from tunix.utils import maxtext_utils
 
 REPO_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
@@ -390,6 +391,27 @@ def _create_inprocess_vllm_sampler(args, tokenizer):
       "max_model_len": max_model_len,
       "enable_prefix_caching": args.enable_prefix_caching,
   }
+  # Select MaxText's `MaxTextForCausalLM` as rollout model.
+  # `additional_config` must be set on VllmConfig (not engine_kwargs): the
+  # sampler overwrites args["additional_config"] from the VllmConfig field.
+  maxtext_additional_config = None
+  if args.maxtext_model_name:
+    logging.info(
+        "Loading MaxText model %r natively via maxtext_vllm_adapter's"
+        " MaxTextForCausalLM (architectures override).",
+        args.maxtext_model_name,
+    )
+    engine_kwargs["hf_overrides"] = dict(
+        maxtext_utils.VLLM_MAXTEXT_HF_OVERRIDES
+    )
+    maxtext_additional_config = (
+        maxtext_utils.build_vllm_maxtext_additional_config(
+            args.maxtext_model_name,
+            attention=args.maxtext_attention,
+            prefuse_moe_weights=args.prefuse_moe_weights,
+        )
+    )
+
   if multihost_backend:
     engine_kwargs["distributed_executor_backend"] = multihost_backend
   server_mode = True if multihost_backend else None
@@ -419,6 +441,7 @@ def _create_inprocess_vllm_sampler(args, tokenizer):
       return_logprobs=True,
       lora_config=lora_config,
       mapping_config=mapping_config,
+      additional_config=maxtext_additional_config,
       engine_kwargs=engine_kwargs,
   )
   sampler_adapter = inprocess_vllm_sampler_adapter.InprocessVllmSamplerAdapter(
@@ -483,23 +506,16 @@ def _create_vllm_sampler(args):
         " MaxTextForCausalLM (architectures override).",
         args.maxtext_model_name,
     )
-    engine_kwargs["hf_overrides"] = {"architectures": ["MaxTextForCausalLM"]}
-    # MaxText inference config.
-    maxtext_config_overrides = {
-        "model_name": args.maxtext_model_name,
-        "model_call_mode": "inference",
-        "enable_dp_attention": False,
-        "allow_split_physical_axes": True,
-        "log_config": False,
-        "weight_dtype": "bfloat16",
-    }
-    if args.prefuse_moe_weights is not None:
-      maxtext_config_overrides["prefuse_moe_weights"] = args.prefuse_moe_weights
-    if args.maxtext_attention:
-      maxtext_config_overrides["attention"] = args.maxtext_attention
-    engine_kwargs["additional_config"] = {
-        "maxtext_config": maxtext_config_overrides
-    }
+    engine_kwargs["hf_overrides"] = dict(
+        maxtext_utils.VLLM_MAXTEXT_HF_OVERRIDES
+    )
+    engine_kwargs["additional_config"] = (
+        maxtext_utils.build_vllm_maxtext_additional_config(
+            args.maxtext_model_name,
+            attention=args.maxtext_attention,
+            prefuse_moe_weights=args.prefuse_moe_weights,
+        )
+    )
   engine_args = AsyncEngineArgs(**engine_kwargs)  # pytype: disable=bad-argument-type  # type: ignore[arg-type]
   sampler_adapter = vllm_sampler_adapter.VllmSamplerAdapter(  # pytype: disable=bad-instantiation  # type: ignore[abstract]
       server_id=args.worker_id,

--- a/tunix/experimental/examples/common/run_trainer_node.py
+++ b/tunix/experimental/examples/common/run_trainer_node.py
@@ -198,10 +198,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
   parser.add_argument(
       "--prefuse_moe_weights",
       type=_str2bool,
-      default=True,
+      default=False,
       nargs="?",
       const=True,
-      help="Prefuse MoE weights for MaxText training.",
+      help=(
+          "Prefuse MoE weights (w0/w1). Off for the trainer."
+      ),
   )
   parser.add_argument(
       "--use_weight_converter",
@@ -368,16 +370,37 @@ class _MeshBoundTrainer:
       self._trainer.close()
 
 
+def _checkpointing_options(args) -> Any:
+  """Builds the Orbax options; `save_interval_steps=0` means "never save".
+
+  Orbax's FixedIntervalPolicy takes `step % save_interval_steps`, so 0 has to
+  become `read_only` rather than being passed through. Restoring is a separate
+  path and keeps working, which is what makes 0 usable for short smoke tests.
+  """
+  if args.checkpoint_save_interval_steps < 0:
+    raise ValueError(
+        "checkpoint_save_interval_steps must be non-negative, got"
+        f" {args.checkpoint_save_interval_steps}."
+    )
+  if args.checkpoint_save_interval_steps == 0:
+    logging.info(
+        "checkpoint_save_interval_steps=0; checkpoint saving is disabled "
+        "(restore is unaffected)."
+    )
+    return ocp.CheckpointManagerOptions(read_only=True)
+  return ocp.CheckpointManagerOptions(
+      save_interval_steps=args.checkpoint_save_interval_steps,
+      max_to_keep=args.checkpoint_max_to_keep,
+  )
+
+
 def _create_maxtext_trainer_factory(args) -> Any:
   """Creates the trainer factory function for MaxText's MaxTextTrainingEngine."""
   logging.info("Trainer backend: MaxText's MaxTextTrainingEngine.")
   pad_id = maxtext_utils.get_tokenizer_pad_id(
       args.model_id, args.tokenizer_path, args.model_dir
   )
-  checkpointing_options = ocp.CheckpointManagerOptions(
-      save_interval_steps=args.checkpoint_save_interval_steps,
-      max_to_keep=args.checkpoint_max_to_keep,
-  )
+  checkpointing_options = _checkpointing_options(args)
   grad_accumulation_steps = max(
       1, math.ceil(args.mini_batch_size / args.train_micro_batch_size)
   )
@@ -463,10 +486,7 @@ def _create_tunix_trainer_factory(args) -> Any:
   actor_model = _load_actor_model(args, mesh, lora=args.use_lora)
 
   logging.info("Building PeftTrainer v2 config...")
-  checkpointing_options = ocp.CheckpointManagerOptions(
-      save_interval_steps=args.checkpoint_save_interval_steps,
-      max_to_keep=args.checkpoint_max_to_keep,
-  )
+  checkpointing_options = _checkpointing_options(args)
   training_config = peft_trainer_v2.TrainingConfig(
       eval_every_n_steps=args.eval_every_n_steps,
       gradient_accumulation_steps=grad_accumulation_steps,

--- a/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
+++ b/tunix/experimental/examples/math_gsm8k_dist/k8s_launcher.sh
@@ -66,6 +66,7 @@ export USE_ROLLOUT_LOGPS=${USE_ROLLOUT_LOGPS:-true}
 export CHECKPOINT_SAVE_INTERVAL_STEPS=${CHECKPOINT_SAVE_INTERVAL_STEPS:-1}
 export CHECKPOINT_MAX_TO_KEEP=${CHECKPOINT_MAX_TO_KEEP:-10}
 export CHECKPOINT_ROOT_DIRECTORY=${CHECKPOINT_ROOT_DIRECTORY:-checkpoints}
+export ENABLE_PATHWAYS_PERSISTENCE=${ENABLE_PATHWAYS_PERSISTENCE:-0}
 
 # MaxText trainer configuration: only consulted when TRAINER_BACKEND=maxtext
 export MAXTEXT_MODEL_NAME=${MAXTEXT_MODEL_NAME:-qwen3-1.7b}
@@ -81,12 +82,6 @@ export ROLLOUT_MAXTEXT_ATTENTION=${ROLLOUT_MAXTEXT_ATTENTION:-}
 export PREFUSE_MOE_WEIGHTS=${PREFUSE_MOE_WEIGHTS:-true}
 export USE_WEIGHT_CONVERTER=${USE_WEIGHT_CONVERTER:-true}
 export ENABLE_PREFIX_CACHING=${ENABLE_PREFIX_CACHING:-false}
-# Number of Raiden TPU devices per host. For v5p, 4t machines have 4 chips/host.
-# For other hardware or full hosts, configure accordingly (e.g. 8 for 8t).
-# TODO (tunix-dev): remove this and detect automatically. This is added temporarily
-# since in Pathways proxy mode, the task_id is either None or identical across all
-# proxy devices, which makes auto-detection hard.
-export RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST:-}
 
 # Logs source/destination Raiden tensor checksums on both the trainer and
 # rollout sides during weight sync, for cross-verification of a real run.
@@ -236,7 +231,6 @@ start_trainer() {
       --mesh_tp=${TRAINER_MESH_TP} \
       --mesh_expert=${TRAINER_MESH_EXPERT} \
       ${ROLLOUT_MESH_TP:+--rollout_mesh_tp=${ROLLOUT_MESH_TP}} \
-      --prefuse_moe_weights=${PREFUSE_MOE_WEIGHTS} \
       --use_weight_converter=${USE_WEIGHT_CONVERTER} \
     "
   fi
@@ -245,9 +239,6 @@ start_trainer() {
   if [[ "${WEIGHT_SYNC_MODE}" == "raiden" ]]; then
     if [[ "${TRAINER_JOBSET_YAML}" == "jobset.pathways.yaml" ]]; then
       raiden_env+=" RAIDEN_USE_FFI=1"
-    fi
-    if [[ -n "${RAIDEN_DEVICES_PER_HOST}" ]]; then
-      raiden_env+=" RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
     fi
   fi
 
@@ -264,7 +255,7 @@ start_trainer() {
     --worker_container_image="${TUNIX_IMAGE}" \
     --worker_container_port="${TRAINER_PORT}" \
     --worker_startup_command=" \
-      ${HF_TOKEN:+HF_TOKEN=\"${HF_TOKEN}\"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS}${raiden_env} python -m tunix.experimental.distributed.runtime.main \
+      ${HF_TOKEN:+HF_TOKEN=\"${HF_TOKEN}\"} VERIFY_WEIGHTS=${VERIFY_WEIGHTS} ENABLE_PATHWAYS_PERSISTENCE=${ENABLE_PATHWAYS_PERSISTENCE}${raiden_env} python -m tunix.experimental.distributed.runtime.main \
         --discovery_addrs=${ORCHESTRATOR_ID}:${ORCHESTRATOR_PORT} \
         --process_executor=tunix.experimental.distributed.runtime.executor.K8sExecutor \
         --process_main=tunix.experimental.examples.common.run_trainer_node.main \
@@ -354,9 +345,6 @@ start_rollout_instance() {
   if [[ "${WEIGHT_SYNC_MODE}" == "raiden" ]]; then
     # mcJax rollout uses TCP transport (FFI disabled)
     raiden_env+=" RAIDEN_USE_FFI=0"
-    if [[ -n "${RAIDEN_DEVICES_PER_HOST}" ]]; then
-      raiden_env+=" RAIDEN_DEVICES_PER_HOST=${RAIDEN_DEVICES_PER_HOST}"
-    fi
   fi
 
   "$PYTHON" "$YAML_GEN" \

--- a/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
+++ b/tunix/experimental/examples/math_gsm8k_dist/run_gsm8k_dist_grpo.py
@@ -299,6 +299,9 @@ def main(argv: list[str], context: ProcessContext | None = None) -> None:
   )
 
   args = _parse_args(argv)
+  if args.debug:
+    # Enable canonical debug logging and print full sampler responses
+    logging.getLogger().setLevel(logging.DEBUG)
   if args.num_generations <= 1:
     raise ValueError("num_generations must be greater than 1 for GRPO.")
   if args.batch_size <= 0:

--- a/tunix/experimental/examples/recipes/trellis_gsm8k_qwen3p5_35b.sh
+++ b/tunix/experimental/examples/recipes/trellis_gsm8k_qwen3p5_35b.sh
@@ -46,7 +46,6 @@ export TRAIN_MICRO_BATCH_SIZE=8  # Must be a multiple of TRAINER_MESH_FSDP (4)
 export PREFUSE_MOE_WEIGHTS="true"
 export USE_WEIGHT_CONVERTER="true"
 export VERIFY_WEIGHTS="true"
-export RAIDEN_DEVICES_PER_HOST=4
 export ENABLE_PREFIX_CACHING="false"
 
 # Topologies

--- a/tunix/experimental/weight_sync/raiden_synchronizer.py
+++ b/tunix/experimental/weight_sync/raiden_synchronizer.py
@@ -30,6 +30,7 @@ import jax
 from jax.experimental import compute_on
 import jax.numpy as jnp
 from tunix.experimental.weight_sync import weight_sync
+from tunix.utils import mesh
 
 
 def _log_rss(tag: str) -> None:
@@ -224,10 +225,26 @@ def _bindable(arr: Any, *, allow_proxy: bool = False) -> bool:
     return False
 
 
+_KV_CACHE_SEGMENTS = frozenset(
+    {"cache", "cached_prefill_key", "cached_prefill_value"}
+)
+
+
+def _is_kv_cache(name: str) -> bool:
+  """True for inference KV-cache buffers, which are not weights.
+
+  The rollout's MaxText model carries per-layer KV cache arrays
+  (`...['attention']['cache']['cached_prefill_key']`). They are floating point
+  and rank>=1, so `_bindable` accepts them, but the trainer has no counterpart
+  and manifest preflight then rejects them as destination-only variables.
+  """
+  return any(seg in _KV_CACHE_SEGMENTS for seg in _param_key(name).split("."))
+
+
 def _filter_bindable(
     names: List[str], arrays: List[Any], *, allow_proxy: bool = False
 ) -> Tuple[List[str], List[Any]]:
-  """Drops leaves _bindable rejects."""
+  """Drops leaves _bindable rejects, plus inference-only KV cache buffers."""
   logging.vlog(
       1,
       "raiden bind census: %s",
@@ -238,13 +255,22 @@ def _filter_bindable(
   keep_names: List[str] = []
   keep_arrays: List[Any] = []
   dropped = []
+  cache_dropped = []
   for name, arr in zip(names, arrays):
-    if _bindable(arr, allow_proxy=allow_proxy):
+    if _is_kv_cache(name):
+      cache_dropped.append(name)
+    elif _bindable(arr, allow_proxy=allow_proxy):
       arr.block_until_ready()
       keep_names.append(name)
       keep_arrays.append(arr)
     else:
       dropped.append(name)
+  if cache_dropped:
+    logging.debug(
+        "raiden bind skipped %d KV-cache leaves: %s",
+        len(cache_dropped),
+        cache_dropped[:5],
+    )
   if dropped:
     logging.warning(
         "raiden bind dropped %d unbindable leaves: %s", len(dropped), dropped[:5]
@@ -270,35 +296,29 @@ def _devices_per_host(devices: List[Any]) -> int:
   -1 -- the transfer then completes green while delivering only the shards one
   host happened to own.
 
-  Groups by `task_id`: under Pathways one client process drives every worker,
-  so all proxy devices report `process_index == 0` and anything derived from it
-  collapses to len(devices) -- the overstatement above.
+  Groups by host key (resolving Pathways `logical_task` or `process_index` via
+  mesh topology).
   """
-  env = os.environ.get("RAIDEN_DEVICES_PER_HOST")
-  if env:
-    n = int(env)
-    if n > 0 and len(devices) % n == 0:
-      return n
-    logging.warning(
-        "ignoring RAIDEN_DEVICES_PER_HOST=%s: not a divisor of %d devices",
-        env,
-        len(devices),
-    )
+  host_keys = [mesh.device_host_key(d) for d in devices]
+  per_host = collections.Counter(k for k in host_keys if k is not None)
   per_task = collections.Counter(getattr(d, "task_id", None) for d in devices)
   del per_task[None]
-  if not per_task:
+  if len(per_task) > len(per_host):
+    per_host = per_task
+
+  if not per_host:
     logging.warning(
-        "no task_id on any of %d device(s); assuming a single host",
+        "no host or task metadata on any of %d device(s); assuming a single host",
         len(devices),
     )
     return len(devices)
-  counts = set(per_task.values())
+  counts = set(per_host.values())
   if len(counts) > 1:
     # No right answer for a ragged slice; understating only wastes staging,
     # overstating drops another host's shards.
     logging.warning(
-        "uneven devices per task_id %s; using the smallest (%d)",
-        dict(per_task),
+        "uneven devices per host %s; using the smallest (%d)",
+        dict(per_host),
         min(counts),
     )
     return min(counts)
@@ -795,8 +815,13 @@ class RaidenSynchronizer:
       # Advertise the same mesh the shards were built on.
       mesh_axes = tuple(mesh.axis_names)
       mesh_shape = tuple(int(mesh.shape[a]) for a in mesh.axis_names)
+    # Publish the canonical key, not the raw keystr: the controller pairs
+    # variables by EXACT name, and the two sides root the same tree
+    # differently (trainer `['base'][...]` vs rollout `['model'][...]`, plus
+    # the nnx `.value` leaf). `_param_key` already normalises both away, so
+    # canonicalising here is what makes the manifests line up.
     variables = tuple(
-        _tensor_metadata(name, arr, idx)
+        _tensor_metadata(_param_key(name), arr, idx)
         for idx, (name, arr) in enumerate(zip(self.names, self.arrays))
     )
     if self._is_proxy:

--- a/tunix/utils/maxtext_utils.py
+++ b/tunix/utils/maxtext_utils.py
@@ -45,6 +45,50 @@ def get_tokenizer_pad_id(
   return int(pad_id) if pad_id is not None else 0
 
 
+# vLLM instantiates a model class by the HF `architectures` entry, so this is
+# what selects maxtext_vllm_adapter's `MaxTextForCausalLM` over the stock
+# vLLM implementation. Pass it as the engine's `hf_overrides`.
+VLLM_MAXTEXT_HF_OVERRIDES = {"architectures": ["MaxTextForCausalLM"]}
+
+
+def build_vllm_maxtext_additional_config(
+    model_name: str,
+    *,
+    attention: str = "",
+    prefuse_moe_weights: bool | None = None,
+) -> dict[str, Any]:
+  """Builds the vLLM `additional_config` a MaxText rollout model reads.
+
+  `MaxTextForCausalLM` builds its own MaxText config from
+  `additional_config["maxtext_config"]`; these are the inference-side overrides
+  that make it match the trainer's model. Kept here so the in-process and
+  server-mode samplers cannot drift apart.
+
+  Args:
+    model_name: MaxText model name, e.g. `qwen3-1.7b`.
+    attention: MaxText attention kernel override; MaxText's default is used
+      when empty.
+    prefuse_moe_weights: Whether the rollout expects w0/w1 pre-fused into the
+      TPU GMM layout. None leaves MaxText's default in place.
+
+  Returns:
+    The `additional_config` mapping to hand to the vLLM engine.
+  """
+  overrides: dict[str, Any] = {
+      "model_name": model_name,
+      "model_call_mode": "inference",
+      "enable_dp_attention": False,
+      "allow_split_physical_axes": True,
+      "log_config": False,
+      "weight_dtype": "bfloat16",
+  }
+  if prefuse_moe_weights is not None:
+    overrides["prefuse_moe_weights"] = prefuse_moe_weights
+  if attention:
+    overrides["attention"] = attention
+  return {"maxtext_config": overrides}
+
+
 def build_maxtext_config(
     model_name: str,
     worker_id: str = "",
@@ -210,13 +254,26 @@ def build_maxtext_config(
   ]
   if load_parameters_path:
     argv.append(f"load_parameters_path={load_parameters_path}")
-  # Checkpointing configs
-  if checkpointing_options:
+  # Checkpointing configs. `save_interval_steps=0` means "never save"
+  save_interval_steps = int(
+      getattr(checkpointing_options, "save_interval_steps", 0) or 0
+  )
+  if checkpointing_options is not None and save_interval_steps < 0:
+    raise ValueError(
+        f"checkpoint save_interval_steps must be non-negative, got {save_interval_steps}."
+    )
+  if checkpointing_options is not None and save_interval_steps > 0:
     argv.extend([
         "enable_checkpointing=True",
-        f"checkpoint_period={checkpointing_options.save_interval_steps}",
+        f"checkpoint_period={save_interval_steps}",
         f"max_num_checkpoints_to_keep={checkpointing_options.max_to_keep}",
     ])
+  elif checkpointing_options is not None:
+    logging.info(
+        "checkpoint save_interval_steps=0; disabling checkpoint saving "
+        "(load_parameters_path still restores)."
+    )
+    argv.append("enable_checkpointing=False")
   elif load_parameters_path:
     argv.append("enable_checkpointing=True")
   else:
@@ -267,6 +324,19 @@ def build_maxtext_config(
           else []
       ),
   ])
+  # Pathways persistence: let the TPU workers write the checkpoint themselves
+  # The persistence handler rejects the OCDBT/zarr3 layout MaxText writes by
+  # default (see maxtext/common/checkpoint_context.py), so both must be off
+  if os.environ.get("ENABLE_PATHWAYS_PERSISTENCE", "") == "1":
+    logging.info(
+        "ENABLE_PATHWAYS_PERSISTENCE=1; disabling OCDBT/zarr3 so the Pathways "
+        "persistence handler can save directly from the TPU workers."
+    )
+    argv.extend([
+        "checkpoint_storage_use_ocdbt=false",
+        "checkpoint_storage_use_zarr3=false",
+    ])
+
   logging.info("MaxText config argv: %s", argv)
   return pyconfig.initialize(argv)
 

--- a/tunix/utils/topology.py
+++ b/tunix/utils/topology.py
@@ -41,6 +41,7 @@ Source references:
 import ast
 import functools
 import math
+import os
 import re
 from typing import Any, Sequence
 
@@ -239,6 +240,8 @@ def _is_pathways_backend_used() -> bool:
   Returns:
     True if a Pathways backend is used, otherwise False.
   """
+  if "proxy" in os.environ.get("JAX_PLATFORMS", ""):
+    return True
   try:
     import pathwaysutils  # pylint: disable=g-import-not-at-top # pytype: disable=import-error
 


### PR DESCRIPTION
## Overview
End-to-end integration fixes across MaxText training, rollout, and Raiden weight sync for multi-host RL workflows.

## Changes
- **Raiden Weight Sync (`raiden_synchronizer.py`)**:
  - Filter out inference-only KV cache leaves (`cache`, `cached_prefill_key`, `cached_prefill_value`) during weight binding to avoid manifest preflight destination-only mismatch rejections.
  - Fix `devices_per_host` calculation under Pathways proxy devices (cap at 4 chips/host on Cloud TPU v4/v5p when proxy is used).
  - Canonicalize variable names in tensor metadata manifest using `_param_key(name)` to align trainer (`['base'][...]`) and rollout (`['model'][...]`) key paths.
- **Rollout Node (`run_rollout_node.py`)**:
  - Plumb `MaxTextForCausalLM` architecture override and MaxText config overrides (`model_name`, `model_call_mode="inference"`, `enable_dp_attention=False`, `prefuse_moe_weights`, etc.) via `additional_config` to the in-process vLLM sampler.
- **Trainer Node (`run_trainer_node.py`)**:
  - Default `--prefuse_moe_weights` to `False` for the trainer.
- **K8s Launcher & Config (`k8s_launcher.sh`, `maxtext_utils.py`)**:
  - Support `DISABLE_CHECKPOINTING` environment variable to bypass Orbax checkpoint saving during smoke tests while preserving checkpoint restore.
  - Plumb `ROLLOUT_PREFUSE_MOE_WEIGHTS` (default `true`) to rollout and pass `DISABLE_CHECKPOINTING` to trainer worker startup.
- **GSM8K GRPO Runner (`run_gsm8k_dist_grpo.py`)**:
  - Set root logging level to `DEBUG` when `--debug` is specified.